### PR TITLE
Refine membership application review workflow and tabs.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -72,7 +72,6 @@ class DashboardController < AdminController
     # Important: Pending membership applications
     @pending_applications_count = MembershipApplication.pending.count
     @submitted_applications_count = MembershipApplication.submitted_apps.count
-    @under_review_applications_count = MembershipApplication.under_review.count
 
     # Important: Parking notices
     @active_parking_permit_count = ParkingNotice.permits.active_notices.count

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -6,11 +6,11 @@ class MembershipApplicationsController < ApplicationController
   include MembershipApplicationWizard::Actions
 
   ADMIN_ACTIONS = %i[
-    index show import approve reject mark_under_review link_user unlink_user vote_ai_feedback
+    index show import approve reject link_user unlink_user vote_ai_feedback
     save_tour_feedback vote_acceptance
   ].freeze
   APPLICATION_MEMBER_ACTIONS = %i[
-    show approve reject mark_under_review link_user unlink_user vote_ai_feedback
+    show approve reject link_user unlink_user vote_ai_feedback
     save_tour_feedback vote_acceptance
   ].freeze
 
@@ -42,15 +42,23 @@ class MembershipApplicationsController < ApplicationController
   def index
     base_scope = MembershipApplication.where.not(status: 'draft').newest_first
     @applications = base_scope.includes(:user, :reviewed_by, :application_answers, :acceptance_votes)
-    @applications = @applications.where(status: params[:status]) if params[:status].present?
+    @current_status = params[:status].presence || 'submitted'
+    @applications = case @current_status
+                    when 'all'
+                      @applications
+                    when 'unlinked'
+                      @applications.where(user_id: nil).where.not(status: 'rejected')
+                    else
+                      @applications.where(status: @current_status)
+                    end
     @applications = @applications.admin_search(params[:q])
 
     @status_counts = {
       all: MembershipApplication.where.not(status: 'draft').count,
       submitted: MembershipApplication.submitted_apps.count,
-      under_review: MembershipApplication.under_review.count,
       approved: MembershipApplication.approved.count,
-      rejected: MembershipApplication.rejected.count
+      rejected: MembershipApplication.rejected.count,
+      unlinked: MembershipApplication.where.not(status: %w[draft rejected]).where(user_id: nil).count
     }
 
     @pagy, @applications = pagy(@applications, limit: 25)
@@ -155,12 +163,6 @@ class MembershipApplicationsController < ApplicationController
       redirect_to membership_application_path(@application),
                   notice: 'Application rejected. No email was queued (recipient has no email address).'
     end
-  end
-
-  def mark_under_review
-    @application.mark_under_review!(current_user)
-    redirect_to membership_application_path(@application),
-                notice: 'Application marked as under review.'
   end
 
   def vote_ai_feedback

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -1,5 +1,5 @@
 class MembershipApplication < ApplicationRecord
-  STATUSES = %w[draft submitted under_review approved rejected].freeze
+  STATUSES = %w[draft submitted approved rejected].freeze
 
   # Training topic name (TrainingTopic.name) — viewers with this training see applicant PII without masking.
   EXECUTIVE_DIRECTOR_TRAINING_TOPIC_NAME = 'Executive Director'.freeze
@@ -39,10 +39,9 @@ class MembershipApplication < ApplicationRecord
     where.not(status: 'draft').where(ai_feedback_processed_at: nil)
   }
   scope :submitted_apps, -> { where(status: 'submitted') }
-  scope :under_review, -> { where(status: 'under_review') }
   scope :approved, -> { where(status: 'approved') }
   scope :rejected, -> { where(status: 'rejected') }
