### PR TITLE
Add AI-assisted queued mail rewriting with in-place UX.

### DIFF
--- a/app/controllers/queued_mails_controller.rb
+++ b/app/controllers/queued_mails_controller.rb
@@ -1,5 +1,5 @@
 class QueuedMailsController < AdminController
-  before_action :set_queued_mail, only: %i[show edit update approve reject regenerate retry_delivery]
+  before_action :set_queued_mail, only: %i[show edit update approve reject regenerate retry_delivery rewrite_with_ai]
 
   def index
     @filter = params[:filter].presence || 'pending'
@@ -111,6 +111,31 @@ class QueuedMailsController < AdminController
     redirect_to queued_mail_path(@queued_mail), notice: 'Message regenerated from template.'
   end
 
+  def rewrite_with_ai
+    unless @queued_mail.pending?
+      render json: { error: 'Only pending messages can be rewritten.' }, status: :unprocessable_content
+      return
+    end
+
+    attrs = rewrite_params
+    result = QueuedMails::RewriteWithAi.call(
+      queued_mail: @queued_mail,
+      subject: attrs[:subject],
+      body_html: attrs[:body_html],
+      body_text: attrs[:body_text]
+    )
+
+    if result.success?
+      render json: {
+        body_html: result.body_html,
+        body_text: result.body_text,
+        message: result.message
+      }
+    else
+      render json: { error: result.message }, status: :unprocessable_content
+    end
+  end
+
   private
 
   def set_queued_mail
@@ -119,5 +144,9 @@ class QueuedMailsController < AdminController
 
   def queued_mail_params
     params.expect(queued_mail: %i[to subject body_html body_text])
+  end
+
+  def rewrite_params
+    params.expect(rewrite: %i[subject body_html body_text])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -287,7 +287,22 @@ class UsersController < AuthenticatedController
     if @user.save
       redirect_to user_path(@user), notice: 'Member created successfully.'
     else
-      flash.now[:alert] = 'Unable to create member.'
+      if @user.errors.of_kind?(:email, :taken)
+        existing_user = find_existing_user_by_email(@user.email)
+        flash.now[:alert] = if existing_user
+                              helpers.safe_join(
+                                [
+                                  'Unable to create member: email is already in use by ',
+                                  helpers.link_to(existing_user.display_name, user_path(existing_user)),
+                                  '.'
+                                ]
+                              )
+                            else
+                              'Unable to create member: email is already in use.'
+                            end
+      else
+        flash.now[:alert] = 'Unable to create member.'
+      end
       render :new, status: :unprocessable_content
     end
   end
@@ -611,5 +626,12 @@ class UsersController < AuthenticatedController
       attrs[:do_not_greet]               = true
       attrs[:greeting_name]              = ''
     end
+  end
+
+  def find_existing_user_by_email(email)
+    normalized_email = email.to_s.strip.downcase
+    return nil if normalized_email.blank?
+
+    User.where('LOWER(email) = ?', normalized_email).first
   end
 end

