### PR TITLE
Log all outgoing mail and add built-in vs external apply flow

### DIFF
--- a/app/controllers/application_form_pages_controller.rb
+++ b/app/controllers/application_form_pages_controller.rb
@@ -3,6 +3,7 @@ class ApplicationFormPagesController < AdminController
 
   def index
     @pages = ApplicationFormPage.ordered.includes(:questions)
+    @membership_setting = MembershipSetting.instance
   end
 
   def new
@@ -31,6 +32,21 @@ class ApplicationFormPagesController < AdminController
   def destroy
     @page.destroy!
     redirect_to application_form_pages_path, notice: 'Page removed.'
+  end
+
+  def update_application_flow
+    setting = MembershipSetting.instance
+    raw = params[:use_builtin_membership_application]
+    if raw.nil?
+      redirect_to application_form_pages_path, alert: 'Choose how applicants should apply.'
+      return
+    end
+
+    if setting.update(use_builtin_membership_application: ActiveModel::Type::Boolean.new.cast(raw))
+      redirect_to application_form_pages_path, notice: 'Application flow updated.'
+    else
+      redirect_to application_form_pages_path, alert: setting.errors.full_messages.to_sentence
+    end
   end
 
   private

--- a/app/controllers/application_verifications_controller.rb
+++ b/app/controllers/application_verifications_controller.rb
@@ -1,5 +1,13 @@
 class ApplicationVerificationsController < ApplicationController
+  before_action :redirect_builtin_only_requests_when_external, only: %i[send_verification verify_email check_email]
+
   def gate
+    unless MembershipSetting.use_builtin_membership_application?
+      @apply_content = TextFragment.content_for('apply_for_membership')
+      render :gate_external
+      return
+    end
+
     @code_of_conduct_doc = Document.find_by('LOWER(title) = ?', 'code of conduct')
   end
 
@@ -50,6 +58,13 @@ class ApplicationVerificationsController < ApplicationController
   def check_email; end
 
   private
+
+  def redirect_builtin_only_requests_when_external
+    return if MembershipSetting.use_builtin_membership_application?
+
+    redirect_to apply_path,
+                alert: 'Applications use the instructions on the apply page. Follow the link from sign-in to apply.'
+  end
 
   def open_house_confirmation_ok?
     return true if params[:confirmed_open_house] == '1'

--- a/app/controllers/concerns/membership_application_wizard/actions.rb
+++ b/app/controllers/concerns/membership_application_wizard/actions.rb
@@ -6,6 +6,8 @@ module MembershipApplicationWizard
     extend ActiveSupport::Concern
 
     included do
+      before_action :require_builtin_membership_application!,
+                    only: %i[start save_page page submit_application confirmation]
       before_action :require_verified_email!, only: %i[start save_page page submit_application]
       before_action :load_pages, only: %i[start page]
     end

--- a/app/controllers/concerns/membership_application_wizard/verification.rb
+++ b/app/controllers/concerns/membership_application_wizard/verification.rb
@@ -19,5 +19,12 @@ module MembershipApplicationWizard
 
       ApplicationVerification.find_by(token: token)
     end
+
+    def require_builtin_membership_application!
+      return if MembershipSetting.use_builtin_membership_application?
+
+      redirect_to apply_path,
+                  alert: 'Applications use the instructions on the apply page. Follow the link from sign-in to apply.'
+    end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,7 +2,14 @@ class ApplicationMailer < ActionMailer::Base
   default from: -> { ENV.fetch('EMAIL_FROM_ADDRESS', 'noreply@example.com') }
   layout 'mailer'
 
+  after_action :set_member_manager_mail_trace_headers
+
   private
+
+  def set_member_manager_mail_trace_headers
+    headers['X-MemberManager-Mailer'] = self.class.name
+    headers['X-MemberManager-Action'] = action_name.to_s
+  end
 
   # Helper to get the organization name for emails
   def organization_name

--- a/app/mailers/queued_mail_mailer.rb
+++ b/app/mailers/queued_mail_mailer.rb
@@ -1,4 +1,7 @@
 class QueuedMailMailer < ApplicationMailer
+  skip_after_action :set_member_manager_mail_trace_headers
+  after_action :mark_skip_duplicate_mail_log
+
   def deliver_queued(queued_mail)
     @body_html = queued_mail.body_html
     @body_text = queued_mail.body_text
@@ -7,5 +10,11 @@ class QueuedMailMailer < ApplicationMailer
       format.html { render html: @body_html.html_safe, layout: 'mailer' }
       format.text { render plain: @body_text } if @body_text.present?
     end
