### PR TITLE
Admin mail application link, mail nav under Admin

### DIFF
--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -229,13 +229,17 @@ class MemberMailer < ApplicationMailer
     end
   end
 
-  # Notify admins of a new application
-  def admin_new_application(user, admin_email)
-    @user = user
+  # Notify admins of a new application (+opts+ may include +:application_url+ for that application’s admin page).
+  def admin_new_application(applicant, admin_email, opts = {})
+    opts = opts.symbolize_keys
+    @user = applicant
     @organization = organization_name
     @admin_email = admin_email
+    explicit_url = opts[:application_url].presence
+    @application_url = explicit_url || membership_applications_fallback_url
+    extra_vars = { application_url: @application_url }
 
-    if send_from_template('admin_new_application', user, {}, to: admin_email)
+    if send_from_template('admin_new_application', applicant, extra_vars, to: admin_email)
       # Email sent from database template
     else
       mail(
@@ -351,6 +355,13 @@ class MemberMailer < ApplicationMailer
       date: Date.current.strftime('%B %d, %Y'),
       app_url: ENV.fetch('APP_BASE_URL', 'http://localhost:3000')
     }
+  end
+
+  def membership_applications_fallback_url
+    membership_applications_url
+  rescue ArgumentError, ActionController::UrlGenerationError
+    base = ENV.fetch('APP_BASE_URL', 'http://localhost:3000').chomp('/')
+    "#{base}/membership_applications"
   end
 
   def send_parking_notice_mail(template_key, user, opts = {})

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -261,7 +261,7 @@ class EmailTemplate < ApplicationRecord
     },
     'admin_new_application' => {
       name: 'Admin: New Application',
-      description: 'Sent to admins when a new application is submitted ({{application_url}} — specific app or list fallback)',
+      description: 'Admin notice for new applications; includes {{application_url}} (detail page or list fallback).',
       subject: '{{organization_name}}: New Member Application - {{member_name}}',
       body_html: <<~HTML,
         <h1>New Member Application</h1>

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -14,7 +14,7 @@ class EmailTemplate < ApplicationRecord
     '{{invitation_expiry}}' => 'When the invitation expires (invitation emails only)',
     '{{invitation_type}}' => 'Type of membership being offered, e.g. Sponsored Member (invitation emails only)',
     '{{invitation_type_details}}' => 'Description of what the membership type includes (invitation emails only)',
-    '{{application_url}}' => 'Direct link to the membership application in admin (staff new application alert only)'
+    '{{application_url}}' => 'Direct link to the membership application (admin new application & staff alert templates)'
   }.freeze
 
   # Default templates that can be seeded
