### PR TITLE
Split dashboard attention into two cards; refine headings

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -21,11 +21,11 @@
   }
 }
 
-// Needs attention vs. all-good: strong separator between the two lists on the admin dashboard
-.dashboard-attention-major-divider {
-  height: 0;
-  margin: 0;
-  border-top: 2px solid var(--bs-border-color);
+// Urgent / Important / Housekeeping blocks inside the needs-attention dashboard card
+.dashboard-attention-subsection + .dashboard-attention-subsection {
+  margin-top: 1.25rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--bs-border-color-translucent);
 }
 
 .dashboard-attention-tier-boundary hr {

--- a/app/views/dashboard/_attention_all_good_card.html.erb
+++ b/app/views/dashboard/_attention_all_good_card.html.erb
@@ -1,0 +1,11 @@
+<%# locals: attention_ok %>
+<div class="card dashboard-panel mb-4">
+  <div class="card-header bg-success bg-opacity-10 rounded-0">
+    <h5 class="mb-0"><i class="bi bi-check-circle-fill text-success me-2"></i>No Action Required</h5>
+  </div>
+  <div class="card-body p-0">
+    <ul class="list-group list-group-flush">
+      <%= render 'dashboard/attention_tiered_list', items: attention_ok, show_numbers: false %>
+    </ul>
+  </div>
+</div>

--- a/app/views/dashboard/_attention_needs_card.html.erb
+++ b/app/views/dashboard/_attention_needs_card.html.erb
@@ -1,0 +1,54 @@
+<%# locals: attention_need %>
+<% urgent_need = attention_need.select { |i| i[:tier] == :urgent } %>
+<% important_need = attention_need.select { |i| i[:tier] == :important } %>
+<% housekeeping_need = attention_need.select { |i| i[:tier] == :housekeeping } %>
+
+<div class="card dashboard-panel mb-4">
+  <div class="card-header bg-danger bg-opacity-10 rounded-0">
+    <h5 class="mb-0"><i class="bi bi-exclamation-octagon-fill text-danger me-2"></i>Needs attention</h5>
+  </div>
+  <div class="card-body p-0">
+    <% if attention_need.empty? %>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item py-3 text-muted">
+          <i class="bi bi-check2-circle text-success me-2"></i>
+          Nothing needs attention right now.
+        </li>
+      </ul>
+    <% else %>
+      <% offset = 0 %>
+      <% if urgent_need.any? %>
+        <section class="dashboard-attention-subsection">
+          <div class="card-header bg-danger bg-opacity-10 rounded-0 border-0">
+            <h5 class="mb-0"><i class="bi bi-exclamation-octagon-fill text-danger me-2"></i>Urgent</h5>
+          </div>
+          <ul class="list-group list-group-flush">
+            <%= render 'dashboard/attention_tiered_list', items: urgent_need, show_numbers: true, number_offset: offset %>
+          </ul>
+        </section>
+        <% offset += urgent_need.size %>
+      <% end %>
+      <% if important_need.any? %>
+        <section class="dashboard-attention-subsection">
+          <div class="card-header bg-info bg-opacity-10 rounded-0 border-0">
+            <h5 class="mb-0"><i class="bi bi-info-circle-fill text-info me-2"></i>Important</h5>
+          </div>
+          <ul class="list-group list-group-flush">
+            <%= render 'dashboard/attention_tiered_list', items: important_need, show_numbers: true, number_offset: offset %>
+          </ul>
+        </section>
+        <% offset += important_need.size %>
+      <% end %>
+      <% if housekeeping_need.any? %>
+        <section class="dashboard-attention-subsection">
+          <div class="card-header bg-warning bg-opacity-10 rounded-0 border-0">
+            <h5 class="mb-0"><i class="bi bi-clipboard-check text-warning me-2"></i>Housekeeping</h5>
+          </div>
+          <ul class="list-group list-group-flush">
+            <%= render 'dashboard/attention_tiered_list', items: housekeeping_need, show_numbers: true, number_offset: offset %>
+          </ul>
+        </section>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/dashboard/_attention_tiered_list.html.erb
+++ b/app/views/dashboard/_attention_tiered_list.html.erb
@@ -1,6 +1,7 @@
-<%# locals: items (array of tiered hashes), show_numbers: boolean %>
+<%# locals: items (array of tiered hashes), show_numbers: boolean, number_offset: integer (default 0) %>
 <% items = local_assigns.fetch(:items) %>
 <% show_numbers = local_assigns.fetch(:show_numbers, false) %>
+<% number_offset = local_assigns.fetch(:number_offset, 0) %>
 <% prev_tier = nil %>
 <% items.each_with_index do |item, i| %>
   <% if prev_tier && item[:tier] != prev_tier %>
@@ -8,7 +9,7 @@
   <% end %>
   <li class="list-group-item d-flex align-items-start gap-2 py-3">
     <% if show_numbers %>
-      <span class="badge rounded-pill text-bg-secondary"><%= i + 1 %></span>
+      <span class="badge rounded-pill text-bg-secondary"><%= number_offset + i + 1 %></span>
     <% end %>
     <%= render 'dashboard/attention_item_body', item_id: item[:id] %>
   </li>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -83,29 +83,8 @@
       <% attention_need = @dashboard_attention_items.reject { |i| i[:ok] } %>
       <% attention_ok = @dashboard_attention_items.select { |i| i[:ok] } %>
 
-      <div class="card dashboard-panel mb-4">
-        <div class="card-body p-0">
-          <div class="card-header bg-danger bg-opacity-10 rounded-0">
-            <h5 class="mb-0"><i class="bi bi-exclamation-octagon-fill text-danger me-2"></i>Needs attention</h5>
-          </div>
-          <ul class="list-group list-group-flush">
-            <% if attention_need.any? %>
-              <%= render 'dashboard/attention_tiered_list', items: attention_need, show_numbers: true %>
-            <% else %>
-              <li class="list-group-item py-3 text-muted">
-                <i class="bi bi-check2-circle text-success me-2"></i>
-                Nothing needs attention right now.
-              </li>
-            <% end %>
-          </ul>
-          <% if attention_ok.any? %>
-            <div class="dashboard-attention-major-divider" role="presentation"></div>
-            <ul class="list-group list-group-flush dashboard-attention-all-good">
-              <%= render 'dashboard/attention_tiered_list', items: attention_ok, show_numbers: false %>
-            </ul>
-          <% end %>
-        </div>
-      </div>
+      <%= render 'dashboard/attention_needs_card', attention_need: attention_need %>
+      <%= render 'dashboard/attention_all_good_card', attention_ok: attention_ok if attention_ok.any? %>
     </div>
 
     <!-- Highlights Column -->


### PR DESCRIPTION
Move needs-attention and clear-state lists into separate dashboard-panel cards. Restore Urgent, Important, and Housekeeping subheads only under Needs attention, with continuous priority numbering via list offsets.

Add a second card titled No Action Required for healthy checks only (tier separators, no subheadings). Update subsection spacing in SCSS.

Made-with: Cursor