+  end
+
+  private
+
+  def mark_skip_duplicate_mail_log
+    headers['X-MemberManager-Skip-MailLog'] = '1'
   end
 end

--- a/app/models/mail_delivery_log_interceptor.rb
+++ b/app/models/mail_delivery_log_interceptor.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Logs every outgoing Action Mailer message to +MailLogEntry+ (except +QueuedMailMailer+,
+# which is already logged via +QueuedMail#deliver_now!+).
+class MailDeliveryLogInterceptor
+  def self.delivering_email(mail)
+    return if mail['X-MemberManager-Skip-MailLog']&.decoded.to_s == '1'
+
+    to = Array(mail.to).compact.join(', ')
+    return if to.blank? || mail.subject.blank?
+
+    MailLogEntry.log_direct_delivery!(
+      to: to,
+      subject: mail.subject.to_s.truncate(500),
+      mailer_class: mail['X-MemberManager-Mailer']&.decoded,
+      mailer_action: mail['X-MemberManager-Action']&.decoded,
+      details: nil
+    )
+  end
+end

--- a/app/models/mail_log_entry.rb
+++ b/app/models/mail_log_entry.rb
@@ -1,10 +1,11 @@
 class MailLogEntry < ApplicationRecord
   EVENTS = %w[created edited regenerated approved rejected sent send_failed].freeze
 
-  belongs_to :queued_mail
+  belongs_to :queued_mail, optional: true
   belongs_to :actor, class_name: 'User', optional: true
 
   validates :event, presence: true, inclusion: { in: EVENTS }
+  validate :queued_mail_or_direct_delivery_fields
 
   scope :newest_first, -> { order(created_at: :desc) }
   scope :oldest_first, -> { order(created_at: :asc) }
@@ -17,6 +18,23 @@ class MailLogEntry < ApplicationRecord
       details: details
     )
   end
+
+  # Logs an immediate Action Mailer delivery (not via +QueuedMail+).
+  # rubocop:disable Metrics/ParameterLists -- mirrors mail metadata fields
+  def self.log_direct_delivery!(to:, subject:, mailer_class:, mailer_action:, details: nil, actor: nil)
+    detail = details.presence || [mailer_class, mailer_action].compact.join('#')
+    create!(
+      queued_mail: nil,
+      event: 'sent',
+      actor: actor,
+      details: detail,
+      delivery_to: to,
+      delivery_subject: subject,
+      delivery_mailer: mailer_class,
+      delivery_action: mailer_action
+    )
+  end
+  # rubocop:enable Metrics/ParameterLists
 
   def self.log_once!(queued_mail, event, actor: nil, details: nil)
     last_entry = queued_mail.mail_log_entries
@@ -31,6 +49,7 @@ class MailLogEntry < ApplicationRecord
 
   def wait_duration
     return nil unless event.in?(%w[approved rejected sent])
+    return nil unless queued_mail
 
     queued_mail.created_at ? (created_at - queued_mail.created_at) : nil
   end
@@ -50,5 +69,14 @@ class MailLogEntry < ApplicationRecord
       days = (seconds / 86_400).round
       "#{days} #{'day'.pluralize(days)}"
     end
+  end
+
+  private
+
+  def queued_mail_or_direct_delivery_fields
+    return if queued_mail.present?
+    return if delivery_to.present? && delivery_subject.present?
+
+    errors.add(:base, 'Either queued mail or direct delivery fields (to and subject) must be present')
   end
 end

--- a/app/models/membership_setting.rb
+++ b/app/models/membership_setting.rb
@@ -48,4 +48,8 @@ class MembershipSetting < ApplicationRecord
   def self.manual_payment_due_soon_days
     instance.manual_payment_due_soon_days
   end
+
+  def self.use_builtin_membership_application?
+    instance.use_builtin_membership_application?
+  end
 end

--- a/app/views/application_form_pages/index.html.erb
+++ b/app/views/application_form_pages/index.html.erb
@@ -3,6 +3,41 @@
   <%= link_to "Add Page", new_application_form_page_path, class: "btn btn-primary" %>
 </div>
 
