### PR TITLE
Reorganize admin navbar: Members, Space, Admin dropdowns

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,8 +27,9 @@
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <% if user_signed_in? %>
             <% if current_user_admin? %>
+                <% admin_settings_nav_active = current_page?(settings_path) || current_page?(training_topics_path) || current_page?(applications_path) || controller_name == 'applications' || controller_name == 'application_groups' || controller_name == 'text_fragments' || controller_name == 'documents' || controller_name == 'incoming_webhooks' || controller_name == 'rooms' || controller_name == 'printers' || controller_name == 'application_form_pages' || controller_name == 'application_form_questions' || controller_name == 'ai_ollama_profiles' %>
                 <li class="nav-item dropdown">
-                  <a class="nav-link dropdown-toggle <%= (current_page?(users_path) || current_page?(sheet_entries_path) || current_page?(slack_users_path) || current_page?(authentik_users_path)) ? 'active' : '' %>"
+                  <a class="nav-link dropdown-toggle <%= (current_page?(users_path) || current_page?(sheet_entries_path) || current_page?(slack_users_path) || current_page?(authentik_users_path) || controller_name == 'membership_applications') ? 'active' : '' %>"
                      href="#"
                      role="button"
                      data-bs-toggle="dropdown"
@@ -47,6 +48,10 @@
                     </li>
                     <li>
                       <%= link_to "Slack", slack_users_path, class: "dropdown-item #{current_page?(slack_users_path) ? 'active' : ''}" %>
+                    </li>
+                    <li><hr class="dropdown-divider"></li>
+                    <li>
+                      <%= link_to "Applications", membership_applications_path, class: "dropdown-item #{controller_name == 'membership_applications' ? 'active' : ''}" %>
                     </li>
                   </ul>
                 </li>
@@ -80,23 +85,45 @@
                 <li class="nav-item">
                   <%= link_to "Journal", journals_path, class: "nav-link #{current_page?(journals_path) ? 'active' : ''}" %>
                 </li>
-                <li class="nav-item">
-                  <%= link_to "Access", access_logs_path, class: "nav-link #{current_page?(access_logs_path) ? 'active' : ''}" %>
+                <li class="nav-item dropdown">
+                  <a class="nav-link dropdown-toggle <%= (current_page?(access_logs_path) || controller_name == 'incident_reports' || controller_name == 'parking_notices') ? 'active' : '' %>"
+                     href="#"
+                     role="button"
+                     data-bs-toggle="dropdown"
+                     aria-expanded="false">
+                    Space
+                  </a>
+                  <ul class="dropdown-menu">
+                    <li>
+                      <%= link_to "Access", access_logs_path, class: "dropdown-item #{current_page?(access_logs_path) ? 'active' : ''}" %>
+                    </li>
+                    <li>
+                      <%= link_to "Incidents", incident_reports_path, class: "dropdown-item #{controller_name == 'incident_reports' ? 'active' : ''}" %>
+                    </li>
+                    <li>
+                      <%= link_to "Parking", parking_notices_path, class: "dropdown-item #{controller_name == 'parking_notices' ? 'active' : ''}" %>
+                    </li>
+                  </ul>
                 </li>
-                <li class="nav-item">
-                  <%= link_to "Reports", reports_path, class: "nav-link #{current_page?(reports_path) ? 'active' : ''}" %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to "Incidents", incident_reports_path, class: "nav-link #{controller_name == 'incident_reports' ? 'active' : ''}" %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to "Parking", parking_notices_path, class: "nav-link #{controller_name == 'parking_notices' ? 'active' : ''}" %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to "Settings", settings_path, class: "nav-link #{current_page?(settings_path) || current_page?(training_topics_path) || current_page?(applications_path) || controller_name == 'applications' || controller_name == 'application_groups' || controller_name == 'text_fragments' || controller_name == 'documents' || controller_name == 'incoming_webhooks' || controller_name == 'rooms' || controller_name == 'printers' || controller_name == 'application_form_pages' || controller_name == 'application_form_questions' || controller_name == 'ai_ollama_profiles' ? 'active' : ''}" %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to "Sidekiq", '/goh7zeeNiezoozaingothu4', class: "nav-link", target: "_blank" %>
+                <li class="nav-item dropdown">
+                  <a class="nav-link dropdown-toggle <%= (controller_name == 'reports' || admin_settings_nav_active) ? 'active' : '' %>"
+                     href="#"
+                     role="button"
+                     data-bs-toggle="dropdown"
+                     aria-expanded="false">
+                    Admin
+                  </a>
+                  <ul class="dropdown-menu">
+                    <li>
+                      <%= link_to "Reports", reports_path, class: "dropdown-item #{controller_name == 'reports' ? 'active' : ''}" %>
+                    </li>
+                    <li>
+                      <%= link_to "Settings", settings_path, class: "dropdown-item #{admin_settings_nav_active ? 'active' : ''}" %>
+                    </li>
+                    <li>
+                      <%= link_to "Sidekiq", '/goh7zeeNiezoozaingothu4', class: "dropdown-item", target: "_blank" %>
+                    </li>
+                  </ul>
                 </li>
               <% else %>
                 <%# non-admins see no extra admin links %>


### PR DESCRIPTION
- Add Applications (membership applications index) to Members menu after divider
- Group Access, Incidents, Parking under Space dropdown
- Group Reports, Settings, Sidekiq under Admin dropdown
- Reuse settings-section active state for Admin toggle and Settings item

Made-with: Cursor