### PR TITLE
Add admin CSV import for membership applications.

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -1,7 +1,9 @@
 class MembershipApplicationsController < ApplicationController
+  require 'csv'
+
   include Pagy::Backend
 
-  before_action :require_admin!, only: %i[index show approve reject mark_under_review]
+  before_action :require_admin!, only: %i[index show import approve reject mark_under_review]
   before_action :set_application_admin, only: %i[show approve reject mark_under_review]
   before_action :require_verified_email!, only: %i[start save_page page submit_application]
   before_action :load_pages, only: %i[start page]
@@ -80,6 +82,24 @@ class MembershipApplicationsController < ApplicationController
   def confirmation; end
 
   # --- Admin actions ---
+
+  def import
+    if params[:file].blank?
+      redirect_to membership_applications_path, alert: 'Please choose a CSV file to import.'
+      return
+    end
+
+    result = MembershipApplications::CsvImporter.new(imported_by: current_user).call(params[:file])
+    notice_parts = ["Imported #{result[:imported]} application(s)."]
+    notice_parts << "#{result[:skipped]} row(s) skipped." if result[:skipped].positive?
+    if result[:errors].any?
+      msg = result[:errors].first(5).join(' ')
+      flash[:alert] = result[:errors].size > 5 ? "#{msg} …" : msg
+    end
+    redirect_to membership_applications_path, notice: notice_parts.join(' ')
+  rescue CSV::MalformedCSVError => e
+    redirect_to membership_applications_path, alert: "Invalid CSV: #{e.message}"
+  end
 
   def index
     @applications = MembershipApplication.where.not(status: 'draft').newest_first