--- a/app/javascript/controllers/queued_mail_rewrite_controller.js
+++ b/app/javascript/controllers/queued_mail_rewrite_controller.js
@@ -1,0 +1,112 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["subject", "bodyHtml", "bodyText", "rewriteButton", "undoButton", "spinner", "status"]
+  static values = { url: String }
+
+  connect() {
+    this.previousState = null
+    this.loading = false
+  }
+
+  async rewrite(event) {
+    event.preventDefault()
+    if (this.loading) return
+
+    this.previousState = {
+      bodyHtml: this.currentHtmlBody(),
+      bodyText: this.bodyTextTarget.value
+    }
+    this.toggleUndo(true)
+    this.setStatus("", "")
+    this.setLoading(true)
+
+    try {
+      const response = await fetch(this.urlValue, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+          "X-CSRF-Token": this.csrfToken()
+        },
+        body: JSON.stringify({
+          rewrite: {
+            subject: this.subjectTarget.value,
+            body_html: this.currentHtmlBody(),
+            body_text: this.bodyTextTarget.value
+          }
+        })
+      })
+
+      const payload = await response.json()
+      if (!response.ok) {
+        this.setStatus(payload.error || "Rewrite failed.", "danger")
+        return
+      }
+
+      this.setHtmlBody(payload.body_html || "")
+      this.bodyTextTarget.value = payload.body_text || ""
+      this.setStatus(payload.message || "Message rewritten.", "success")
+    } catch (_error) {
+      this.setStatus("Rewrite failed. Please try again.", "danger")
+    } finally {
+      this.setLoading(false)
+    }
+  }
+
+  undo(event) {
+    event.preventDefault()
+    if (!this.previousState) return
+
+    this.setHtmlBody(this.previousState.bodyHtml)
+    this.bodyTextTarget.value = this.previousState.bodyText
+    this.previousState = null
+    this.toggleUndo(false)
+    this.setStatus("Restored previous message body.", "secondary")
+  }
+
+  setLoading(isLoading) {
+    this.loading = isLoading
+    this.rewriteButtonTarget.disabled = isLoading
+    this.spinnerTarget.classList.toggle("d-none", !isLoading)
+  }
+
+  setStatus(message, variant) {
+    this.statusTarget.textContent = message
+    this.statusTarget.className = "small"
+    if (message && variant) {
+      this.statusTarget.classList.add(`text-${variant}`)
+    } else {
+      this.statusTarget.classList.add("text-muted")
+    }
+  }
+
+  toggleUndo(show) {
+    this.undoButtonTarget.classList.toggle("d-none", !show)
+    this.undoButtonTarget.disabled = !show
+  }
+
+  currentHtmlBody() {
+    const editor = this.editorInstance()
+    return editor ? editor.getContent() : this.bodyHtmlTarget.value
+  }
+
+  setHtmlBody(value) {
+    const editor = this.editorInstance()
+    this.bodyHtmlTarget.value = value
+    if (editor) {
+      editor.setContent(value)
+      editor.save()
+    }
+  }
+
+  editorInstance() {
+    if (typeof tinymce === "undefined") return null
+    return tinymce.get(this.bodyHtmlTarget.id)
+  }
+
+  csrfToken() {
+    const tag = document.querySelector("meta[name='csrf-token']")
+    return tag ? tag.content : ""
+  }
+}

--- a/app/models/ai_ollama_profile.rb
+++ b/app/models/ai_ollama_profile.rb
@@ -1,5 +1,12 @@
 class AiOllamaProfile < ApplicationRecord
-  KEYS = %w[default application_status recommendation_engine].freeze
+  EMAIL_REWRITING_DEFAULT_PROMPT = <<~PROMPT.freeze
+    You rewrite outbound emails for clarity, warmth, and professionalism.
+    Keep the original intent, factual details, and calls to action.
+    Preserve all links, placeholders, and template variables exactly as provided.
+    Return polished copy that is concise and easy to read.
+  PROMPT
+
+  KEYS = %w[default application_status recommendation_engine email_rewriting].freeze
   HEALTH_STATUSES = %w[unknown healthy unhealthy not_configured].freeze
 
   validates :key, presence: true, uniqueness: true, inclusion: { in: KEYS }
@@ -16,11 +23,18 @@ class AiOllamaProfile < ApplicationRecord
     [
       { key: 'default', name: 'Default', display_order: 0 },
       { key: 'application_status', name: 'Application Status', display_order: 1 },
-      { key: 'recommendation_engine', name: 'Recommendation Engine', display_order: 2 }
+      { key: 'recommendation_engine', name: 'Recommendation Engine', display_order: 2 },
+      {
+        key: 'email_rewriting',
+        name: 'Email Rewriting',
+        display_order: 3,
+        prompt: EMAIL_REWRITING_DEFAULT_PROMPT
+      }
     ].each do |attrs|
       find_or_initialize_by(key: attrs[:key]).tap do |row|
         row.name = attrs[:name]
         row.display_order = attrs[:display_order]
+        row.prompt = attrs[:prompt] if row.prompt.to_s.strip.blank? && attrs[:prompt].present?
         row.enabled = true if row.enabled.nil?
         row.health_status = 'not_configured' if row.new_record?
         row.save!

