### PR TITLE
Simplify lint stack to use a standalone RuboCop image.

### DIFF
--- a/.cursor/rules/docker-ci.mdc
+++ b/.cursor/rules/docker-ci.mdc
@@ -23,8 +23,8 @@ Use `-f docker-compose.<stack>.yml`; each stack sets a top-level `name:` so volu
 | `docker-compose.dev.yml` | Local dev: Postgres + Redis + `web` + `sidekiq` (bind-mounted app). Postgres container `membermanager-dev-postgres`, host DB port `5432`. |
 | `docker-compose.test.yml` | Tests (quick): prebuilt `member_manager_web:latest`, bind-mounted app; Postgres + Redis + `test` service. |
 | `docker-compose.test.build.yml` | Same as test stack but **includes** a `build:` for the app image (full Docker build before runs). |
-| `docker-compose.lint.yml` | RuboCop (quick): prebuilt `member_manager_lint:latest`, bind-mounted app; Postgres + `rubocop`. |
-| `docker-compose.lint.build.yml` | Same as lint stack but **includes** a `build:` for the `lint` Dockerfile target. |
+| `docker-compose.lint.yml` | RuboCop (quick): prebuilt `member_manager_rubocop:latest`, bind-mounted app; no Postgres service. |
+| `docker-compose.lint.build.yml` | Same as lint stack but **includes** a `build:` for `Dockerfile.rubocop`. |
 | `docker-compose.server.yml` | Prod/staging-style: **no** Postgres service; set `DATABASE_URL` (or DB\_\* ) for external DB. Includes Redis for Sidekiq unless `REDIS_URL` points elsewhere. |
 
 - **Dev migrate:** `docker compose -f docker-compose.dev.yml --profile tools run --rm migrate`
@@ -34,7 +34,7 @@ Use `-f docker-compose.<stack>.yml`; each stack sets a top-level `name:` so volu
 - **Lint (full build):** `docker compose -f docker-compose.lint.build.yml run --rm rubocop`
 - **Server migrate:** `docker compose -f docker-compose.server.yml --profile tools run --rm migrate`
 
-Dev/test/lint bind-mount the repo at `/rails`; server uses the built image only.
+Dev/test bind-mount the repo at `/rails`; lint bind-mounts at `/workspace`; server uses the built image only.
 
 ## GitHub Actions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,16 +65,6 @@ RUN bundle exec bootsnap precompile app/ lib/
 RUN --mount=type=cache,target=/rails/tmp/cache \
     SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
-# Lint image: full bundle including development gems (RuboCop + native deps).
-# `docker compose -f docker-compose.lint.yml run --rm rubocop`
-FROM build AS lint
-ENV BUNDLE_WITHOUT=""
-RUN bundle install && \
-    rm -rf "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
-# No USER rails here — that user is only created in the final app stage; lint runs as root.
-ENTRYPOINT ["bundle", "exec", "rubocop"]
-
-
 # Final stage for app image
 FROM base
 ARG APP_VERSION=dev