--- a/app/services/membership_applications/csv_importer.rb
+++ b/app/services/membership_applications/csv_importer.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module MembershipApplications
+  # Imports historical membership application rows from CSV exports.
+  # Does not call +submit!+, +approve!+, or +reject!+ — no journal entries and no mail side effects.
+  class CsvImporter
+    RESERVED_HEADERS = %w[Approved Timestamp Email Address].freeze
+
+    def initialize(imported_by: nil, logger: Rails.logger)
+      @imported_by = imported_by
+      @logger = logger
+      @question_ids_by_label = ApplicationFormQuestion.pluck(:label, :id).to_h
+    end
+
+    # @param file [#read] uploaded file or StringIO
+    # @return [Hash] { imported: Integer, skipped: Integer, errors: Array<String> }
+    def call(file)
+      raise ArgumentError, 'CSV file is missing' if file.blank?
+
+      csv_content = file.read.force_encoding('UTF-8')
+      csv_content = csv_content.sub(/\A\uFEFF/, '')
+      csv_data = CSV.parse(csv_content, headers: true)
+
+      counts = { imported: 0, skipped: 0 }
+      errors = []
+
+      MembershipApplication.transaction do
+        csv_data.each_with_index do |row, idx|
+          line = idx + 2
+          import_row(row, line, counts, errors)
+        rescue StandardError => e
+          counts[:skipped] += 1
+          errors << "Row #{line}: #{e.message}"
+          @logger.error("Membership application CSV row #{line}: #{e.message}")
+        end
+      end
+
+      { imported: counts[:imported], skipped: counts[:skipped], errors: errors }
+    end
+
+    private
+
+    def import_row(row, line, counts, errors)
+      row_hash = row.to_h.transform_keys { |k| k.to_s.strip }
+      email = row_hash['Email Address']&.strip
+      if email.blank?
+        counts[:skipped] += 1
+        errors << "Row #{line}: missing Email Address"
+        return
+      end
+
+      submitted_at = parse_timestamp(row_hash['Timestamp'])
+      status, reviewed_at = interpret_approved(row_hash['Approved'])
+      reviewed_at = finalize_reviewed_at(status, reviewed_at, submitted_at)
+
+      app = build_application(row_hash, email:, status:, submitted_at:, reviewed_at:)
+      app.save!
+      create_answers!(row_hash, app)
+
+      counts[:imported] += 1
+    end
+
+    def finalize_reviewed_at(status, reviewed_at, submitted_at)
+      return reviewed_at unless status.in?(%w[approved rejected])
+
+      reviewed_at || submitted_at || Time.current
+    end
+
+    def build_application(row_hash, email:, status:, submitted_at:, reviewed_at:)
+      extras = unmapped_column_notes(row_hash)
+      app = MembershipApplication.new(
+        email: email,
+        status: status,
+        submitted_at: submitted_at,
+        reviewed_at: reviewed_at,
+        reviewed_by: (@imported_by if status.in?(%w[approved rejected])),
+        admin_notes: extras.join("\n\n").presence
+      )
+      if submitted_at
+        app.created_at = submitted_at
+        app.updated_at = submitted_at
+      end
+      app
+    end
+
+    def unmapped_column_notes(row_hash)
+      extras = []
+      row_hash.each do |header, value|
+        next if RESERVED_HEADERS.include?(header)
+        next if value.blank?
+        next if @question_ids_by_label.key?(header)
+
+        extras << "#{header}: #{value}"
+      end
+      extras
+    end
+
+    def create_answers!(row_hash, app)
+      row_hash.each do |header, value|
+        next if RESERVED_HEADERS.include?(header)
+        next if value.blank?
+
+        qid = @question_ids_by_label[header]
+        next unless qid
+
+        ApplicationAnswer.create!(
+          membership_application: app,
+          application_form_question_id: qid,
+          value: value.to_s.strip
+        )
+      end
+    end
+
+    def interpret_approved(raw)
+      s = raw.to_s.strip
+      return ['submitted', nil] if s.blank?
+
+      return ['approved', nil] if s.match?(/\A(yes|true|1|y|approved|x)\z/i)
+
+      return ['rejected', nil] if s.match?(/\A(no|false|0|n|rejected)\z/i)
+
+      t = parse_timestamp(s)
+      return ['approved', t] if t
+
+      ['submitted', nil]
+    end
+
+    def parse_timestamp(val)
+      return nil if val.blank?
+
+      Time.zone.parse(val.to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
+  end
+end

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -1,5 +1,38 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
   <h1 class="h3 mb-0">Membership Applications</h1>
+  <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#importApplicationsCsvModal">Import CSV</button>
+</div>
+
+<div class="modal fade" id="importApplicationsCsvModal" tabindex="-1" aria-labelledby="importApplicationsCsvModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="importApplicationsCsvModalLabel">Import membership applications from CSV</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <%= form_with url: import_membership_applications_path, method: :post, multipart: true, local: true do |f| %>
+        <div class="modal-body">
+          <p class="text-muted small mb-2">
+            Columns <strong>Approved</strong>, <strong>Timestamp</strong>, and <strong>Email Address</strong> are required metadata.
+            All other columns must match form question labels exactly (as in your export). Rows without an email are skipped.
+          </p>
+          <p class="text-muted small mb-3">
+            Import does not send email and does not run the normal submit/approve workflow.
+          </p>
+          <div class="mb-3">
+            <%= f.file_field :file, accept: 'text/csv,.csv', class: "form-control", required: true %>
+          </div>
+          <div class="alert alert-warning mb-0 small">
+            <strong>Tip:</strong> Columns that do not match any question are appended to Admin notes on each application.
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <%= f.submit "Import", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>
 
 <ul class="nav nav-tabs mb-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -375,6 +375,9 @@ Rails.application.routes.draw do
   end
 
   resources :membership_applications, only: %i[index show] do
+    collection do
+      post :import
+    end
     member do
       post :approve
       post :reject

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+    sign_in_as_admin
+    @page = ApplicationFormPage.create!(title: 'Controller Import Page', position: 901)
+    @page.questions.create!(label: 'Name', field_type: 'text', required: false, position: 1)
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+  end
+
+  test 'import creates membership application from csv' do
+    file = fixture_file_upload('membership_application_import.csv', 'text/csv')
+
+    assert_difference('MembershipApplication.count', 1) do
+      post import_membership_applications_path, params: { file: file }
+    end
+
+    assert_redirected_to membership_applications_path
+    follow_redirect!
+    assert_match(/Imported 1 application/, flash[:notice])
+
+    app = MembershipApplication.find_by!(email: 'controller-csv-import@example.com')
+    assert_equal 'approved', app.status
+    assert_equal 'Sam Sample', app.answer_for(@page.questions.first)&.value
+  end
+
+  test 'import without file redirects with alert' do
+    post import_membership_applications_path
+    assert_redirected_to membership_applications_path
+    assert_equal 'Please choose a CSV file to import.', flash[:alert]
+  end
+
+  private
+
+  def sign_in_as_admin
+    account = local_accounts(:active_admin)
+    post local_login_path, params: {
+      session: { email: account.email, password: 'localpassword123' }
+    }
+  end
+end

--- a/test/fixtures/files/membership_application_import.csv
+++ b/test/fixtures/files/membership_application_import.csv
@@ -1,0 +1,2 @@
+Approved,Timestamp,Email Address,Name
+Yes,2024-06-01 08:00:00 UTC,controller-csv-import@example.com,Sam Sample

--- a/test/services/membership_applications/csv_importer_test.rb
+++ b/test/services/membership_applications/csv_importer_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MembershipApplications
+  class CsvImporterTest < ActiveSupport::TestCase
+    setup do
+      @page = ApplicationFormPage.create!(title: 'Importer Test Page', position: 900)
+      @page.questions.create!(label: 'Name', field_type: 'text', required: false, position: 1)
+      @page.questions.create!(label: 'Mailing Address', field_type: 'text', required: false, position: 2)
+    end
+
+    test 'creates application with answers and approved status without journal or queued mail' do
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name,Mailing Address
+        Yes,2024-01-15 10:00:00 UTC,importer-test@example.com,Jane Doe,123 Main St
+      CSV
+
+      importer = CsvImporter.new(imported_by: users(:one))
+      journal_app_actions = %w[application_submitted application_approved application_rejected]
+      assert_no_difference -> { Journal.where(action: journal_app_actions).count } do
+        assert_no_difference 'QueuedMail.count' do
+          result = importer.call(StringIO.new(csv))
+          assert_equal 1, result[:imported]
+          assert_equal 0, result[:skipped]
+          assert_empty result[:errors]
+        end
+      end
+
+      app = MembershipApplication.find_by!(email: 'importer-test@example.com')
+      assert_equal 'approved', app.status
+      name_ans = app.application_answers
+                    .joins(:application_form_question)
+                    .find_by(application_form_questions: { label: 'Name' })
+      assert_equal 'Jane Doe', name_ans.value
+      addr_ans = app.application_answers
+                    .joins(:application_form_question)
+                    .find_by(application_form_questions: { label: 'Mailing Address' })
+      assert_equal '123 Main St', addr_ans.value
+      assert_equal users(:one), app.reviewed_by
+      assert app.reviewed_at.present?
+    end
+
+    test 'stores unknown columns in admin_notes' do
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name,Estimated co-working hours per week? (@ ^H)
+        ,2024-02-01 12:00:00 UTC,extras@example.com,Pat,10
+      CSV
+
+      result = CsvImporter.new.call(StringIO.new(csv))
+      assert_equal 1, result[:imported]
+      app = MembershipApplication.find_by!(email: 'extras@example.com')
+      assert_includes app.admin_notes, 'Estimated co-working hours per week? (@ ^H)'
+      assert_includes app.admin_notes, '10'
+    end
+
+    test 'rejected when Approved is no' do
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        No,2024-03-01,rejected@example.com,X
+      CSV
+
+      CsvImporter.new(imported_by: users(:one)).call(StringIO.new(csv))
+      app = MembershipApplication.find_by!(email: 'rejected@example.com')
+      assert_equal 'rejected', app.status
+    end
+
+    test 'skipped row with blank email' do
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        Yes,2024-01-01,,Nobody
+      CSV
+
+      result = CsvImporter.new.call(StringIO.new(csv))
+      assert_equal 0, result[:imported]
+      assert_equal 1, result[:skipped]
+      assert_match(/missing Email Address/, result[:errors].join)
+    end
+  end
+end


### PR DESCRIPTION
Import maps export columns to ApplicationFormQuestion labels, sets status from the Approved column, and skips submit/approve/reject so no email or journal workflow runs. Tests cover importer behavior and the import action.

Made-with: Cursor