--- a/app/services/queued_mails/rewrite_with_ai.rb
+++ b/app/services/queued_mails/rewrite_with_ai.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module QueuedMails
+  class RewriteWithAi
+    JSON_INSTRUCTION = <<~TXT.squish
+      Respond with a single JSON object only (no markdown fences), using exactly these keys:
+      "body_html" (string),
+      "body_text" (string).
+      Keep placeholders/template tokens unchanged.
+    TXT
+
+    Result = Struct.new(:status, :message, :body_html, :body_text) do
+      def success?
+        status == :success
+      end
+    end
+
+    def self.call(queued_mail:, subject:, body_html:, body_text:)
+      new(queued_mail: queued_mail, subject: subject, body_html: body_html, body_text: body_text).call
+    end
+
+    def initialize(queued_mail:, subject:, body_html:, body_text:)
+      @queued_mail = queued_mail
+      @subject = subject.to_s
+      @body_html = body_html.to_s
+      @body_text = body_text.to_s
+    end
+
+    def call
+      profile = AiOllamaProfile.find_by(key: 'email_rewriting')
+      return Result.new(:failure, 'Email Rewriting AI profile is disabled.') unless profile&.enabled?
+
+      base_url = profile.effective_base_url
+      model = profile.effective_model
+      return Result.new(:failure, 'Email Rewriting AI profile is not configured.') if base_url.blank? || model.blank?
+
+      system_prompt = [profile.prompt.to_s.strip, JSON_INSTRUCTION].compact_blank.join("\n\n")
+      completion = Ollama::ChatCompletion.call(
+        base_url: base_url,
+        model: model,
+        system: system_prompt,
+        user: build_user_prompt,
+        format_json: true
+      )
+      return Result.new(:failure, completion.error.presence || 'Rewrite failed.') unless completion.ok
+
+      parsed = parse_json(completion.assistant_content)
+      return Result.new(:failure, 'AI response was not valid JSON.') unless parsed
+
+      Result.new(:success, 'Message rewritten.', parsed[:body_html], parsed[:body_text])
+    rescue StandardError => e
+      Result.new(:failure, "Rewrite failed: #{e.message}")
+    end
+
+    private
+
+    def build_user_prompt
+      <<~PROMPT
+        Rewrite this queued email body.
+
+        Subject:
+        #{@subject}
+
+        Current HTML body:
+        #{@body_html}
+
+        Current plain text body:
+        #{@body_text}
+      PROMPT
+    end
+
+    def parse_json(raw)
+      json = JSON.parse(raw.to_s)
+      return nil unless json.is_a?(Hash)
+
+      {
+        body_html: json['body_html'].to_s,
+        body_text: json['body_text'].to_s
+      }
+    rescue JSON::ParserError
+      nil
+    end
+  end
+end

--- a/app/views/ai_ollama_profiles/edit.html.erb
+++ b/app/views/ai_ollama_profiles/edit.html.erb
@@ -34,6 +34,9 @@
       <div class="mb-3">
         <%= f.label :model, class: "form-label" %>
         <%= f.text_field :model, class: "form-control", placeholder: "e.g. llama3.2" %>
+        <% if @ai_ollama_profile.key != 'default' %>
+          <div class="form-text">Leave blank to use the Default profile's model.</div>
+        <% end %>
       </div>
 
       <div class="mb-3">

--- a/app/views/ai_ollama_profiles/index.html.erb
+++ b/app/views/ai_ollama_profiles/index.html.erb
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
   <div>
     <h1 class="h3 mb-1">Manage AI</h1>
-    <p class="text-muted mb-0">Ollama endpoints, models, and prompts. Job-specific profiles fall back to Default when their endpoint is blank.</p>
+    <p class="text-muted mb-0">Ollama endpoints, models, and prompts. Job-specific profiles fall back to Default when their endpoint or model is blank.</p>
   </div>
   <div class="d-flex gap-2 flex-wrap">
     <%= button_to "Run health check now", check_health_now_ai_ollama_profiles_path, method: :post, class: "btn btn-outline-primary" %>
@@ -22,6 +22,9 @@
                 <% if profile.key != 'default' && profile.base_url.to_s.strip.blank? && profile.effective_base_url.present? %>
                   <span class="badge text-bg-info">Uses default endpoint</span>
                 <% end %>
+                <% if profile.key != 'default' && profile.model.to_s.strip.blank? && profile.effective_model.present? %>
+                  <span class="badge text-bg-info">Uses default model</span>
+                <% end %>
               </div>
               <div class="text-muted small">
                 <div><span class="text-secondary">Key:</span> <code><%= profile.key %></code></div>