-  scope :pending, -> { where(status: %w[submitted under_review]) }
+  scope :pending, -> { submitted_apps }
   scope :newest_first, -> { order(created_at: :desc) }
   scope :admin_search, lambda { |query|
     raw = query.to_s.strip
@@ -81,10 +80,6 @@ class MembershipApplication < ApplicationRecord
     status == 'submitted'
   end
 
-  def under_review?
-    status == 'under_review'
-  end
-
   def approved?
     status == 'approved'
   end
@@ -98,10 +93,6 @@ class MembershipApplication < ApplicationRecord
     Journal.record_application_event!(application: self, action: 'application_submitted')
     MembershipApplicationAiFeedbackJob.perform_later(id)
     MembershipApplications::NotifyDirectorsOfSubmission.call(self)
-  end
-
-  def mark_under_review!(admin)
-    update!(status: 'under_review', reviewed_by: admin)
   end
 
   # Updates status and journal only. The web UI uses +MembershipApplications::FinalizeApproval+ instead
@@ -134,13 +125,14 @@ class MembershipApplication < ApplicationRecord
   end
 
   def status_display
+    return 'Open' if submitted?
+
     status&.titleize
   end
 
   def status_badge_color
     case status
     when 'submitted' then 'primary'
-    when 'under_review' then 'warning'
     when 'approved' then 'success'
     when 'rejected' then 'danger'
     else 'secondary'

--- a/app/views/dashboard/_attention_item_body.html.erb
+++ b/app/views/dashboard/_attention_item_body.html.erb
@@ -85,10 +85,7 @@ when :ac_issues %>
         <strong><%= @pending_applications_count %></strong> pending membership <%= 'application'.pluralize(@pending_applications_count) %>
       <% end %>
       <div class="text-muted small mt-1">
-        <% parts = [] %>
-        <% parts << "#{@submitted_applications_count} submitted" if @submitted_applications_count > 0 %>
-        <% parts << "#{@under_review_applications_count} under review" if @under_review_applications_count > 0 %>
-        <%= parts.join(', ') %>
+        <%= "#{@submitted_applications_count} open" if @submitted_applications_count > 0 %>
       </div>
     </div>
   <% end %>

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -41,31 +41,31 @@
   <ul class="nav nav-tabs mb-3">
     <li class="nav-item">
       <%= link_to membership_applications_path(ma_nav.merge(status: 'submitted')),
-          class: "nav-link #{params[:status] == 'submitted' ? 'active' : ''}" do %>
-        Submitted <span class="badge bg-primary"><%= @status_counts[:submitted] %></span>
-      <% end %>
-    </li>
-    <li class="nav-item">
-      <%= link_to membership_applications_path(ma_nav.merge(status: 'under_review')),
-          class: "nav-link #{params[:status] == 'under_review' ? 'active' : ''}" do %>
-        Under Review <span class="badge bg-warning text-dark"><%= @status_counts[:under_review] %></span>
+          class: "nav-link #{@current_status == 'submitted' ? 'active' : ''}" do %>
+        Open <span class="badge bg-primary"><%= @status_counts[:submitted] %></span>
       <% end %>
     </li>
     <li class="nav-item">
       <%= link_to membership_applications_path(ma_nav.merge(status: 'approved')),
-          class: "nav-link #{params[:status] == 'approved' ? 'active' : ''}" do %>
+          class: "nav-link #{@current_status == 'approved' ? 'active' : ''}" do %>
         Approved <span class="badge bg-success"><%= @status_counts[:approved] %></span>
       <% end %>
     </li>
     <li class="nav-item">
       <%= link_to membership_applications_path(ma_nav.merge(status: 'rejected')),
-          class: "nav-link #{params[:status] == 'rejected' ? 'active' : ''}" do %>
+          class: "nav-link #{@current_status == 'rejected' ? 'active' : ''}" do %>
         Rejected <span class="badge bg-danger"><%= @status_counts[:rejected] %></span>
       <% end %>
     </li>
     <li class="nav-item">
-      <%= link_to membership_applications_path(ma_nav),
-          class: "nav-link #{params[:status].blank? ? 'active' : ''}" do %>
+      <%= link_to membership_applications_path(ma_nav.merge(status: 'unlinked')),
+          class: "nav-link #{@current_status == 'unlinked' ? 'active' : ''}" do %>
+        Unlinked <span class="badge bg-warning text-dark"><%= @status_counts[:unlinked] %></span>
+      <% end %>
+    </li>
+    <li class="nav-item">
+      <%= link_to membership_applications_path(ma_nav.merge(status: 'all')),
+          class: "nav-link #{@current_status == 'all' ? 'active' : ''}" do %>
         All <span class="badge bg-secondary"><%= @status_counts[:all] %></span>
       <% end %>
     </li>

--- a/app/views/membership_applications/show.html.erb
+++ b/app/views/membership_applications/show.html.erb
@@ -18,14 +18,7 @@
     Application #<%= @application.id %>
     <span class="badge bg-<%= @application.status_badge_color %>"><%= @application.status_display %></span>
   </h1>
-  <div class="d-flex gap-2">
-    <% if @application.submitted? %>
-      <%= link_to mark_under_review_membership_application_path(@application),
-          data: { turbo_method: :post },
-          class: "btn btn-outline-warning" do %>
-        <i class="bi bi-eye me-1"></i> Mark Under Review
-      <% end %>
-    <% end %>
+  <div>
     <%= link_to membership_applications_path, class: "btn btn-outline-secondary" do %>
       <i class="bi bi-arrow-left me-1"></i> Back
     <% end %>
@@ -37,54 +30,68 @@
     <div class="row">
       <div class="col-md-6">
         <dl>
-          <dt>Email</dt>
-          <dd>
-            <%= membership_application_masked_contact_capture do %>
-              <%= @application.email %>
-            <% end %>
-          </dd>
-
-          <dt>Status</dt>
-          <dd><span class="badge bg-<%= @application.status_badge_color %>"><%= @application.status_display %></span></dd>
-
-          <dt>Submitted</dt>
-          <dd><%= @application.submitted_at&.strftime('%B %d, %Y at %l:%M %p') || 'Not yet submitted' %></dd>
-
-          <dt>Linked member</dt>
-          <dd class="d-flex flex-wrap align-items-center gap-2">
-            <% if @application.user %>
-              <%= link_to @application.user.display_name, user_path(@application.user), class: "text-decoration-none" %>
-              <%= button_to 'Unlink', unlink_user_membership_application_path(@application),
-                            method: :post,
-                            class: 'btn btn-sm btn-outline-warning',
-                            form: { data: { turbo_confirm: 'Remove the member link from this application?' } } %>
-            <% else %>
-              <span class="text-muted">Not linked</span>
-              <% if @users_for_application_link.any? %>
-                <button type="button" class="btn btn-sm btn-primary"
-                        data-bs-toggle="modal" data-bs-target="#maLinkMemberModal">
-                  Link member
-                </button>
+          <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
+            <dt>Email</dt>
+            <dd class="mb-0">
+              <%= membership_application_masked_contact_capture do %>
+                <%= @application.email %>
               <% end %>
-            <% end %>
-          </dd>
+            </dd>
+          </div>
+
+          <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
+            <dt>Status</dt>
+            <dd class="mb-0"><span class="badge bg-<%= @application.status_badge_color %>"><%= @application.status_display %></span></dd>
+          </div>
+
+          <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
+            <dt>Submitted</dt>
+            <dd class="mb-0"><%= @application.submitted_at&.strftime('%B %d, %Y at %l:%M %p') || 'Not yet submitted' %></dd>
+          </div>
+
+          <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-0">
+            <dt>Linked member</dt>
+            <dd class="mb-0 d-flex flex-wrap align-items-center gap-2">
+              <% if @application.user %>
+                <%= link_to @application.user.display_name, user_path(@application.user), class: "text-decoration-none" %>
+                <%= button_to 'Unlink', unlink_user_membership_application_path(@application),
+                              method: :post,
+                              class: 'btn btn-sm btn-outline-warning',
+                              form: { data: { turbo_confirm: 'Remove the member link from this application?' } } %>
+              <% else %>
+                <span class="text-muted">Not linked</span>
+                <% if @users_for_application_link.any? %>
+                  <button type="button" class="btn btn-sm btn-primary"
+                          data-bs-toggle="modal" data-bs-target="#maLinkMemberModal">
+                    Link member
+                  </button>
+                <% end %>
+              <% end %>
+            </dd>
+          </div>
         </dl>
       </div>
       <div class="col-md-6">
         <dl>
           <% if @application.reviewed_by.present? %>
-            <dt>Reviewed by</dt>
-            <dd><%= link_to @application.reviewed_by.display_name, user_path(@application.reviewed_by) %></dd>
+            <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
+              <dt>Reviewed by</dt>
+              <dd class="mb-0"><%= link_to @application.reviewed_by.display_name, user_path(@application.reviewed_by) %></dd>
+            </div>
           <% end %>
 
           <% if @application.reviewed_at.present? %>
-            <dt>Reviewed on</dt>
-            <dd><%= @application.reviewed_at.strftime('%B %d, %Y at %l:%M %p') %></dd>
+            <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
+              <dt>Reviewed on</dt>
+              <dd class="mb-0"><%= @application.reviewed_at.strftime('%B %d, %Y at %l:%M %p') %></dd>
+            </div>
           <% end %>
 
           <% if @application.admin_notes.present? %>
-            <dt>Admin Notes</dt>
-            <dd><%= simple_format(@application.admin_notes) %></dd>
+            <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-0">
+              <dt>Admin Notes</dt>
+              <dd class="mb-0"><%= simple_format(@application.admin_notes) %></dd>
+            </div>
           <% end %>
         </dl>
       </div>
@@ -117,9 +124,9 @@
     </div>
     <div class="card-body">
       <% questions.each do |qa| %>
-        <div class="mb-3">
-          <dt class="text-muted small"><%= qa[:question].label %></dt>
-          <dd class="mb-2">
+        <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
+          <div class="text-muted small fw-semibold mb-1"><%= qa[:question].label %></div>
+          <div class="mb-0">
             <% if qa[:answer]&.value.present? %>
               <% if membership_application_sensitive_answer_label?(qa[:question].label) %>
                 <%= membership_application_masked_contact_capture do %>
@@ -131,11 +138,15 @@
             <% else %>
               <span class="text-muted fst-italic">No answer</span>
             <% end %>
-          </dd>
+          </div>
         </div>
       <% end %>
     </div>
   </div>
+<% end %>
+
+<% unless @application.draft? %>
+  <%= render 'acceptance_votes_card', application: @application, current_acceptance_vote: @current_acceptance_vote %>
 <% end %>
 
 <% unless @application.approved? || @application.rejected? %>
@@ -169,7 +180,7 @@
       <% else %>
         <p class="text-muted mb-0">
           Only members trained as <strong>Executive Director</strong> may approve or reject applications.
-          Use admin acceptance votes below to record your recommendation.
+          Use admin acceptance votes above to record your recommendation.
         </p>
       <% end %>
     </div>
@@ -194,10 +205,6 @@
       })();
     </script>
   <% end %>
