### PR TITLE
Show AI feedback on membership application admin pages

### DIFF
--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -119,6 +119,18 @@ class MembershipApplication < ApplicationRecord
     ai_feedback_processed_at.present?
   end
 
+  AI_FEEDBACK_REC_BADGES = {
+    'accept' => 'success', 'accepted' => 'success', 'approve' => 'success', 'approved' => 'success',
+    'reject' => 'danger', 'rejected' => 'danger', 'deny' => 'danger', 'denied' => 'danger',
+    'needs_review' => 'warning', 'need_more_info' => 'warning', 'clarify' => 'warning', 'uncertain' => 'warning'
+  }.freeze
+
+  # Bootstrap badge color for +ai_feedback_recommendation+ (free-form model output).
+  def ai_feedback_recommendation_badge_color
+    key = ai_feedback_recommendation.to_s.downcase.strip.tr(' ', '_')
+    AI_FEEDBACK_REC_BADGES.fetch(key, 'secondary')
+  end
+
   private
 
   def generate_token

--- a/app/views/membership_applications/_ai_feedback_card.html.erb
+++ b/app/views/membership_applications/_ai_feedback_card.html.erb
@@ -1,0 +1,88 @@
+<%# locals: (application:) %>
+<div class="card shadow-sm border-0 mb-4">
+  <div class="card-header bg-body-secondary d-flex flex-wrap justify-content-between align-items-center gap-2">
+    <h5 class="mb-0">
+      <i class="bi bi-robot me-1"></i> AI feedback
+    </h5>
+    <% if application.ai_feedback_processed_at.present? %>
+      <small class="text-body-secondary">
+        Processed <%= application.ai_feedback_processed_at.strftime('%b %d, %Y at %l:%M %p') %>
+      </small>
+    <% end %>
+  </div>
+  <div class="card-body">
+    <% if application.ai_feedback_processed? %>
+      <% if application.ai_feedback_garbage %>
+        <div class="alert alert-warning d-flex align-items-start gap-2 mb-3">
+          <i class="bi bi-exclamation-triangle-fill flex-shrink-0 mt-1"></i>
+          <div>
+            <strong>Flagged as low-quality or spam</strong>
+            <% if application.ai_feedback_garbage_reason.present? %>
+              <div class="small mt-1 mb-0"><%= simple_format application.ai_feedback_garbage_reason, class: 'mb-0' %></div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <div class="row g-3">
+        <div class="col-md-4">
+          <dt class="text-muted small text-uppercase fw-semibold">Score</dt>
+          <dd class="mb-0 fs-5">
+            <% if application.ai_feedback_score.nil? %>
+              <span class="text-muted">—</span>
+            <% else %>
+              <span class="badge bg-dark fs-6"><%= application.ai_feedback_score %></span>
+            <% end %>
+          </dd>
+        </div>
+        <div class="col-md-8">
+          <dt class="text-muted small text-uppercase fw-semibold">Recommendation</dt>
+          <dd class="mb-0">
+            <% if application.ai_feedback_recommendation.present? %>
+              <span class="badge bg-<%= application.ai_feedback_recommendation_badge_color %>">
+                <%= application.ai_feedback_recommendation.to_s.humanize %>
+              </span>
+            <% else %>
+              <span class="text-muted">—</span>
+            <% end %>
+          </dd>
+        </div>
+      </div>
+
+      <% if application.ai_feedback_score_rationale.present? %>
+        <div class="mt-3">
+          <dt class="text-muted small text-uppercase fw-semibold">Score rationale</dt>
+          <dd class="mb-0"><%= application.ai_feedback_score_rationale %></dd>
+        </div>
+      <% end %>
+
+      <% questions = application.ai_feedback_questions %>
+      <% if questions.is_a?(Array) && questions.any? %>
+        <div class="mt-3">
+          <dt class="text-muted small text-uppercase fw-semibold">Suggested follow-up questions</dt>
+          <dd class="mb-0">
+            <ul class="mb-0 ps-3">
+              <% questions.each do |q| %>
+                <li><%= q %></li>
+              <% end %>
+            </ul>
+          </dd>
+        </div>
+      <% end %>
+    <% elsif application.ai_feedback_last_error.present? %>
+      <div class="alert alert-danger mb-0">
+        <strong>AI feedback failed</strong>
+        <div class="small mt-2 font-monospace text-break"><%= application.ai_feedback_last_error %></div>
+        <p class="small mb-0 mt-2 text-body-secondary">
+          Fix the Application Status (or Default) Ollama profile and re-run
+          <code class="small">rails membership_applications:process_ai_feedback</code> if needed.
+        </p>
+      </div>
+    <% else %>
+      <p class="text-body-secondary mb-0">
+        <i class="bi bi-hourglass-split me-1"></i>
+        AI feedback is not available yet. It runs in the background after submit; refresh this page in a moment.
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -77,6 +77,7 @@
             <th>#</th>
             <th>Email</th>
             <th>Status</th>