@@ -30,9 +33,7 @@
                 <% else %>
                   <div class="mt-1"><span class="text-secondary">Endpoint:</span> —</div>
                 <% end %>
-                <% if profile.model.present? %>
-                  <div class="mt-1"><span class="text-secondary">Model:</span> <%= profile.model %></div>
-                <% end %>
+                <div class="mt-1"><span class="text-secondary">Model:</span> <%= profile.effective_model.presence || '—' %></div>
                 <% if profile.last_health_check_at.present? %>
                   <div class="mt-1"><span class="text-secondary">Last check:</span> <%= l(profile.last_health_check_at, format: :short) %></div>
                 <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -45,7 +45,7 @@
         <div class="card-body">
           <div class="d-flex flex-wrap justify-content-center gap-3 mb-3">
             <%= link_to onboard_path, class: "btn btn-primary btn-lg" do %>
-              <i class="bi bi-person-badge me-2"></i>Onboard New Member
+              <i class="bi bi-person-badge me-2"></i>Create New Member
             <% end %>
             <%= link_to new_invitation_path, class: "btn btn-info btn-lg" do %>
               <i class="bi bi-envelope-plus me-2"></i>Send Invitation

--- a/app/views/membership_applications/show.html.erb
+++ b/app/views/membership_applications/show.html.erb
@@ -50,7 +50,7 @@
           </div>
 
           <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-0">
-            <dt>Linked member</dt>
+            <dt>Linked Member</dt>
             <dd class="mb-0 d-flex flex-wrap align-items-center gap-2">
               <% if @application.user %>
                 <%= link_to @application.user.display_name, user_path(@application.user), class: "text-decoration-none" %>
@@ -75,14 +75,14 @@
         <dl>
           <% if @application.reviewed_by.present? %>
             <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
-              <dt>Reviewed by</dt>
+              <dt>Reviewed By</dt>
               <dd class="mb-0"><%= link_to @application.reviewed_by.display_name, user_path(@application.reviewed_by) %></dd>
             </div>
           <% end %>
 
           <% if @application.reviewed_at.present? %>
             <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
-              <dt>Reviewed on</dt>
+              <dt>Reviewed On</dt>
               <dd class="mb-0"><%= @application.reviewed_at.strftime('%B %d, %Y at %l:%M %p') %></dd>
             </div>
           <% end %>
@@ -117,30 +117,32 @@
   <% questions = entry[:questions] %>
   <div class="card shadow-sm border-0 mb-3">
     <div class="card-header bg-body-secondary">
-      <h5 class="mb-0"><%= page.title %></h5>
+      <h5 class="mb-0"><%= page.title.to_s.titleize %></h5>
       <% if page.description.present? %>
         <small class="text-body-secondary"><%= page.description %></small>
       <% end %>
     </div>
     <div class="card-body">
-      <% questions.each do |qa| %>
-        <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
-          <div class="text-muted small fw-semibold mb-1"><%= qa[:question].label %></div>
-          <div class="mb-0">
-            <% if qa[:answer]&.value.present? %>
-              <% if membership_application_sensitive_answer_label?(qa[:question].label) %>
-                <%= membership_application_masked_contact_capture do %>
+      <div class="rounded border border-secondary-subtle bg-body-tertiary p-3">
+        <% questions.each_with_index do |qa, idx| %>
+          <div class="<%= 'border-bottom border-secondary-subtle pb-3 mb-3' if idx < questions.length - 1 %>">
+            <div class="text-muted small fw-semibold mb-1"><%= qa[:question].label.to_s.titleize %></div>
+            <div class="mb-0">
+              <% if qa[:answer]&.value.present? %>
+                <% if membership_application_sensitive_answer_label?(qa[:question].label) %>
+                  <%= membership_application_masked_contact_capture do %>
+                    <%= simple_format(qa[:answer].value) %>
+                  <% end %>
+                <% else %>
                   <%= simple_format(qa[:answer].value) %>
                 <% end %>
               <% else %>
-                <%= simple_format(qa[:answer].value) %>
+                <span class="text-muted fst-italic">No answer</span>
               <% end %>