@@ -261,7 +261,7 @@ class EmailTemplate < ApplicationRecord
     },
     'admin_new_application' => {
       name: 'Admin: New Application',
-      description: 'Sent to admins when a new application is submitted',
+      description: 'Sent to admins when a new application is submitted ({{application_url}} — specific app or list fallback)',
       subject: '{{organization_name}}: New Member Application - {{member_name}}',
       body_html: <<~HTML,
         <h1>New Member Application</h1>
@@ -281,7 +281,8 @@ class EmailTemplate < ApplicationRecord
             <td style="padding: 8px; border-bottom: 1px solid #ddd;">{{member_username}}</td>
           </tr>
         </table>
-        <p style="margin-top: 20px;">Please review this application and take appropriate action.</p>
+        <p style="margin-top: 20px;"><a href="{{application_url}}">Open this application in Member Manager</a></p>
+        <p>Please review this application and take appropriate action.</p>
       HTML
       body_text: <<~TEXT
         New Member Application
@@ -293,6 +294,8 @@ class EmailTemplate < ApplicationRecord
         Name: {{member_name}}
         Email: {{member_email}}
         Username: {{member_username}}
+
+        Open in Member Manager: {{application_url}}
 
         Please review this application and take appropriate action.
       TEXT

--- a/app/models/queued_mail.rb
+++ b/app/models/queued_mail.rb
@@ -41,6 +41,7 @@ class QueuedMail < ApplicationRecord
 
     template = EmailTemplate.find_enabled(action.to_s)
     variables = MemberMailer.build_template_variables(user, extra_args)
+    ensure_admin_new_application_application_url!(variables, action, extra_args) if template
 
     record = if template
                rendered = template.render(variables)
@@ -126,6 +127,14 @@ class QueuedMail < ApplicationRecord
     record
   end
 
+  def self.ensure_admin_new_application_application_url!(variables, action, extra_args)
+    return unless action.to_s == 'admin_new_application'
+
+    raw = extra_args[:application_url].presence || extra_args['application_url'].presence
+    variables[:application_url] = raw.presence ||
+                                  "#{ENV.fetch('APP_BASE_URL', 'http://localhost:3000').chomp('/')}/membership_applications"
+  end
+
   def self.applicant_recipient_for(application)
     name = application.applicant_display_name
     name = 'Applicant' if name.blank? || name == '—'
@@ -155,6 +164,7 @@ class QueuedMail < ApplicationRecord
     if email_template && recipient
       args = (mailer_args || {}).symbolize_keys
       variables = MemberMailer.build_template_variables(recipient, args)
+      self.class.ensure_admin_new_application_application_url!(variables, mailer_action, args)
       rendered = email_template.render(variables)
       update!(
         subject: rendered[:subject],
@@ -202,7 +212,7 @@ class QueuedMail < ApplicationRecord
   def self.build_mailer_args(action, user, to_addr, extra_args)
     case action.to_s
     when 'admin_new_application'
-      [user, to_addr || extra_args[:admin_email]]
+      [user, to_addr || extra_args[:admin_email], extra_args.slice(:application_url)]
     when 'payment_past_due'
       [user, { days_overdue: extra_args[:days_overdue] }.compact]
     when 'membership_cancelled', 'membership_banned', 'application_rejected'

--- a/app/models/queued_mail.rb
+++ b/app/models/queued_mail.rb
@@ -40,8 +40,7 @@ class QueuedMail < ApplicationRecord
     return nil if dest.blank?
 
     template = EmailTemplate.find_enabled(action.to_s)
-    variables = MemberMailer.build_template_variables(user, extra_args)
-    ensure_admin_new_application_application_url!(variables, action, extra_args) if template
+    variables = enqueue_render_variables(action, user, extra_args, template)
 
     record = if template
                rendered = template.render(variables)
@@ -162,24 +161,9 @@ class QueuedMail < ApplicationRecord
 
   def regenerate!(actor: nil)
     if email_template && recipient
-      args = (mailer_args || {}).symbolize_keys
-      variables = MemberMailer.build_template_variables(recipient, args)
-      self.class.ensure_admin_new_application_application_url!(variables, mailer_action, args)
-      rendered = email_template.render(variables)
-      update!(
-        subject: rendered[:subject],
-        body_html: rendered[:body_html],
-        body_text: rendered[:body_text] || ''
-      )
+      regenerate_from_email_template!
     elsif recipient
-      message = MemberMailer.public_send(
-        mailer_action,
-        *self.class.build_mailer_args(mailer_action, recipient, to, (mailer_args || {}).symbolize_keys)
-      )
-      msg = message.message
-      html_body = msg.multipart? ? msg.html_part&.body&.decoded : msg.body.decoded
-      text_body = msg.multipart? ? msg.text_part&.body&.decoded : ''
-      update!(subject: msg.subject, body_html: html_body || '', body_text: text_body || '')
+      regenerate_from_mailer!
     end
     MailLogEntry.log!(self, 'regenerated', actor: actor, details: 'Regenerated from template')
   end
@@ -207,6 +191,37 @@ class QueuedMail < ApplicationRecord
     error_message = "#{error.class}: #{error.message}"
     update!(last_error: error_message, last_error_at: Time.current)
     MailLogEntry.log_once!(self, 'send_failed', details: error_message)
+  end
+
+  def regenerate_from_email_template!
+    args = (mailer_args || {}).symbolize_keys
+    variables = MemberMailer.build_template_variables(recipient, args)
+    self.class.ensure_admin_new_application_application_url!(variables, mailer_action, args)
+    rendered = email_template.render(variables)
+    update!(
+      subject: rendered[:subject],
+      body_html: rendered[:body_html],
+      body_text: rendered[:body_text] || ''
+    )
+  end
+
+  def regenerate_from_mailer!
+    message = MemberMailer.public_send(
+      mailer_action,
+      *self.class.build_mailer_args(mailer_action, recipient, to, (mailer_args || {}).symbolize_keys)
+    )
+    msg = message.message
+    html_body = msg.multipart? ? msg.html_part&.body&.decoded : msg.body.decoded
+    text_body = msg.multipart? ? msg.text_part&.body&.decoded : ''
+    update!(subject: msg.subject, body_html: html_body || '', body_text: text_body || '')
+  end
+
+  private :regenerate_from_email_template!, :regenerate_from_mailer!
+
+  def self.enqueue_render_variables(action, user, extra_args, template)
+    variables = MemberMailer.build_template_variables(user, extra_args)
+    ensure_admin_new_application_application_url!(variables, action, extra_args) if template
+    variables
   end
 
   def self.build_mailer_args(action, user, to_addr, extra_args)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
             <% if user_signed_in? %>
             <% if current_user_admin? %>
                 <% admin_settings_nav_active = current_page?(settings_path) || current_page?(training_topics_path) || current_page?(applications_path) || controller_name == 'applications' || controller_name == 'application_groups' || controller_name == 'text_fragments' || controller_name == 'documents' || controller_name == 'incoming_webhooks' || controller_name == 'rooms' || controller_name == 'printers' || controller_name == 'application_form_pages' || controller_name == 'application_form_questions' || controller_name == 'ai_ollama_profiles' %>
+                <% admin_dropdown_active = controller_name == 'reports' || admin_settings_nav_active || controller_name == 'queued_mails' || controller_name == 'mail_log' %>
                 <li class="nav-item dropdown">
                   <a class="nav-link dropdown-toggle <%= (current_page?(users_path) || current_page?(sheet_entries_path) || current_page?(slack_users_path) || current_page?(authentik_users_path) || controller_name == 'membership_applications' || controller_name == 'incident_reports') ? 'active' : '' %>"
                      href="#"
@@ -106,7 +107,7 @@
                   </ul>
                 </li>
                 <li class="nav-item dropdown">
-                  <a class="nav-link dropdown-toggle <%= (controller_name == 'reports' || admin_settings_nav_active) ? 'active' : '' %>"
+                  <a class="nav-link dropdown-toggle <%= admin_dropdown_active ? 'active' : '' %>"
                      href="#"
                      role="button"
                      data-bs-toggle="dropdown"
@@ -116,6 +117,12 @@
                   <ul class="dropdown-menu">
                     <li>
                       <%= link_to "Reports", reports_path, class: "dropdown-item #{controller_name == 'reports' ? 'active' : ''}" %>
+                    </li>
+                    <li>
+                      <%= link_to "Mail queue", queued_mails_path, class: "dropdown-item #{controller_name == 'queued_mails' ? 'active' : ''}" %>
+                    </li>
+                    <li>
+                      <%= link_to "Mail log", mail_log_path, class: "dropdown-item #{controller_name == 'mail_log' ? 'active' : ''}" %>
                     </li>
                     <li>
                       <%= link_to "Settings", settings_path, class: "dropdown-item #{admin_settings_nav_active ? 'active' : ''}" %>

--- a/app/views/member_mailer/admin_new_application.html.erb
+++ b/app/views/member_mailer/admin_new_application.html.erb
@@ -19,6 +19,10 @@
   </tr>
 </table>
 
+<% if @application_url.present? %>
+<p style="margin-top: 20px;"><a href="<%= @application_url %>">Open this application in Member Manager</a></p>
+<% end %>
+
 <p style="margin-top: 20px;">
   Please review this application and take appropriate action.
 </p>

--- a/app/views/member_mailer/admin_new_application.text.erb
+++ b/app/views/member_mailer/admin_new_application.text.erb
@@ -8,4 +8,8 @@ Name: <%= @user.display_name %>
 Email: <%= @user.email || 'Not provided' %>
 Username: <%= @user.username || 'Not set' %>
 
+<% if @application_url.present? %>
+Open in Member Manager: <%= @application_url %>
+
+<% end %>
 Please review this application and take appropriate action.

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -114,15 +114,6 @@
   <div class="col-md-6 col-lg-4">
     <div class="card shadow-sm border-0 h-100">
       <div class="card-body d-flex flex-column">
-        <h5 class="card-title">Mail Log</h5>
-        <p class="card-text text-muted">View the history of all generated email: queued, edited, approved, and rejected.</p>
-        <%= link_to "View Mail Log", mail_log_path, class: "btn btn-primary mt-auto" %>
-      </div>
-    </div>
-  </div>
-  <div class="col-md-6 col-lg-4">
-    <div class="card shadow-sm border-0 h-100">
-      <div class="card-body d-flex flex-column">
         <h5 class="card-title">Member Sources</h5>
         <p class="card-text text-muted">Track Authentik, Sheet, and Slack integrations and identify records needing reconciliation.</p>
         <%= link_to "Manage Member Sources", member_sources_path, class: "btn btn-primary mt-auto" %>

--- a/db/migrate/20260406140000_amend_admin_new_application_email_add_application_link.rb
+++ b/db/migrate/20260406140000_amend_admin_new_application_email_add_application_link.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AmendAdminNewApplicationEmailAddApplicationLink < ActiveRecord::Migration[8.1]
+  def up
+    tpl = EmailTemplate.find_by(key: 'admin_new_application')
+    return unless tpl
+
+    attrs = EmailTemplate::DEFAULT_TEMPLATES['admin_new_application']
+    tpl.update!(body_html: attrs[:body_html], body_text: attrs[:body_text])
+  end
+
+  def down
+    # Non-reversible; prior bodies were site-specific.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_06_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_06_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -80,31 +80,6 @@ services:
     depends_on:
       - db
 
-<<<<<<< HEAD:docker-compose.yml
-  # Run the full test suite.
-  # Creates and loads the test database schema before running tests.
-  # Usage: docker compose run --rm test
-  #        docker compose run --rm test bin/rails test test/models/interest_test.rb
-  test:
-    <<: *web-common
-    command: sh -c "bin/rails db:create db:schema:load && bin/rails test"
-    profiles: ["test"]
-    environment:
-      RAILS_ENV: test
-      DB_HOST: db
-      DB_USERNAME: postgres
-      DB_PASSWORD: postgres
-      DB_PORT: 5432
-      DATABASE_URL: postgres://postgres:postgres@db:5432/member_manager_test
-      REDIS_URL: redis://redis:6379/0
-      SKIP_CSS_BUILD: "1"
-      AUTHENTIK_API_TOKEN: test-placeholder-token
-    depends_on:
-      - db
-      - redis
-
-=======
->>>>>>> fafe18db9c2d6346d22c6083b1ddc25d5cb9b1bb:docker-compose.dev.yml
 volumes:
   dev_postgres_data:
   dev_redis_data:

--- a/docker-compose.lint.yml
+++ b/docker-compose.lint.yml
@@ -5,6 +5,8 @@
 # Postgres is published on host port 5434 so it can run alongside dev/test stacks.
 # Usage: docker compose -f docker-compose.lint.yml run --rm rubocop
 #        docker compose -f docker-compose.lint.yml run --rm rubocop app/models
+# If you see GemNotFound against Gemfile.lock, refresh gems then RuboCop (same file):
+#   docker compose -f docker-compose.lint.yml run --rm --entrypoint sh rubocop -c "bundle install && bundle exec rubocop"
 name: membermanager-lint
 
 services:

--- a/test/mailers/member_mailer_test.rb
+++ b/test/mailers/member_mailer_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MemberMailerTest < ActionMailer::TestCase
+  test 'admin_new_application includes application URL in body when provided' do
+    EmailTemplate.where(key: 'admin_new_application').update_all(enabled: false)
+
+    applicant = users(:one)
+    url = 'https://www.example.com/membership_applications/4242'
+
+    email = MemberMailer.admin_new_application(applicant, 'ops@example.com', application_url: url).deliver_now
+
+    assert_includes email.html_part.body.to_s, url
+    text = email.text_part ? email.text_part.body.to_s : email.body.to_s
+    assert_includes text, url
+  end
+end

--- a/test/mailers/previews/member_mailer_preview.rb
+++ b/test/mailers/previews/member_mailer_preview.rb
@@ -59,7 +59,10 @@ class MemberMailerPreview < ActionMailer::Preview
   # Preview at http://localhost:3000/rails/mailers/member_mailer/admin_new_application
   def admin_new_application
     user = User.first || sample_user
-    MemberMailer.admin_new_application(user, 'admin@example.com')
+    app = MembershipApplication.order(id: :desc).first
+    base = ENV.fetch('APP_BASE_URL', 'http://localhost:3000').chomp('/')
+    url = app ? "#{base}/membership_applications/#{app.id}" : "#{base}/membership_applications/1"
+    MemberMailer.admin_new_application(user, 'admin@example.com', application_url: url)
   end
 
   # Preview at http://localhost:3000/rails/mailers/member_mailer/staff_new_application


### PR DESCRIPTION
- Pass {{application_url}} into admin new application template and mailer; QueuedMail ensures a URL when queuing or regenerating; migration updates existing template bodies.
- Move Mail queue and Mail log links from Settings to the Admin navbar dropdown; drop the Mail Log card from the settings index.
- Add MemberMailer test and update mailer preview for admin new application.

Made-with: Cursor