### PR TITLE
Add staging env, letter_opener_web, and per-environment .env examples

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,76 @@
+# -----------------------------------------------------------------------------
+# Development — copy to `.env`. For docker compose, `docker-compose.yml` still
+# sets DB_HOST/REDIS_URL/DATABASE_URL on the service; values below suit a
+# bare-metal app server hitting local Postgres/Redis.
+# -----------------------------------------------------------------------------
+
+RAILS_ENV=development
+
+# --- App URLs & branding ---
+APP_BASE_URL=http://localhost:3000
+# Optional: explicit public base for webhook helpers (defaults to APP_BASE_URL)
+# MEMBER_MANAGER_BASE_URL=http://localhost:3000
+ORGANIZATION_NAME=Member Manager
+EMAIL_FROM_ADDRESS=noreply@localhost
+EMAIL_SUPPORT_ADDRESS=support@localhost
+TIMEZONE=UTC
+
+# --- Database (docker compose: host `db`) ---
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/member_manager_development
+
+# --- Redis (docker compose: host `redis`, db `/0`) ---
+REDIS_URL=redis://localhost:6379/0
+
+# --- Optional: Puma ---
+# RAILS_MAX_THREADS=5
+# PORT=3000
+
+# --- Optional: local password login (off unless true) ---
+LOCAL_AUTH_ENABLED=false
+# LOCAL_AUTH_EMAIL=admin@localhost
+# LOCAL_AUTH_PASSWORD=change-me
+# LOCAL_AUTH_FULL_NAME=Local Admin
+
+# --- Omniauth / Authentik (set when testing SSO locally) ---
+# AUTHENTIK_ISSUER=https://authentik.example.com/application/o/member-manager/
+# AUTHENTIK_CLIENT_ID=
+# AUTHENTIK_CLIENT_SECRET=
+# AUTHENTIK_REDIRECT_URI=http://localhost:3000/auth/authentik/callback
+# AUTHENTIK_GROUP_ID=
+# AUTHENTIK_API_BASE_URL=
+# AUTHENTIK_API_TOKEN=
+# AUTHENTIK_TOKEN_ENDPOINT=
+# AUTHENTIK_WEBHOOK_SECRET=
+# AUTHENTIK_GROUP_PAGE_SIZE=200
+
+# --- Integrations (enable as needed) ---
+# PAYPAL_CLIENT_ID=
+# PAYPAL_CLIENT_SECRET=
+# PAYPAL_API_BASE_URL=https://api-m.sandbox.paypal.com
+# RECHARGE_API_KEY=
+# RECHARGE_WEBHOOK_SECRET=
+# GOOGLE_SHEETS_CREDENTIALS=
+# GOOGLE_SHEETS_ID=
+# SLACK_API_TOKEN=
+# KOFI_VERIFICATION_TOKEN=
+# ACCESS_WEBHOOK_KEY=
+
+# --- Optional observability ---
+# SENTRY_DSN=
+# SENTRY_TRACES_SAMPLE_RATE=0.1
+# SENTRY_PROFILES_SAMPLE_RATE=0.1
+
+# --- Access controller jobs (optional) ---
+# SYSLOG_SERVER=
+# SYSLOG_PORT=
+# ACCESS_LOGS_DIRECTORY=
+
+# --- RFID webhook ---
+# RFID_WEBHOOK_IP_WHITELIST=
+
+# --- Version label (optional; Docker sets via build arg) ---
+# APP_VERSION=dev

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# -----------------------------------------------------------------------------
+# Environment templates — copy the file that matches how you run the app.
+#
+#   cp .env.development.example .env
+#
+# Committed examples (safe placeholders only; never put real secrets in git):
+#   .env.development.example  — local machine or docker compose (default stack)
+#   .env.test.example         — optional overrides for bare-metal test runs
+#   .env.staging.example       — RAILS_ENV=staging (mail captured; see file)
+#   .env.production.example   — RAILS_ENV=production
+#
+# dotenv-rails loads `.env` in all environments unless overridden. For
+# per-environment files, use `.env.development` / `.env.test` etc. if you
+# prefer not to use a single `.env`.
+# -----------------------------------------------------------------------------

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,88 @@
+# -----------------------------------------------------------------------------
+# Production — RAILS_ENV=production
+# Use your secrets manager / platform env UI; never commit filled-in values.
+# -----------------------------------------------------------------------------
+
+RAILS_ENV=production
+
+# RAILS_MASTER_KEY=<required for encrypted credentials if used>
+
+# --- App URLs & branding ---
+APP_BASE_URL=https://members.example.com
+MEMBER_MANAGER_BASE_URL=https://members.example.com
+ORGANIZATION_NAME=Member Manager
+EMAIL_FROM_ADDRESS=noreply@members.example.com
+EMAIL_SUPPORT_ADDRESS=support@members.example.com
+TIMEZONE=UTC
+
+# --- Database ---
+# Prefer DATABASE_URL for platform deploys.
+DATABASE_URL=postgres://USER:PASSWORD@HOST:5432/member_manager_production
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+# DB_PASSWORD=
+
+# --- Redis / Sidekiq / Action Cable ---
+REDIS_URL=redis://localhost:6379/1
+
+# --- Puma ---
+# WEB_CONCURRENCY=2
+# RAILS_MAX_THREADS=5
+RAILS_LOG_LEVEL=info
+
+# --- SMTP (required for real outbound mail) ---
+SMTP_ADDRESS=smtp.example.com
+SMTP_PORT=587
+SMTP_DOMAIN=example.com
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_AUTHENTICATION=plain
+SMTP_ENABLE_STARTTLS=true
+
+# --- Omniauth / Authentik ---
+AUTHENTIK_ISSUER=
+AUTHENTIK_CLIENT_ID=
+AUTHENTIK_CLIENT_SECRET=
+AUTHENTIK_REDIRECT_URI=
+AUTHENTIK_GROUP_ID=
+AUTHENTIK_API_BASE_URL=
+AUTHENTIK_API_TOKEN=
+AUTHENTIK_TOKEN_ENDPOINT=
+AUTHENTIK_WEBHOOK_SECRET=
+AUTHENTIK_GROUP_PAGE_SIZE=200
+
+# --- Payments & integrations ---
+PAYPAL_CLIENT_ID=
+PAYPAL_CLIENT_SECRET=
+# PAYPAL_API_BASE_URL=https://api-m.paypal.com
+# PAYPAL_TRANSACTIONS_LOOKBACK_DAYS=30
+RECHARGE_API_KEY=
+# RECHARGE_API_BASE_URL=https://api.rechargeapps.com
+# RECHARGE_TRANSACTIONS_LOOKBACK_DAYS=30
+RECHARGE_WEBHOOK_SECRET=
+GOOGLE_SHEETS_CREDENTIALS=
+GOOGLE_SHEETS_ID=
+SLACK_API_TOKEN=
+# SLACK_API_BASE_URL=https://slack.com
+KOFI_VERIFICATION_TOKEN=
+ACCESS_WEBHOOK_KEY=
+
+# --- Observability ---
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.1
+SENTRY_PROFILES_SAMPLE_RATE=0.1
+
+# --- Optional version label (often injected at image build) ---
+# APP_VERSION=1.0.0
+
+# --- Access controller jobs ---
+# SYSLOG_SERVER=
+# SYSLOG_PORT=
+# ACCESS_LOGS_DIRECTORY=
+
+# --- RFID webhook IP allow list (optional) ---
+# RFID_WEBHOOK_IP_WHITELIST=
+
+# --- Local auth must stay off in production ---
+LOCAL_AUTH_ENABLED=false

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,79 @@
+# -----------------------------------------------------------------------------
+# Staging — RAILS_ENV=staging (inherits production.rb + letter_opener_web).
+#
+# Outbound email is captured only; browse at https://YOUR_HOST/letter_opener
+# (protect that path at your reverse proxy). SMTP settings below are optional
+# and unused for delivery in staging.
+# -----------------------------------------------------------------------------
+
+RAILS_ENV=staging
+
+# RAILS_MASTER_KEY=<from credentials or secrets manager>
+
+# --- App URLs & branding ---
+APP_BASE_URL=https://staging.example.com
+MEMBER_MANAGER_BASE_URL=https://staging.example.com
+ORGANIZATION_NAME=Member Manager (staging)
+EMAIL_FROM_ADDRESS=noreply@staging.example.com
+EMAIL_SUPPORT_ADDRESS=support@staging.example.com
+TIMEZONE=UTC
+
+# --- Database ---
+# DATABASE_URL=postgres://USER:PASSWORD@HOST:5432/member_manager_staging
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+# DB_PASSWORD=
+# DATABASE_URL=
+
+# --- Redis / Sidekiq / Action Cable ---
+REDIS_URL=redis://localhost:6379/1
+
+# --- Puma (same behavior as production) ---
+# WEB_CONCURRENCY=2
+# RAILS_MAX_THREADS=5
+# RAILS_LOG_LEVEL=info
+
+# --- Optional: SMTP (not used for delivery in staging; letter_opener_web captures mail) ---
+# SMTP_ADDRESS=
+# SMTP_PORT=587
+# SMTP_DOMAIN=
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# SMTP_AUTHENTICATION=plain
+# SMTP_ENABLE_STARTTLS=true
+
+# --- Omniauth / Authentik ---
+AUTHENTIK_ISSUER=
+AUTHENTIK_CLIENT_ID=
+AUTHENTIK_CLIENT_SECRET=
+AUTHENTIK_REDIRECT_URI=
+AUTHENTIK_GROUP_ID=
+AUTHENTIK_API_BASE_URL=
+AUTHENTIK_API_TOKEN=
+AUTHENTIK_TOKEN_ENDPOINT=
+AUTHENTIK_WEBHOOK_SECRET=
+AUTHENTIK_GROUP_PAGE_SIZE=200
+
+# --- Integrations ---
+PAYPAL_CLIENT_ID=
+PAYPAL_CLIENT_SECRET=
+RECHARGE_API_KEY=
+RECHARGE_WEBHOOK_SECRET=
+GOOGLE_SHEETS_CREDENTIALS=
+GOOGLE_SHEETS_ID=
+SLACK_API_TOKEN=
+KOFI_VERIFICATION_TOKEN=
+ACCESS_WEBHOOK_KEY=
+
+# --- Observability ---
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.1
+SENTRY_PROFILES_SAMPLE_RATE=0.1
+
+# --- Misc ---
+# APP_VERSION=0.0.0-staging
+# SYSLOG_SERVER=
+# SYSLOG_PORT=
+# ACCESS_LOGS_DIRECTORY=
+# RFID_WEBHOOK_IP_WHITELIST=

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,39 @@
+# -----------------------------------------------------------------------------
+# Test — optional when running tests outside Docker (e.g. `RAILS_ENV=test bin/rails test`).
+# docker compose uses the `test` profile with env vars inline; this file is for
+# documenting expected variables or local overrides.
+# -----------------------------------------------------------------------------
+
+RAILS_ENV=test
+
+# CI sets this in GitHub Actions for eager_load; optional locally.
+# CI=true
+
+# Skip CSS pipeline during test:prepare when bundler hooks would run yarn (optional).
+SKIP_CSS_BUILD=1
+
+# --- Database (docker compose test service uses `db` hostname) ---
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/member_manager_test
+
+# --- Redis ---
+REDIS_URL=redis://localhost:6379/0
+
+# --- App URLs (mailers / helpers in some tests) ---
+APP_BASE_URL=http://localhost:3000
+ORGANIZATION_NAME=Member Manager
+EMAIL_FROM_ADDRESS=noreply@example.com
+EMAIL_SUPPORT_ADDRESS=support@example.com
+TIMEZONE=UTC
+
+# --- Many system tests enable local auth ---
+# LOCAL_AUTH_ENABLED=true
+# LOCAL_AUTH_EMAIL=test@localhost
+# LOCAL_AUTH_PASSWORD=test-password
+# LOCAL_AUTH_FULL_NAME=Test Admin
+
+# --- Optional: keep parity with CI secrets without committing real values ---
+# SENTRY_DSN=

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,14 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore all environment files (except templates).
+# Ignore all environment files (except committed examples).
 /.env*
 !/.env*.erb