-<% end %>
-
-<% unless @application.draft? %>
-  <%= render 'acceptance_votes_card', application: @application, current_acceptance_vote: @current_acceptance_vote %>
 <% end %>
 
 </div><%# .membership-application-show %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -395,7 +395,6 @@ Rails.application.routes.draw do
     member do
       post :approve
       post :reject
-      post :mark_under_review
       post :link_user
       post :unlink_user
       post :vote_ai_feedback

--- a/db/migrate/20260411100000_remove_under_review_membership_application_status.rb
+++ b/db/migrate/20260411100000_remove_under_review_membership_application_status.rb
@@ -1,0 +1,14 @@
+class RemoveUnderReviewMembershipApplicationStatus < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE membership_applications
+      SET status = 'submitted'
+      WHERE status = 'under_review'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+          'Cannot safely infer which submitted applications were previously under_review.'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_07_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_11_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -440,11 +440,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_07_120000) do
   create_table "mail_log_entries", force: :cascade do |t|
     t.bigint "actor_id"
     t.datetime "created_at", null: false
-    t.string "details"
     t.string "delivery_action"
     t.string "delivery_mailer"
     t.string "delivery_subject"
     t.string "delivery_to"
+    t.string "details"
     t.string "event", null: false
     t.bigint "queued_mail_id"
     t.datetime "updated_at", null: false

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -71,6 +71,83 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', membership_application_path(miss), count: 0
   end
 
