### PR TITLE
Link membership applications to members by optional user association

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -3,8 +3,8 @@ class MembershipApplicationsController < ApplicationController
 
   include Pagy::Backend
 
-  before_action :require_admin!, only: %i[index show import approve reject mark_under_review]
-  before_action :set_application_admin, only: %i[show approve reject mark_under_review]
+  before_action :require_admin!, only: %i[index show import approve reject mark_under_review link_user unlink_user]
+  before_action :set_application_admin, only: %i[show approve reject mark_under_review link_user unlink_user]
   before_action :require_verified_email!, only: %i[start save_page page submit_application]
   before_action :load_pages, only: %i[start page]
 
@@ -102,7 +102,7 @@ class MembershipApplicationsController < ApplicationController
   end
 
   def index
-    @applications = MembershipApplication.where.not(status: 'draft').newest_first
+    @applications = MembershipApplication.where.not(status: 'draft').newest_first.includes(:user, :reviewed_by)
     @applications = @applications.where(status: params[:status]) if params[:status].present?
 
     @status_counts = {
@@ -114,10 +114,26 @@ class MembershipApplicationsController < ApplicationController
     }
 
     @pagy, @applications = pagy(@applications, limit: 25)
+
+    @users_for_application_link = User.non_service_accounts.ordered_by_display_name.to_a
   end
 
   def show
     @pages_with_answers = @application.answers_by_page
+    @users_for_application_link = User.non_service_accounts.ordered_by_display_name.to_a
+  end
+
+  def link_user
+    user = User.non_service_accounts.find(params[:user_id])
+    @application.update!(user: user)
+    redirect_to membership_application_path(@application),
+                notice: "Application linked to #{user.display_name}."
+  end
+
+  def unlink_user
+    @application.update!(user: nil)
+    redirect_to membership_application_path(@application),
+                notice: 'Member link removed from this application.'
   end
 
   def approve

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -2,6 +2,7 @@ class MembershipApplication < ApplicationRecord
   STATUSES = %w[draft submitted under_review approved rejected].freeze
 
   belongs_to :reviewed_by, class_name: 'User', optional: true
+  belongs_to :user, optional: true
   has_many :application_answers, dependent: :destroy
 
   validates :email, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
   has_many :reported_incidents, class_name: 'IncidentReport', foreign_key: 'reporter_id', dependent: :nullify
   has_and_belongs_to_many :incident_reports, join_table: 'incident_report_members'
   has_many :parking_notices, dependent: :nullify
+  has_many :membership_applications, dependent: :nullify
   has_many :invitations, dependent: :nullify
   has_many :sent_invitations, class_name: 'Invitation', foreign_key: 'invited_by_id', dependent: :nullify
   has_many :sent_messages, class_name: 'Message', foreign_key: 'sender_id', dependent: :destroy

