### PR TITLE
CI: GHCR image ghcr.io/OWNER/member-manager for staging and production

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -8,7 +8,6 @@ concurrency:
   group: production-${{ github.ref }}
   cancel-in-progress: false
 
-# Updated per deployment protocol
 permissions:
   contents: write
   packages: write
@@ -19,7 +18,7 @@ jobs:
 
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/${{ github.event.repository.name }}
+      IMAGE_NAME: ${{ github.repository_owner }}/member-manager
 
     steps:
       - name: Checkout
@@ -27,7 +26,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Updated per deployment protocol
       - name: Version guard and read VERSION
         run: |
           PREV=$(git show HEAD~1:VERSION 2>/dev/null || echo "0.0.0")
@@ -40,7 +38,6 @@ jobs:
           MAJOR="${CURR%%.*}"
           echo "MAJOR=$MAJOR" >> "$GITHUB_ENV"
 
-      # Updated per deployment protocol
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -51,7 +48,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Updated per deployment protocol
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -69,7 +65,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Updated per deployment protocol
       - name: Create and push git tag
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
+      IMAGE_NAME: ${{ github.repository_owner }}/member-manager
 
     steps:
       - name: Checkout
@@ -118,7 +118,7 @@ jobs:
           LATEST_VERSION=""
           
           VERSIONS=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/users/${{ github.repository_owner }}/packages/container/${{ github.event.repository.name }}/versions" \
+            "https://api.github.com/users/${{ github.repository_owner }}/packages/container/member-manager/versions" \
             2>/dev/null || echo "[]")
           
           LATEST_VERSION=$(echo "$VERSIONS" | jq -r '.[] | select(.metadata.container.tags | index("latest")) | .metadata.container.tags[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' | head -1 || echo "")

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -8,7 +8,6 @@ concurrency:
   group: staging-${{ github.ref }}
   cancel-in-progress: true
 
-# Updated per deployment protocol
 permissions:
   contents: read
   packages: write
@@ -19,14 +18,12 @@ jobs:
 
     env:
       REGISTRY: ghcr.io
-      # Separate GHCR package from production (`…/<repo>`) so registry UI and pulls are unambiguous.
-      IMAGE_NAME: ${{ github.repository_owner }}/${{ github.event.repository.name }}-staging
+      IMAGE_NAME: ${{ github.repository_owner }}/member-manager
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Updated per deployment protocol
       - name: Read VERSION and set image tags
         id: meta
         run: |
@@ -35,7 +32,6 @@ jobs:
           SHORT_SHA="${GITHUB_SHA:0:7}"
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
 
-      # Updated per deployment protocol
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -46,7 +42,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Updated per deployment protocol
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -58,7 +53,7 @@ jobs:
           build-args: |
             APP_VERSION=${{ env.APP_VERSION }}-staging
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging-${{ steps.meta.outputs.short_sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Staging publishes :staging and :staging-<sha> only; production uses :latest and semver tags. Align release workflow with the same image path.

Made-with: Cursor