+!/.env.example
+!/.env.development.example
+!/.env.test.example
+!/.env.staging.example
+!/.env.production.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,11 @@ group :development, :test do
   gem 'debug', platforms: %i[mri mswin mswin64 mingw x64_mingw]
 end
 
+# Staging only: browse captured mail at /letter_opener (not loaded in production).
+group :staging do
+  gem 'letter_opener_web', '~> 3.0'
+end
+
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,11 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.1)
@@ -491,6 +496,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   letter_opener (~> 1.10)
+  letter_opener_web (~> 3.0)
   minitest (~> 5.0)
   net-ssh (~> 7.0)
   omniauth (~> 2.1)

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -4,6 +4,11 @@ development:
 test:
   adapter: test
 
+staging:
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  channel_prefix: member_manager_staging
+
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -82,6 +82,10 @@ test:
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #
+staging:
+  <<: *default
+  database: member_manager_staging
+
 production:
   <<: *default
   database: member_manager_production

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,14 @@
+require_relative 'production'
+
+Rails.application.configure do
+  # Staging mirrors production (see production.rb) but never sends real email.
+  # Browse captured messages at /letter_opener (LetterOpenerWeb).
+  #
+  # If web and Sidekiq run in separate containers, set a shared volume for
+  # LetterOpenerWeb’s letters path or configure config.letters_location accordingly.
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = false
+
+  # SMTP is not used in staging; delivery goes through letter_opener_web only.
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -13,7 +13,7 @@ threads min_threads_count, max_threads_count
 
 rails_env = ENV.fetch("RAILS_ENV") { "development" }
 
-if rails_env == "production"
+if %w[production staging].include?(rails_env)
   # If you are running more than 1 thread per process, the workers count
   # should be equal to the number of processors (CPU cores) in production.
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -389,6 +389,10 @@ Rails.application.routes.draw do
   
   require 'sidekiq/web'
   mount Sidekiq::Web => '/goh7zeeNiezoozaingothu4'
+
+  # Staging only: view emails captured instead of being sent (letter_opener_web).
+  # Restrict /letter_opener at the reverse proxy or add auth if exposed.
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.staging?
   
   resources :applications do
     resources :application_groups, except: [:index] do


### PR DESCRIPTION
- Staging loads production settings then captures mail via letter_opener_web (/letter_opener)
- Gemfile :staging group; database/cable/puma updates for staging
- .env.{development,test,staging,production}.example plus root .env.example index
- .gitignore exceptions so example env files are tracked

Made-with: Cursor