+            <th>AI</th>
             <th>Submitted</th>
             <th>Reviewed by</th>
             <th>Linked member</th>
@@ -90,6 +91,18 @@
               <td><%= app.email %></td>
               <td>
                 <span class="badge bg-<%= app.status_badge_color %>"><%= app.status_display %></span>
+              </td>
+              <td class="text-nowrap">
+                <% if app.ai_feedback_processed? %>
+                  <span class="badge bg-dark"><%= app.ai_feedback_score.nil? ? '—' : app.ai_feedback_score %></span>
+                  <% if app.ai_feedback_recommendation.present? %>
+                    <span class="badge bg-<%= app.ai_feedback_recommendation_badge_color %>"><%= app.ai_feedback_recommendation.to_s.truncate(14) %></span>
+                  <% end %>
+                <% elsif app.ai_feedback_last_error.present? %>
+                  <span class="badge bg-danger" title="<%= h app.ai_feedback_last_error %>">AI error</span>
+                <% else %>
+                  <span class="text-muted small">Pending</span>
+                <% end %>
               </td>
               <td><%= app.submitted_at&.strftime('%b %d, %Y') || '—' %></td>
               <td><%= app.reviewed_by&.display_name || '—' %></td>

--- a/app/views/membership_applications/show.html.erb
+++ b/app/views/membership_applications/show.html.erb
@@ -73,6 +73,10 @@
   </div>
 </div>
 
+<% unless @application.draft? %>
+  <%= render 'ai_feedback_card', application: @application %>
+<% end %>
+
 <% if @application.user.nil? && @users_for_application_link.any? %>
   <%= render 'link_member_modal',
              users: @users_for_application_link,

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -52,6 +52,19 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal member.id, app.reload.user_id
   end
 
+  test 'show includes AI feedback section for non-draft applications' do
+    app = MembershipApplication.create!(
+      email: 'show-ai-section@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+
+    get membership_application_path(app)
+
+    assert_response :success
+    assert_match(/AI feedback/i, response.body)
+  end
+
   test 'unlink_user clears member on application' do
     app = MembershipApplication.create!(
       email: 'unlink-app-test@example.com',

--- a/test/models/membership_application_test.rb
+++ b/test/models/membership_application_test.rb
@@ -12,4 +12,16 @@ class MembershipApplicationTest < ActiveSupport::TestCase
       app.submit!
     end
   end
+
+  test 'ai_feedback_recommendation_badge_color maps known recommendations' do
+    app = MembershipApplication.new
+    app.ai_feedback_recommendation = 'accept'
+    assert_equal 'success', app.ai_feedback_recommendation_badge_color
+    app.ai_feedback_recommendation = 'reject'
+    assert_equal 'danger', app.ai_feedback_recommendation_badge_color
+    app.ai_feedback_recommendation = 'needs_review'
+    assert_equal 'warning', app.ai_feedback_recommendation_badge_color
+    app.ai_feedback_recommendation = 'something_else'
+    assert_equal 'secondary', app.ai_feedback_recommendation_badge_color
+  end
 end


### PR DESCRIPTION
Add an AI feedback card on the application detail view (processed, pending, and error states) and an AI column on the index. Map recommendation strings to badge colors; add model and controller tests.

Made-with: Cursor