-            <% else %>
-              <span class="text-muted fst-italic">No answer</span>
-            <% end %>
+            </div>
           </div>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
   </div>
 <% end %>
@@ -152,7 +154,7 @@
 <% unless @application.approved? || @application.rejected? %>
   <div id="review-section" class="card shadow-sm border-0 mb-4">
     <div class="card-header bg-body-secondary">
-      <h5 class="mb-0">Final decision</h5>
+      <h5 class="mb-0">Final Decision</h5>
     </div>
     <div class="card-body">
       <% if true_user.can_finalize_membership_application? %>

--- a/app/views/queued_mails/edit.html.erb
+++ b/app/views/queued_mails/edit.html.erb
@@ -12,7 +12,14 @@
 
 <div class="card shadow-sm border-0 mb-4">
   <div class="card-body">
-    <%= form_with(model: @queued_mail, class: "needs-validation") do |f| %>
+    <%= form_with(
+          model: @queued_mail,
+          class: "needs-validation",
+          data: {
+            controller: "queued-mail-rewrite",
+            queued_mail_rewrite_url_value: rewrite_with_ai_queued_mail_path(@queued_mail)
+          }
+        ) do |f| %>
       <div class="mb-3">
         <%= f.label :to, "Recipient Email", class: "form-label" %>
         <%= f.text_field :to, class: "form-control #{'is-invalid' if @queued_mail.errors.key?(:to)}", required: true %>
@@ -23,7 +30,10 @@
 
       <div class="mb-3">
         <%= f.label :subject, class: "form-label" %>
-        <%= f.text_field :subject, class: "form-control #{'is-invalid' if @queued_mail.errors.key?(:subject)}", required: true %>
+        <%= f.text_field :subject,
+            class: "form-control #{'is-invalid' if @queued_mail.errors.key?(:subject)}",
+            required: true,
+            data: { queued_mail_rewrite_target: "subject" } %>
         <% if @queued_mail.errors.key?(:subject) %>
           <div class="invalid-feedback"><%= @queued_mail.errors[:subject].join(', ') %></div>
         <% end %>
@@ -34,7 +44,11 @@
         <div class="mb-2">
           <small class="text-muted">Use the toolbar to format, or click "Source Code" (&lt;&gt;) to edit raw HTML.</small>
         </div>
-        <%= f.text_area :body_html, class: "form-control #{'is-invalid' if @queued_mail.errors.key?(:body_html)}", rows: 16, required: true, data: { rich_editor_target: "editor" } %>
+        <%= f.text_area :body_html,
+            class: "form-control #{'is-invalid' if @queued_mail.errors.key?(:body_html)}",
+            rows: 16,
+            required: true,
+            data: { rich_editor_target: "editor", queued_mail_rewrite_target: "bodyHtml" } %>
         <% if @queued_mail.errors.key?(:body_html) %>
           <div class="invalid-feedback"><%= @queued_mail.errors[:body_html].join(', ') %></div>
         <% end %>
@@ -43,8 +57,32 @@
 
       <div class="mb-3">
         <%= f.label :body_text, "Plain Text Body", class: "form-label" %>
-        <%= f.text_area :body_text, class: "form-control font-monospace", rows: 10 %>
+        <%= f.text_area :body_text,
+            class: "form-control font-monospace",
+            rows: 10,
+            data: { queued_mail_rewrite_target: "bodyText" } %>
         <div class="form-text">Optional plain text alternative for email clients that don't support HTML.</div>
+      </div>
+
+      <div class="mb-3 border rounded bg-body-tertiary p-3">
+        <div class="d-flex flex-wrap gap-2 align-items-center">
+          <button type="button"
+                  class="btn btn-outline-primary"
+                  data-action="queued-mail-rewrite#rewrite"
+                  data-queued-mail-rewrite-target="rewriteButton">
+            Rewrite With AI
+            <span class="spinner-border spinner-border-sm ms-2 d-none" role="status" aria-hidden="true"
+                  data-queued-mail-rewrite-target="spinner"></span>
+          </button>
+          <button type="button"
+                  class="btn btn-outline-secondary d-none"
+                  data-action="queued-mail-rewrite#undo"
+                  data-queued-mail-rewrite-target="undoButton">
+            Undo AI Rewrite
+          </button>
+          <span class="small text-muted"
+                data-queued-mail-rewrite-target="status">Rewrites both HTML and plain text body in place.</span>
+        </div>
       </div>
 
       <div class="d-flex gap-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,6 +290,7 @@ Rails.application.routes.draw do
       post :approve
       post :reject
       post :regenerate