+<div class="card shadow-sm border-0 mb-4">
+  <div class="card-header">
+    <strong>How applicants apply</strong>
+  </div>
+  <div class="card-body">
+    <%= form_with url: update_application_flow_application_form_pages_path, method: :patch, local: true do %>
+      <div class="form-check mb-2">
+        <%= radio_button_tag :use_builtin_membership_application, '1',
+            @membership_setting.use_builtin_membership_application?,
+            class: 'form-check-input', id: 'flow_builtin' %>
+        <label class="form-check-label" for="flow_builtin">
+          Built-in flow at <code>/apply/new</code> (email verification and the wizard below).
+        </label>
+      </div>
+      <div class="form-check mb-3">
+        <%= radio_button_tag :use_builtin_membership_application, '0',
+            !@membership_setting.use_builtin_membership_application?,
+            class: 'form-check-input', id: 'flow_external' %>
+        <label class="form-check-label" for="flow_external">
+          External: show the Apply for membership text (for example a Google Form link) instead of the built-in wizard.
+        </label>
+      </div>
+      <% frag = TextFragment.find_by(key: 'apply_for_membership') %>
+      <% if frag %>
+        <p class="text-muted small mb-3">
+          <%= link_to 'Edit apply text', edit_text_fragment_path(frag), class: 'text-decoration-none' %>:
+          same copy as the public <%= link_to 'apply page', apply_path, class: 'text-decoration-none' %>.
+          With the external option, <code>/apply/new</code> shows only that content (no wizard).
+        </p>
+      <% end %>
+      <%= submit_tag 'Save application flow', class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>
+
 <% if @pages.any? %>
   <% @pages.each do |page| %>
     <div class="card shadow-sm border-0 mb-3">

--- a/app/views/application_verifications/gate_external.html.erb
+++ b/app/views/application_verifications/gate_external.html.erb
@@ -1,0 +1,13 @@
+<div class="row justify-content-center py-5">
+  <div class="col-12 col-md-10 col-lg-8">
+    <div class="card shadow-sm border-0">
+      <div class="card-body p-4 p-md-5">
+        <%= sanitize(@apply_content) %>
+      </div>
+    </div>
+
+    <div class="text-center mt-4">
+      <%= link_to "&larr; Back to Sign In".html_safe, login_path, class: "text-decoration-none" %>
+    </div>
+  </div>
+</div>

--- a/app/views/mail_log/index.html.erb
+++ b/app/views/mail_log/index.html.erb
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
   <div>
     <h1 class="h3 mb-1">Mail Log</h1>
-    <p class="text-muted mb-0">History of all generated email: queued, edited, approved, and rejected.</p>
+    <p class="text-muted mb-0">History of all outgoing email: queued mail, immediate deliveries, edits, and approvals.</p>
   </div>
   <div class="d-flex gap-2">
     <%= link_to "Mail Queue", queued_mails_path, class: "btn btn-outline-primary" %>
@@ -46,15 +46,25 @@
                 <span class="badge <%= badge_class %>"><%= entry.event.capitalize %></span>
               </td>
               <td>
-                <div class="fw-semibold">
-                  <%= link_to truncate(qm.subject, length: 50), queued_mail_path(qm), class: "text-decoration-none" %>
-                </div>
-                <div class="text-muted small">
-                  To: <%= qm.to %>
-                  <% if qm.recipient %>
-                    (<%= link_to qm.recipient.display_name, user_path(qm.recipient), class: "text-decoration-none" %>)
-                  <% end %>
-                </div>
+                <% if qm %>
+                  <div class="fw-semibold">
+                    <%= link_to truncate(qm.subject, length: 50), queued_mail_path(qm), class: "text-decoration-none" %>
+                  </div>
+                  <div class="text-muted small">
+                    To: <%= qm.to %>
+                    <% if qm.recipient %>
+                      (<%= link_to qm.recipient.display_name, user_path(qm.recipient), class: "text-decoration-none" %>)
+                    <% end %>
+                  </div>
+                <% else %>
+                  <div class="fw-semibold"><%= truncate(entry.delivery_subject, length: 50) %></div>
+                  <div class="text-muted small">
+                    To: <%= entry.delivery_to %>
+                    <% if entry.delivery_mailer.present? %>
+                      <span class="d-block"><%= entry.delivery_mailer %>#<%= entry.delivery_action %></span>
+                    <% end %>
+                  </div>
+                <% end %>
               </td>
               <td class="text-nowrap">
                 <% if entry.actor %>
@@ -81,7 +91,7 @@
   <div class="card shadow-sm border-0">
     <div class="card-body text-center py-5">
       <i class="bi bi-journal-text display-4 mb-3 d-block text-muted opacity-25"></i>