--- a/app/views/membership_applications/_link_member_modal.html.erb
+++ b/app/views/membership_applications/_link_member_modal.html.erb
@@ -1,0 +1,136 @@
+<%# Locals: users (required), form_url (optional; use # with dynamic linking from index rows), dynamic (optional, default: form_url.blank?) %>
+<% form_action = local_assigns[:form_url].presence || '#' %>
+<% dynamic = local_assigns.fetch(:dynamic, form_action == '#') %>
+<div class="modal fade" id="maLinkMemberModal" tabindex="-1" aria-labelledby="maLinkMemberModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="maLinkMemberModalLabel">Link application to member</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <%= form_with url: form_action, method: :post, local: true, html: { id: 'ma_link_member_form' } do %>
+        <div class="modal-body">
+          <p class="mb-3 text-muted">Search by name, email, or username, then select the member to associate with this application. Applicant email: <strong id="ma_modal_application_email" class="text-break"><%= h(local_assigns[:application_email].to_s.presence || '—') %></strong></p>
+          <div class="mb-3">
+            <label for="ma_user_search" class="form-label">Search members</label>
+            <input type="text" id="ma_user_search" class="form-control mb-2" placeholder="Type to search members..." autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Select member</label>
+            <div id="ma_user_list" class="border rounded" style="max-height: 300px; overflow-y: auto;">
+              <% users.each do |user| %>
+                <div class="ma-user-item p-2 border-bottom" data-user-name="<%= user.display_name.downcase %>" data-user-email="<%= user.email.to_s.downcase %>" data-username="<%= user.username.to_s.downcase %>" role="button">
+                  <input type="radio" name="user_id" id="ma_user_<%= user.id %>" value="<%= user.id %>" class="form-check-input me-2" required>
+                  <label for="ma_user_<%= user.id %>" class="form-check-label mb-0" role="button">
+                    <%= user.display_name %>
+                    <% if user.email.present? %>
+                      <span class="text-muted small">(<%= user.email %>)</span>
+                    <% end %>
+                  </label>
+                </div>
+              <% end %>
+            </div>
+            <div id="ma_no_results" class="text-muted text-center p-3 d-none">
+              No members found matching your search.
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <%= submit_tag 'Link member', class: 'btn btn-primary' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function() {
+    const modal = document.getElementById('maLinkMemberModal');
+    if (!modal) return;
+
+    let searchHandler = null;
+
+    function filterUsers() {
+      const searchInput = document.getElementById('ma_user_search');
+      const userList = document.getElementById('ma_user_list');
+      const noResults = document.getElementById('ma_no_results');
+      if (!searchInput || !userList) return;
+
+      const searchTerm = searchInput.value.toLowerCase().trim();
+      const items = userList.querySelectorAll('.ma-user-item');
+      let visibleCount = 0;
+
+      items.forEach(function(item) {
+        const name = item.getAttribute('data-user-name') || '';
+        const email = item.getAttribute('data-user-email') || '';
+        const username = item.getAttribute('data-username') || '';
+        const haystack = name + ' ' + email + ' ' + username;
+        if (searchTerm === '' || haystack.includes(searchTerm)) {
+          item.style.display = '';
+          visibleCount++;
+        } else {
+          item.style.display = 'none';
+        }
+      });
+
+      if (visibleCount === 0 && searchTerm !== '') {
+        userList.classList.add('d-none');
+        if (noResults) noResults.classList.remove('d-none');
+      } else {
+        userList.classList.remove('d-none');
+        if (noResults) noResults.classList.add('d-none');
+      }
+    }
+
+    function resetSearch() {
+      const searchInput = document.getElementById('ma_user_search');
+      const userList = document.getElementById('ma_user_list');
+      const noResults = document.getElementById('ma_no_results');
+
+      if (searchInput) searchInput.value = '';
+      if (userList) {
+        userList.querySelectorAll('.ma-user-item').forEach(function(item) { item.style.display = ''; });
+        userList.classList.remove('d-none');
+      }
+      if (noResults) noResults.classList.add('d-none');
+    }
+
+    (function delegateRowClicks() {
+      const userList = document.getElementById('ma_user_list');
+      if (!userList || userList.dataset.maDelegated === '1') return;
+      userList.dataset.maDelegated = '1';
+      userList.addEventListener('click', function(e) {
+        const item = e.target.closest('.ma-user-item');
+        if (!item || e.target.type === 'radio' || e.target.tagName === 'LABEL') return;
+        const radio = item.querySelector('input[type="radio"]');
+        if (radio) radio.checked = true;
+      });
+    })();
+
+    modal.addEventListener('show.bs.modal', function(event) {
+      const form = document.getElementById('ma_link_member_form');
+      const emailEl = document.getElementById('ma_modal_application_email');
+      const btn = event.relatedTarget;
+      <% if dynamic %>
+      const action = btn && btn.getAttribute('data-ma-link-action');
+      if (action && form) form.setAttribute('action', action);
+      const rowEmail = btn && btn.getAttribute('data-application-email');
+      if (emailEl && rowEmail) emailEl.textContent = rowEmail;
+      <% end %>
+
+      resetSearch();
+      const searchInput = document.getElementById('ma_user_search');
+      if (searchInput) {
+        if (searchHandler) searchInput.removeEventListener('input', searchHandler);
+        searchHandler = function() { filterUsers(); };
+        searchInput.addEventListener('input', searchHandler);
+      }
+    });
+
+    modal.addEventListener('shown.bs.modal', function() {
+      const searchInput = document.getElementById('ma_user_search');
+      if (searchInput) searchInput.focus();
+    });
+  })();
+</script>

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -79,6 +79,7 @@
             <th>Status</th>
             <th>Submitted</th>
             <th>Reviewed by</th>
