### PR TITLE
Allow boot without AUTHENTIK_TOKEN; surface API gap on dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Set these variables in your shell, `.env`, or Docker Compose environment:
 | `AUTHENTIK_CLIENT_ID` / `AUTHENTIK_CLIENT_SECRET` | OAuth credentials from Authentik |
 | `AUTHENTIK_REDIRECT_URI` | Callback URL registered in Authentik (default `http://localhost:3000/auth/authentik/callback`) |
 | `AUTHENTIK_API_BASE_URL` | Base URL for Authentik's API (defaults to the issuer) |
-| `AUTHENTIK_TOKEN` | Service account API token sent as `Authorization: Bearer` (required at boot in non-test environments) |
+| `AUTHENTIK_TOKEN` | Service account API token sent as `Authorization: Bearer` (optional at boot; the admin dashboard shows Urgent if Authentik login or member sync is enabled but the token or API base URL is missing) |
 | `AUTHENTIK_GROUP_ID` | UUID/slug of the Authentik group to sync |
 | `AUTHENTIK_GROUP_PAGE_SIZE` | Optional page size override when fetching group members (default 200) |
 | `SLACK_API_TOKEN` | Slack Bot/User OAuth token with at least `users:read` scope |

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -49,8 +49,12 @@ class DashboardController < AdminController
                                                          .where(sync_status: %w[degraded failing])
                                                          .order(:name)
 
-    # Urgent: Authentik pull/push sync failures
+    # Urgent: Authentik API not configured (login and/or member sync enabled)
     @authentik_member_source = MemberSource.find_by(key: 'authentik')
+    @authentik_api_urgent = !AuthentikConfig.api_ready? &&
+                            (AuthentikConfig.enabled_for_login? || @authentik_member_source&.enabled?)
+
+    # Urgent: Authentik pull/push sync failures
     @authentik_sync_issue = @authentik_member_source if @authentik_member_source&.enabled? &&
                                                         @authentik_member_source.sync_status.in?(%w[degraded failing])
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -141,7 +141,17 @@
             <% item_number += 1 %>
             <li class="list-group-item d-flex align-items-start gap-2 py-3">
               <span class="badge rounded-pill text-bg-secondary"><%= item_number %></span>
-              <% if @authentik_member_source.nil? || !@authentik_member_source.enabled? %>
+              <% if @authentik_api_urgent %>
+                <div>
+                  <i class="bi bi-x-circle-fill text-danger me-1"></i>
+                  <%= link_to authentik_webhooks_path, class: "text-decoration-none fw-semibold" do %>
+                    Authentik API integration is not configured
+                  <% end %>
+                  <div class="text-muted small mt-1">
+                    Set <code>AUTHENTIK_TOKEN</code> (and a valid API base URL) so group sync, provisioning, and webhooks can call Authentik.
+                  </div>
+                </div>
+              <% elsif @authentik_member_source.nil? || !@authentik_member_source.enabled? %>
                 <div>
                   <i class="bi bi-check-circle-fill text-success me-1"></i>
                   Authentik member source disabled — no sync alerts

--- a/config/initializers/authentik.rb
+++ b/config/initializers/authentik.rb
@@ -18,18 +18,21 @@ module AuthentikConfig
   def self.enabled_for_login?
     settings.client_id.present? && settings.client_secret.present? && settings.issuer.present?
   end
+
+  # Bearer REST API calls require token + base URL (see +Authentik::Client#validate_api_config!+).
+  def self.api_ready?
+    settings.api_token.present? && settings.api_base_url.present?
+  end
 end
 
-# Service account API token is mandatory at runtime. Skip during tests and when precompiling
-# assets in Docker (+SECRET_KEY_BASE_DUMMY+).
+# API token may be unset during local bootstrap; Authentik REST features stay disabled until configured.
+# The admin dashboard surfaces this in the Urgent section.
 unless Rails.env.test? || ENV['SECRET_KEY_BASE_DUMMY'].present?
   token = ENV.fetch('AUTHENTIK_TOKEN', '').strip
   if token.blank?
-    msg = 'MemberManager: AUTHENTIK_TOKEN is missing or empty. Set it to your Authentik service ' \
-          'account API token. The app will send it as Authorization: Bearer. Refusing to start.'
-    Rails.logger.error(msg)
+    msg = 'MemberManager: AUTHENTIK_TOKEN is missing or empty. OIDC login may still work; set a ' \
+          'service account API token for group sync, provisioning, and webhooks.'
+    Rails.logger.warn(msg)
     warn(msg)
-    # Boot must not continue without API credentials; abort is intentional (avoid infinite Sidekiq/API failures).
-    abort(msg) # rubocop:disable Rails/Exit -- fail fast when Authentik API token is unset
   end
 end


### PR DESCRIPTION
Stop aborting when the Authentik API bearer token is unset; log a warning instead. Add AuthentikConfig.api_ready? and show an Urgent dashboard item when login or Authentik member sync is enabled but API credentials are incomplete. Update README env documentation.

Made-with: Cursor