### PR TITLE
Dashboard: show AI unconfigured under Important with clear heading

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -150,6 +150,7 @@ class DashboardController < AdminController
 
     @ai_ollama_profiles = AiOllamaProfile.ordered.to_a
     @ai_ollama_urgent = @ai_ollama_profiles.any?(&:urgent_health_issue?)
+    @ai_ollama_unconfigured = @ai_ollama_profiles.any? { |p| p.enabled? && p.effective_base_url.blank? }
 
     @emergency_active_override_count = User.non_service_accounts.where(emergency_active_override: true).count
 
@@ -165,6 +166,7 @@ class DashboardController < AdminController
       { tier: :important, id: :membership_applications, ok: @pending_applications_count.zero? },
       { tier: :important, id: :unlinked_recharge, ok: @unlinked_recharge_count.zero? },
       { tier: :important, id: :mail_queue, ok: @queued_mail_count.zero? },
+      { tier: :important, id: :ai_ollama_unconfigured, ok: !@ai_ollama_unconfigured },
       { tier: :important, id: :incidents, ok: @active_incident_count.zero? },
       { tier: :important, id: :email_templates, ok: @templates_needing_review_count.zero? },
       { tier: :important, id: :interests, ok: @interests_needing_review_count.zero? },

--- a/app/views/dashboard/_attention_item_body.html.erb
+++ b/app/views/dashboard/_attention_item_body.html.erb
@@ -355,31 +355,36 @@ when :ac_issues %>
       </div>
     </div>
   <% else %>
-    <div class="small">
-      <% @ai_ollama_profiles.each do |p| %>
-        <% if !p.enabled? %>
-          <div class="text-secondary mb-1">
-            <i class="bi bi-slash-circle me-1"></i>
-            <span class="fw-semibold"><%= p.name %></span> — disabled
-          </div>
-        <% elsif p.effective_base_url.blank? %>
+    <div>
+      <i class="bi bi-check-circle-fill text-success me-1"></i>
+      No unhealthy AI / Ollama endpoints
+      <div class="mt-1">
+        <%= link_to "Manage AI", ai_ollama_profiles_path, class: "link-secondary small" %>
+      </div>
+    </div>
+  <% end %>
+<% when :ai_ollama_unconfigured %>
+  <% if @ai_ollama_unconfigured %>
+    <% missing = @ai_ollama_profiles.select { |p| p.enabled? && p.effective_base_url.blank? } %>
+    <div>
+      <h6 class="mb-2">AI unconfigured</h6>
+      <div class="small text-muted">
+        <% missing.each do |p| %>
           <div class="text-warning mb-1">
             <i class="bi bi-exclamation-circle me-1"></i>
-            <span class="fw-semibold"><%= p.name %></span> — unconfigured (no Ollama endpoint)
-          </div>
-        <% elsif p.health_status == 'healthy' %>
-          <div class="text-success mb-1">
-            <i class="bi bi-check-circle-fill me-1"></i>
-            <span class="fw-semibold"><%= p.name %></span> — healthy
-          </div>
-        <% else %>
-          <div class="text-muted mb-1">
-            <i class="bi bi-hourglass-split me-1"></i>
-            <span class="fw-semibold"><%= p.name %></span> — awaiting health check
+            <span class="fw-semibold"><%= p.name %></span> — no Ollama endpoint
           </div>
         <% end %>
-      <% end %>
+      </div>
       <div class="mt-2">
+        <%= link_to "Manage AI", ai_ollama_profiles_path, class: "link-secondary small" %>
+      </div>
+    </div>
+  <% else %>
+    <div>
+      <i class="bi bi-check-circle-fill text-success me-1"></i>
+      All enabled AI profiles have an Ollama endpoint
+      <div class="mt-1">
         <%= link_to "Manage AI", ai_ollama_profiles_path, class: "link-secondary small" %>
       </div>
     </div>


### PR DESCRIPTION
Split Ollama attention: unhealthy endpoints stay Urgent; missing endpoints are a separate Important item with an "AI unconfigured" heading and per-profile lines. The all-clear card now uses a short line for healthy AI instead of a long ambiguous bullet list.

Made-with: Cursor