+  test 'index defaults to open submitted tab' do
+    open_app = MembershipApplication.create!(
+      email: 'default-open@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    closed_app = MembershipApplication.create!(
+      email: 'default-approved@example.com',
+      status: 'approved',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+
+    get membership_applications_path
+
+    assert_response :success
+    assert_select 'a.nav-link.active', text: /Open/
+    assert_select 'a[href=?]', membership_application_path(open_app)
+    assert_select 'a[href=?]', membership_application_path(closed_app), count: 0
+  end
+
+  test 'index unlinked tab lists only unlinked non-rejected applications' do
+    linked_member = users(:member_with_local_account)
+    keep = MembershipApplication.create!(
+      email: 'unlinked-open@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    filtered_rejected = MembershipApplication.create!(
+      email: 'unlinked-rejected@example.com',
+      status: 'rejected',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+    filtered_linked = MembershipApplication.create!(
+      email: 'linked-open@example.com',
+      status: 'submitted',
+      submitted_at: Time.current,
+      user: linked_member
+    )
+
+    get membership_applications_path(status: 'unlinked')
+
+    assert_response :success
+    assert_select 'a.nav-link.active', text: /Unlinked/
+    assert_select 'a[href=?]', membership_application_path(keep)
+    assert_select 'a[href=?]', membership_application_path(filtered_rejected), count: 0
+    assert_select 'a[href=?]', membership_application_path(filtered_linked), count: 0
+  end
+
+  test 'index unlinked count excludes rejected applications' do
+    MembershipApplication.create!(
+      email: 'badge-open-unlinked@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    MembershipApplication.create!(
+      email: 'badge-approved-unlinked@example.com',
+      status: 'approved',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+    MembershipApplication.create!(
+      email: 'badge-rejected-unlinked@example.com',
+      status: 'rejected',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+
+    get membership_applications_path(status: 'all')
+
+    assert_response :success
+    expected_count = MembershipApplication.where.not(status: %w[draft rejected]).where(user_id: nil).count
+    assert_select "a[href='#{membership_applications_path(status: 'unlinked')}'] span.badge",
+                  text: expected_count.to_s
+  end
+
   test 'show masks applicant contact when Executive Director topic exists and viewer is not trained' do
     TrainingTopic.create!(name: 'Executive Director')
     sign_in_as_admin
@@ -183,7 +260,7 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     TrainingTopic.create!(name: 'Executive Director')
     app = MembershipApplication.create!(
       email: 'approve-gate@example.com',
-      status: 'under_review',
+      status: 'submitted',
       submitted_at: Time.current
     )
     assert_no_changes -> { app.reload.status } do
@@ -201,7 +278,7 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     q_name = page1.questions.create!(label: 'Name', field_type: 'text', required: false, position: 1)
     app = MembershipApplication.create!(
       email: 'approve-ok@example.com',
-      status: 'under_review',
+      status: 'submitted',
       submitted_at: Time.current
     )
     app.application_answers.create!(application_form_question: q_name, value: 'Pat Applicant')
@@ -227,7 +304,7 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     Training.create!(trainee: admin, training_topic: topic, trained_at: Time.current)
     app = MembershipApplication.create!(
       email: 'reject-redirect@example.com',
-      status: 'under_review',
+      status: 'submitted',
       submitted_at: Time.current
     )
 
@@ -248,7 +325,7 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     existing = users(:two)
     app = MembershipApplication.create!(
       email: existing.email,
-      status: 'under_review',
+      status: 'submitted',
       submitted_at: Time.current
     )
     assert_no_difference 'User.count' do

--- a/test/models/membership_application_test.rb
+++ b/test/models/membership_application_test.rb
@@ -30,7 +30,7 @@ class MembershipApplicationTest < ActiveSupport::TestCase
   end
 
   test 'reject! creates pending queued rejection mail' do
-    app = MembershipApplication.create!(email: 'reject-mail-test@example.com', status: 'under_review')
+    app = MembershipApplication.create!(email: 'reject-mail-test@example.com', status: 'submitted')
     admin = users(:one)
 
     qm = nil
@@ -49,7 +49,7 @@ class MembershipApplicationTest < ActiveSupport::TestCase
     member = users(:member_with_local_account)
     app = MembershipApplication.create!(
       email: 'other@example.com',
-      status: 'under_review',
+      status: 'submitted',
       user: member
     )
     admin = users(:one)


### PR DESCRIPTION
Consolidate pending applications into Open, remove the under-review state, add an Unlinked filter that excludes rejected applications, and improve application detail layout for clearer grouped sections.

Made-with: Cursor