+      post :rewrite_with_ai
       post :retry_delivery, as: :retry
     end
     collection do

--- a/db/migrate/20260411113000_add_email_rewriting_ai_profile.rb
+++ b/db/migrate/20260411113000_add_email_rewriting_ai_profile.rb
@@ -1,0 +1,10 @@
+class AddEmailRewritingAiProfile < ActiveRecord::Migration[8.1]
+  def up
+    AiOllamaProfile.reset_column_information
+    AiOllamaProfile.seed_defaults!
+  end
+
+  def down
+    AiOllamaProfile.where(key: 'email_rewriting').delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_11_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_11_113000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/test/controllers/queued_mails_controller_test.rb
+++ b/test/controllers/queued_mails_controller_test.rb
@@ -131,6 +131,50 @@ class QueuedMailsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to queued_mail_path(@approved)
   end
 
+  test 'rewrite_with_ai rewrites body in place for pending mail' do
+    ai_ollama_profiles(:default).update!(base_url: 'http://ollama.test:11434', model: 'llama3.2')
+    ai_ollama_profiles(:email_rewriting).update!(enabled: true, base_url: '', model: '', prompt: 'Rewrite this email.')
+
+    response_json = {
+      body_html: '<p>Rewritten HTML</p>',
+      body_text: 'Rewritten text'
+    }
+    stub_result = Ollama::ChatCompletion::Result.new(true, JSON.generate(response_json), nil)
+
+    original_call = Ollama::ChatCompletion.method(:call)
+    Ollama::ChatCompletion.define_singleton_method(:call) { |**_kwargs| stub_result }
+    begin
+      post rewrite_with_ai_queued_mail_path(@pending), params: {
+        rewrite: {
+          subject: @pending.subject,
+          body_html: @pending.body_html,
+          body_text: @pending.body_text
+        }
+      }, as: :json
+    ensure
+      Ollama::ChatCompletion.define_singleton_method(:call, original_call)
+    end
+
+    assert_response :success
+    parsed = response.parsed_body
+    assert_equal '<p>Rewritten HTML</p>', parsed['body_html']
+    assert_equal 'Rewritten text', parsed['body_text']
+  end
+
+  test 'rewrite_with_ai rejects non-pending mail' do
+    post rewrite_with_ai_queued_mail_path(@approved), params: {
+      rewrite: {
+        subject: @approved.subject,
+        body_html: @approved.body_html,
+        body_text: @approved.body_text
+      }
+    }, as: :json
+
+    assert_response :unprocessable_content
+    parsed = response.parsed_body
+    assert_match(/Only pending messages/, parsed['error'])
+  end
+
   # ─── Admin access required ────────────────────────────────────────
 
   test 'non-admin cannot access queue' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -59,6 +59,19 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Authentik source is disabled.', flash[:alert]
   end
 
+  test 'create with duplicate email shows link to existing member profile' do
+    post users_path, params: {
+      user: {
+        full_name: 'Duplicate Email Test',
+        email: @user.email
+      }
+    }
+
+    assert_response :unprocessable_content
+    assert_select '.alert', text: /Unable to create member: email is already in use by/
+    assert_select ".alert a[href='#{user_path(@user)}']", text: @user.display_name
+  end
+
   private
 
   def sign_in_as_local_admin

--- a/test/fixtures/ai_ollama_profiles.yml
+++ b/test/fixtures/ai_ollama_profiles.yml
@@ -29,3 +29,13 @@ recommendation_engine:
   enabled: true
   health_status: not_configured
   display_order: 2
+
+email_rewriting:
+  key: email_rewriting
+  name: Email Rewriting
+  base_url:
+  model:
+  prompt: ""
+  enabled: true
+  health_status: not_configured
+  display_order: 3


### PR DESCRIPTION
Introduce queued mail rewrite controls with spinner and undo, add a rewrite endpoint backed by a dedicated Email Rewriting AI profile with default endpoint/model fallback, and improve related admin messaging and tests.

Made-with: Cursor