--- a/Dockerfile.rubocop
+++ b/Dockerfile.rubocop
@@ -1,0 +1,16 @@
+ARG RUBY_VERSION=3.3.11
+FROM ruby:${RUBY_VERSION}-slim
+
+ARG RUBOCOP_VERSION=1.86.0
+ARG RUBOCOP_RAILS_VERSION=2.34.3
+
+WORKDIR /workspace
+
+# Keep the lint image lightweight and stable: install only RuboCop and plugins.
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential && \
+    rm -rf /var/lib/apt/lists/* && \
+    gem install --no-document rubocop -v "${RUBOCOP_VERSION}" && \
+    gem install --no-document rubocop-rails -v "${RUBOCOP_RAILS_VERSION}"
+
+ENTRYPOINT ["rubocop"]

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The repository ships **four** Compose files so local stacks stay predictable and
 | [`docker-compose.dev.yml`](docker-compose.dev.yml) | Day-to-day local development (`web`, Sidekiq, live-mounted source). | Included. Container: `membermanager-dev-postgres`, published on **localhost:5432**. |
 | [`docker-compose.test.yml`](docker-compose.test.yml) | Running the test suite from Docker (prebuilt `member_manager_web:latest`, fast reruns with bind-mounted code). | Included. Container: `membermanager-test-postgres`, published on **localhost:5433** (so dev can use 5432 at the same time). Redis: `membermanager-test-redis`, **localhost:6380**. |
 | [`docker-compose.test.build.yml`](docker-compose.test.build.yml) | Same as test stack but **builds** the app image first (use after Dockerfile changes or to create the image the first time). | Same Postgres/Redis as `docker-compose.test.yml`. |
-| [`docker-compose.lint.yml`](docker-compose.lint.yml) | RuboCop only (prebuilt `member_manager_lint:latest`). | Included (isolated DB for naming parity). Container: `membermanager-lint-postgres`, **localhost:5434**. |
-| [`docker-compose.lint.build.yml`](docker-compose.lint.build.yml) | Same as lint stack but **builds** the lint-stage image first. | Same as `docker-compose.lint.yml`. |
+| [`docker-compose.lint.yml`](docker-compose.lint.yml) | RuboCop only (prebuilt `member_manager_rubocop:latest`, bind-mounted source). | Not required. RuboCop is static and does not use PostgreSQL. |
+| [`docker-compose.lint.build.yml`](docker-compose.lint.build.yml) | Same as lint stack but **builds** the dedicated RuboCop image first. | Not required. |
 | [`docker-compose.server.yml`](docker-compose.server.yml) | Production- or staging-style runs (image-based app, no source mount). | **Not included.** Point `DATABASE_URL` (or `DB_HOST` and related variables) at an existing PostgreSQL server. Redis defaults to the bundled `redis` service; set `REDIS_URL` to use an external instance. |
 
 ### Local development
@@ -100,7 +100,7 @@ docker compose -f docker-compose.test.build.yml run --rm test
 
 ### Lint (Docker)
 
-Same pattern: use a prebuilt `member_manager_lint:latest` for quick runs. Build or refresh when the Dockerfile or Ruby lint gems change:
+Same pattern: use a prebuilt `member_manager_rubocop:latest` for quick runs. Build or refresh when RuboCop versions change:
 
 ```bash
 docker compose -f docker-compose.lint.build.yml build rubocop

--- a/docker-compose.lint.build.yml
+++ b/docker-compose.lint.build.yml
@@ -1,5 +1,5 @@
-# Same stack as docker-compose.lint.yml but builds the lint-stage image first.
-# Use when validating Dockerfile / Gemfile changes or creating member_manager_lint:latest from scratch.
+# Same stack as docker-compose.lint.yml but builds the RuboCop-only image first.
+# Use when updating RuboCop tooling or creating member_manager_rubocop:latest from scratch.
 # Usage: docker compose -f docker-compose.lint.build.yml build rubocop
 #        docker compose -f docker-compose.lint.build.yml run --rm rubocop
 #        docker compose -f docker-compose.lint.build.yml run --rm rubocop app/models
@@ -10,10 +10,12 @@ include:
 
 services:
   rubocop:
+    image: member_manager_rubocop:latest
     build:
       context: .
-      dockerfile: Dockerfile
-      target: lint
+      dockerfile: Dockerfile.rubocop
       pull: true
       args:
         RUBY_VERSION: "3.3.11"
+        RUBOCOP_VERSION: "1.86.0"
+        RUBOCOP_RAILS_VERSION: "2.34.3"

--- a/docker-compose.lint.yml
+++ b/docker-compose.lint.yml
@@ -1,45 +1,16 @@
-# RuboCop only, with a dedicated Postgres container (name-isolated; optional future tooling).
-# Quick path: uses existing member_manager_lint:latest (bind-mounts repo at /rails).
-# Build or refresh the lint image when the Dockerfile or Gemfile changes:
+# RuboCop only (no Rails app boot, no database required).
+# Quick path: uses prebuilt member_manager_rubocop:latest (bind-mounts repo at /workspace).
+# Build or refresh the lint image when RuboCop tooling changes:
 #   docker compose -f docker-compose.lint.build.yml build rubocop
-# Postgres is published on host port 5434 so it can run alongside dev/test stacks.
 # Usage: docker compose -f docker-compose.lint.yml run --rm rubocop
 #        docker compose -f docker-compose.lint.yml run --rm rubocop app/models
-# If you see GemNotFound against Gemfile.lock, refresh gems then RuboCop (same file):
-#   docker compose -f docker-compose.lint.yml run --rm --entrypoint sh rubocop -c "bundle install && bundle exec rubocop"
 name: membermanager-lint
 
 services:
-  db:
-    image: postgres:16
-    container_name: membermanager-lint-postgres
-    environment:
-      POSTGRES_DB: member_manager_lint
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-    volumes:
-      - lint_postgres_data:/var/lib/postgresql/data
-#    ports:
-#      - "5434:5432"
-
   rubocop:
-    image: member_manager_lint:latest
-    env_file:
-      - .env
+    image: member_manager_rubocop:latest
     volumes:
-      - .:/rails
+      - .:/workspace
       - ./tmp/access:/tmp/access
-    working_dir: /rails
-    environment:
-      RAILS_ENV: development
-      DB_HOST: db
-      DB_USERNAME: postgres
-      DB_PASSWORD: postgres
-      DB_PORT: 5432
-      DATABASE_URL: postgres://postgres:postgres@db:5432/member_manager_lint
-    depends_on:
-      - db
-    entrypoint: ["bundle", "exec", "rubocop"]
-
-volumes:
-  lint_postgres_data:
+    working_dir: /workspace
+    entrypoint: ["rubocop"]


### PR DESCRIPTION
Remove unnecessary Postgres and app-image coupling from lint compose, and document a dedicated bind-mounted RuboCop workflow that only rebuilds when lint tooling changes.

Made-with: Cursor