-      <p class="text-muted mb-0">No mail log entries yet. Entries appear when emails are queued, edited, approved, or rejected.</p>
+      <p class="text-muted mb-0">No mail log entries yet. Entries appear when mail is queued, edited, approved, sent, or delivery fails.</p>
     </div>
   </div>
 <% end %>

--- a/config/initializers/mail_delivery_log_interceptor.rb
+++ b/config/initializers/mail_delivery_log_interceptor.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  interceptors = ActionMailer::Base.delivery_interceptors
+  next if interceptors.include?(MailDeliveryLogInterceptor)
+
+  ActionMailer::Base.register_interceptor(MailDeliveryLogInterceptor)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get  "/invite/:token/accepted", to: "invite#accepted", as: :invite_accepted
 
   get "/login", to: "sessions#new"
-  get "/apply", to: "pages#apply"
+  get "/apply", to: "pages#apply", as: :apply
   get "/help", to: "pages#help", as: :help
   get "/help/faq", to: "pages#help_faq", as: :help_faq
   get "/help/admin_faq", to: "pages#help_admin_faq", as: :help_admin_faq
@@ -378,6 +378,9 @@ Rails.application.routes.draw do
   resources :rooms, path: 'settings/rooms'
 
   resources :application_form_pages, path: 'settings/application_form' do
+    collection do
+      patch :update_application_flow
+    end
     resources :application_form_questions, only: %i[new create edit update destroy]
   end
 

--- a/db/migrate/20260407120000_add_direct_mail_log_and_application_flow_toggle.rb
+++ b/db/migrate/20260407120000_add_direct_mail_log_and_application_flow_toggle.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddDirectMailLogAndApplicationFlowToggle < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :mail_log_entries, :queued_mail_id, true
+
+    add_column :mail_log_entries, :delivery_to, :string
+    add_column :mail_log_entries, :delivery_subject, :string
+    add_column :mail_log_entries, :delivery_mailer, :string
+    add_column :mail_log_entries, :delivery_action, :string
+
+    add_column :membership_settings, :use_builtin_membership_application, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_06_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_07_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -441,8 +441,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_06_140000) do
     t.bigint "actor_id"
     t.datetime "created_at", null: false
     t.string "details"
+    t.string "delivery_action"
+    t.string "delivery_mailer"
+    t.string "delivery_subject"
+    t.string "delivery_to"
     t.string "event", null: false
-    t.bigint "queued_mail_id", null: false
+    t.bigint "queued_mail_id"
     t.datetime "updated_at", null: false
     t.index ["actor_id"], name: "index_mail_log_entries_on_actor_id"
     t.index ["created_at"], name: "index_mail_log_entries_on_created_at"
@@ -564,6 +568,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_06_140000) do
     t.integer "payment_grace_period_days", default: 14, null: false
     t.integer "reactivation_grace_period_months", default: 3, null: false
     t.datetime "updated_at", null: false
+    t.boolean "use_builtin_membership_application", default: true, null: false
   end
 
   create_table "messages", force: :cascade do |t|

--- a/test/controllers/application_form_pages_controller_test.rb
+++ b/test/controllers/application_form_pages_controller_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationFormPagesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+    sign_in_as_local_admin
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+    MembershipSetting.instance.update!(use_builtin_membership_application: true)
+  end
+
+  test 'update_application_flow toggles membership setting' do
+    MembershipSetting.instance.update!(use_builtin_membership_application: true)
+
+    patch update_application_flow_application_form_pages_path,
+          params: { use_builtin_membership_application: '0' }
+
+    assert_redirected_to application_form_pages_path
+    assert_not MembershipSetting.instance.reload.use_builtin_membership_application?
+
+    patch update_application_flow_application_form_pages_path,
+          params: { use_builtin_membership_application: '1' }
+
+    assert_redirected_to application_form_pages_path
+    assert MembershipSetting.instance.reload.use_builtin_membership_application?
+  end
+
+  test 'update_application_flow without choice shows alert' do
+    patch update_application_flow_application_form_pages_path, params: {}
+
+    assert_redirected_to application_form_pages_path
+    assert_equal 'Choose how applicants should apply.', flash[:alert]
+  end
+
+  private
+
+  def sign_in_as_local_admin
+    account = local_accounts(:active_admin)
+    post local_login_path, params: {
+      session: {
+        email: account.email,
+        password: 'localpassword123'
+      }
+    }
+  end
+end