+            <th>Linked member</th>
             <th class="text-end">Actions</th>
           </tr>
         </thead>
@@ -92,7 +93,22 @@
               </td>
               <td><%= app.submitted_at&.strftime('%b %d, %Y') || '—' %></td>
               <td><%= app.reviewed_by&.display_name || '—' %></td>
-              <td class="text-end">
+              <td>
+                <% if app.user %>
+                  <%= link_to app.user.display_name, user_path(app.user), class: "text-decoration-none" %>
+                <% else %>
+                  <span class="text-muted">—</span>
+                <% end %>
+              </td>
+              <td class="text-end text-nowrap">
+                <% if app.user.nil? %>
+                  <button type="button" class="btn btn-sm btn-primary"
+                          data-bs-toggle="modal" data-bs-target="#maLinkMemberModal"
+                          data-ma-link-action="<%= link_user_membership_application_path(app) %>"
+                          data-application-email="<%= h(app.email) %>">
+                    Link member
+                  </button>
+                <% end %>
                 <%= link_to "View", membership_application_path(app), class: "btn btn-sm btn-outline-primary" %>
               </td>
             </tr>
@@ -110,4 +126,8 @@
     <i class="bi bi-inbox fs-1 d-block mb-2"></i>
     <p>No applications found.</p>
   </div>
+<% end %>
+
+<% if @users_for_application_link.any? %>
+  <%= render 'link_member_modal', users: @users_for_application_link, dynamic: true, application_email: '' %>
 <% end %>

--- a/app/views/membership_applications/show.html.erb
+++ b/app/views/membership_applications/show.html.erb
@@ -30,6 +30,25 @@
 
           <dt>Submitted</dt>
           <dd><%= @application.submitted_at&.strftime('%B %d, %Y at %l:%M %p') || 'Not yet submitted' %></dd>
+
+          <dt>Linked member</dt>
+          <dd class="d-flex flex-wrap align-items-center gap-2">
+            <% if @application.user %>
+              <%= link_to @application.user.display_name, user_path(@application.user), class: "text-decoration-none" %>
+              <%= button_to 'Unlink', unlink_user_membership_application_path(@application),
+                            method: :post,
+                            class: 'btn btn-sm btn-outline-warning',
+                            form: { data: { turbo_confirm: 'Remove the member link from this application?' } } %>
+            <% else %>
+              <span class="text-muted">Not linked</span>
+              <% if @users_for_application_link.any? %>
+                <button type="button" class="btn btn-sm btn-primary"
+                        data-bs-toggle="modal" data-bs-target="#maLinkMemberModal">
+                  Link member
+                </button>
+              <% end %>
+            <% end %>
+          </dd>
         </dl>
       </div>
       <div class="col-md-6">
@@ -53,6 +72,13 @@
     </div>
   </div>
 </div>
+
+<% if @application.user.nil? && @users_for_application_link.any? %>
+  <%= render 'link_member_modal',
+             users: @users_for_application_link,
+             form_url: link_user_membership_application_path(@application),
+             application_email: @application.email %>
+<% end %>
 
 <% @pages_with_answers.each do |entry| %>
   <% page = entry[:page] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -382,6 +382,8 @@ Rails.application.routes.draw do
       post :approve
       post :reject
       post :mark_under_review
+      post :link_user
+      post :unlink_user
     end
   end
 

--- a/db/migrate/20260402041203_add_user_to_membership_applications.rb
+++ b/db/migrate/20260402041203_add_user_to_membership_applications.rb
@@ -1,0 +1,5 @@
+class AddUserToMembershipApplications < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :membership_applications, :user, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_02_040417) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_02_041203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -466,10 +466,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_040417) do
     t.datetime "submitted_at"
     t.string "token", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["email"], name: "index_membership_applications_on_email"
     t.index ["reviewed_by_id"], name: "index_membership_applications_on_reviewed_by_id"
     t.index ["status"], name: "index_membership_applications_on_status"
     t.index ["token"], name: "index_membership_applications_on_token", unique: true
+    t.index ["user_id"], name: "index_membership_applications_on_user_id"
   end
 
   create_table "membership_plans", force: :cascade do |t|
@@ -946,6 +948,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_040417) do
   add_foreign_key "kofi_payments", "users"
   add_foreign_key "mail_log_entries", "queued_mails"
   add_foreign_key "mail_log_entries", "users", column: "actor_id"
+  add_foreign_key "membership_applications", "users"
   add_foreign_key "membership_applications", "users", column: "reviewed_by_id"
   add_foreign_key "membership_plans", "users"
   add_foreign_key "messages", "users", column: "recipient_id"

--- a/lib/tasks/membership_applications.rake
+++ b/lib/tasks/membership_applications.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+namespace :membership_applications do
+  desc 'Link membership applications to users when emails match (primary or extra_emails), case-insensitive'
+  task link_by_email: :environment do
+    linked = 0
+    skipped = 0
+
+    MembershipApplication.where(user_id: nil).find_each do |app|
+      email = app.email.to_s.strip.downcase
+      if email.blank?
+        skipped += 1
+        next
+      end
+
+      user = User.where('LOWER(TRIM(email)) = ?', email).first
+      user ||= User.where(
+        'EXISTS (SELECT 1 FROM unnest(extra_emails) AS e WHERE LOWER(TRIM(e)) = ?)',
+        email
+      ).first
+
+      if user
+        app.update!(user: user)
+        linked += 1
+        puts "Linked application #{app.id} (#{app.email}) → user #{user.id} (#{user.display_name})"
+      else
+        skipped += 1
+      end
+    end
+
+    puts "Done. Linked #{linked} application(s); #{skipped} skipped (no match or blank email)."
+  end
+end

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -37,6 +37,36 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Please choose a CSV file to import.', flash[:alert]
   end
 
+  test 'link_user associates member with application' do
+    app = MembershipApplication.create!(
+      email: 'link-app-test@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    member = users(:member_with_local_account)
+
+    post link_user_membership_application_path(app), params: { user_id: member.id }
+
+    assert_redirected_to membership_application_path(app)
+    assert_match(/linked/i, flash[:notice])
+    assert_equal member.id, app.reload.user_id
+  end
+
+  test 'unlink_user clears member on application' do
+    app = MembershipApplication.create!(
+      email: 'unlink-app-test@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    member = users(:member_with_local_account)
+    app.update!(user: member)
+
+    post unlink_user_membership_application_path(app)
+
+    assert_redirected_to membership_application_path(app)
+    assert_nil app.reload.user_id
+  end
+
   private
 
   def sign_in_as_admin

--- a/test/tasks/membership_applications_link_by_email_test.rb
+++ b/test/tasks/membership_applications_link_by_email_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MembershipApplicationsLinkByEmailTaskTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks
+    @task = Rake::Task['membership_applications:link_by_email']
+    @task.reenable
+  end
+
+  test 'links unlinked applications when email matches user primary email' do
+    member = users(:one)
+    app = MembershipApplication.create!(
+      email: member.email.upcase,
+      status: 'approved',
+      submitted_at: 1.day.ago,
+      user: nil
+    )
+
+    @task.invoke
+
+    assert_equal member.id, app.reload.user_id
+  end
+
+  test 'links when email matches extra_emails only' do
+    member = users(:one)
+    member.update!(extra_emails: ['aliasapply@example.com'])
+
+    app = MembershipApplication.create!(
+      email: 'aliasapply@example.com',
+      status: 'submitted',
+      submitted_at: Time.current,
+      user: nil
+    )
+
+    @task.invoke
+
+    assert_equal member.id, app.reload.user_id
+  end
+end


### PR DESCRIPTION
Add nullable user_id on membership_applications with belongs_to/from User. Admins can link from the applications list (modal search by name, email, or username) or the application detail page, and unlink with confirmation.

Introduce rake task membership_applications:link_by_email to match unlinked applications to users on primary or extra email.

Made-with: Cursor