--- a/test/controllers/application_verifications_controller_test.rb
+++ b/test/controllers/application_verifications_controller_test.rb
@@ -4,6 +4,10 @@ require 'active_job/test_helper'
 class ApplicationVerificationsControllerTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
+  teardown do
+    MembershipSetting.instance.update!(use_builtin_membership_application: true)
+  end
+
   # ─── Gate Page ───────────────────────────────────────────────────
 
   test 'gate page renders successfully' do
@@ -172,6 +176,35 @@ class ApplicationVerificationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   # ─── Expired Verification ──────────────────────────────────
+
+  test 'gate renders apply fragment when external application flow' do
+    MembershipSetting.instance.update!(use_builtin_membership_application: false)
+    TextFragment.ensure_exists!(
+      key: 'apply_for_membership',
+      title: 'Apply for membership',
+      content: '<p>External apply content</p>'
+    )
+
+    get apply_new_path
+
+    assert_response :success
+    assert_match 'External apply content', response.body
+    assert_no_match 'Send Verification Email', response.body
+  end
+
+  test 'external flow redirects verification post to apply page' do
+    MembershipSetting.instance.update!(use_builtin_membership_application: false)
+
+    assert_no_difference 'ApplicationVerification.count' do
+      post apply_new_path, params: {
+        confirmed_open_house: '1',
+        confirmed_code_of_conduct: '1',
+        email: 'applicant@example.com'
+      }
+    end
+
+    assert_redirected_to apply_path
+  end
 
   test 'expired verification blocks application access' do
     verification = ApplicationVerification.create!(

--- a/test/mailers/member_mailer_test.rb
+++ b/test/mailers/member_mailer_test.rb
@@ -9,7 +9,15 @@ class MemberMailerTest < ActionMailer::TestCase
     applicant = users(:one)
     url = 'https://www.example.com/membership_applications/4242'
 
-    email = MemberMailer.admin_new_application(applicant, 'ops@example.com', application_url: url).deliver_now
+    email = nil
+    assert_difference 'MailLogEntry.count', 1 do
+      email = MemberMailer.admin_new_application(applicant, 'ops@example.com', application_url: url).deliver_now
+    end
+
+    entry = MailLogEntry.order(:created_at).last
+    assert_nil entry.queued_mail_id
+    assert_equal 'ops@example.com', entry.delivery_to
+    assert entry.delivery_subject.present?
 
     assert_includes email.html_part.body.to_s, url
     text = email.text_part ? email.text_part.body.to_s : email.body.to_s

--- a/test/mailers/queued_mail_mailer_test.rb
+++ b/test/mailers/queued_mail_mailer_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class QueuedMailMailerTest < ActionMailer::TestCase
+  test 'deliver_queued does not create a direct-only mail log entry' do
+    qm = queued_mails(:pending_mail)
+    assert_no_difference(-> { MailLogEntry.where(queued_mail_id: nil).count }) do
+      QueuedMailMailer.deliver_queued(qm).deliver_now
+    end
+  end
+end

--- a/test/models/mail_log_entry_test.rb
+++ b/test/models/mail_log_entry_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MailLogEntryTest < ActiveSupport::TestCase
+  test 'log_direct_delivery! creates a sent entry without queued mail' do
+    entry = MailLogEntry.log_direct_delivery!(
+      to: 'admin@example.com',
+      subject: 'Hello',
+      mailer_class: 'MemberMailer',
+      mailer_action: 'admin_new_application'
+    )
+
+    assert_nil entry.queued_mail_id
+    assert_equal 'sent', entry.event
+    assert_equal 'admin@example.com', entry.delivery_to
+    assert_equal 'Hello', entry.delivery_subject
+    assert_equal 'MemberMailer', entry.delivery_mailer
+    assert_equal 'admin_new_application', entry.delivery_action
+  end
+
+  test 'log_direct_delivery! requires to and subject' do
+    assert_raises(ActiveRecord::RecordInvalid) do
+      MailLogEntry.log_direct_delivery!(
+        to: '',
+        subject: 'Subj',
+        mailer_class: 'X',
+        mailer_action: 'y'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Register an Action Mailer delivery interceptor so immediate sends are written to mail_log_entries with to, subject, and mailer metadata. Queued mail keeps a single log path via QueuedMailMailer skip header.

Add membership_settings.use_builtin_membership_application and a Manage Application Form control. When disabled, /apply/new mirrors the public apply text fragment and the wizard routes redirect to /apply.

Update mail log UI for direct entries, add migration and tests.

Made-with: Cursor