### PR TITLE
Add AI rewrite workflow to email template editing.

### DIFF
--- a/app/controllers/email_templates_controller.rb
+++ b/app/controllers/email_templates_controller.rb
@@ -1,6 +1,6 @@
 class EmailTemplatesController < AdminController
   before_action :set_email_template,
-                only: %i[show edit update preview toggle mark_reviewed mark_needs_review]
+                only: %i[show edit update preview toggle mark_reviewed mark_needs_review rewrite_with_ai]
 
   def index
     @email_templates = EmailTemplate.ordered
@@ -78,6 +78,26 @@ class EmailTemplatesController < AdminController
     end
   end
 
+  def rewrite_with_ai
+    attrs = rewrite_params
+    result = EmailTemplates::RewriteWithAi.call(
+      subject: attrs[:subject],
+      body_html: attrs[:body_html],
+      body_text: attrs[:body_text]
+    )
+
+    if result.success?
+      render json: {
+        subject: result.subject,
+        body_html: result.body_html,
+        body_text: result.body_text,
+        message: result.message
+      }
+    else
+      render json: { error: result.message }, status: :unprocessable_content
+    end
+  end
+
   private
 
   def set_email_template
@@ -86,6 +106,10 @@ class EmailTemplatesController < AdminController
 
   def email_template_params
     params.expect(email_template: %i[name description subject body_html body_text enabled])
+  end
+
+  def rewrite_params
+    params.expect(rewrite: %i[subject body_html body_text])
   end
 
   def build_variables_for_user(user, extra = {})

--- a/app/javascript/controllers/email_template_rewrite_controller.js
+++ b/app/javascript/controllers/email_template_rewrite_controller.js
@@ -1,0 +1,115 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["subject", "bodyHtml", "bodyText", "rewriteButton", "undoButton", "spinner", "status"]
+  static values = { url: String }
+
+  connect() {
+    this.previousState = null
+    this.loading = false
+  }
+
+  async rewrite(event) {
+    event.preventDefault()
+    if (this.loading) return
+
+    this.previousState = {
+      subject: this.subjectTarget.value,
+      bodyHtml: this.currentHtmlBody(),
+      bodyText: this.bodyTextTarget.value
+    }
+    this.toggleUndo(true)
+    this.setStatus("", "")
+    this.setLoading(true)
+
+    try {
+      const response = await fetch(this.urlValue, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+          "X-CSRF-Token": this.csrfToken()
+        },
+        body: JSON.stringify({
+          rewrite: {
+            subject: this.subjectTarget.value,
+            body_html: this.currentHtmlBody(),
+            body_text: this.bodyTextTarget.value
+          }
+        })
+      })
+
+      const payload = await response.json()
+      if (!response.ok) {
+        this.setStatus(payload.error || "Rewrite failed.", "danger")
+        return
+      }
+
+      this.subjectTarget.value = payload.subject || ""
+      this.setHtmlBody(payload.body_html || "")
+      this.bodyTextTarget.value = payload.body_text || ""
+      this.setStatus(payload.message || "Template rewritten.", "success")
+    } catch (_error) {
+      this.setStatus("Rewrite failed. Please try again.", "danger")
+    } finally {
+      this.setLoading(false)
+    }
+  }
+
+  undo(event) {
+    event.preventDefault()
+    if (!this.previousState) return
+
+    this.subjectTarget.value = this.previousState.subject
+    this.setHtmlBody(this.previousState.bodyHtml)
+    this.bodyTextTarget.value = this.previousState.bodyText
+    this.previousState = null
+    this.toggleUndo(false)
+    this.setStatus("Restored previous template text.", "secondary")
+  }
+
+  setLoading(isLoading) {
+    this.loading = isLoading
+    this.rewriteButtonTarget.disabled = isLoading
+    this.spinnerTarget.classList.toggle("d-none", !isLoading)
+  }
+
+  setStatus(message, variant) {
+    this.statusTarget.textContent = message
+    this.statusTarget.className = "small"
+    if (message && variant) {
+      this.statusTarget.classList.add(`text-${variant}`)
+    } else {
+      this.statusTarget.classList.add("text-muted")
+    }
+  }
+
+  toggleUndo(show) {
+    this.undoButtonTarget.classList.toggle("d-none", !show)
+    this.undoButtonTarget.disabled = !show
+  }
+
+  currentHtmlBody() {
+    const editor = this.editorInstance()
+    return editor ? editor.getContent() : this.bodyHtmlTarget.value
+  }
+
+  setHtmlBody(value) {
+    const editor = this.editorInstance()
+    this.bodyHtmlTarget.value = value
+    if (editor) {
+      editor.setContent(value)
+      editor.save()
+    }
+  }
+
+  editorInstance() {
+    if (typeof tinymce === "undefined") return null
+    return tinymce.get(this.bodyHtmlTarget.id)
+  }
+
+  csrfToken() {
+    const tag = document.querySelector("meta[name='csrf-token']")
+    return tag ? tag.content : ""
+  }
+}

--- a/app/services/email_templates/rewrite_with_ai.rb
+++ b/app/services/email_templates/rewrite_with_ai.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module EmailTemplates
+  class RewriteWithAi
+    JSON_INSTRUCTION = <<~TXT.squish
+      Respond with a single JSON object only (no markdown fences), using exactly these keys:
+      "subject" (string),
+      "body_html" (string),
+      "body_text" (string).
+      Keep placeholders/template tokens unchanged.
+    TXT
+
+    Result = Struct.new(:status, :message, :subject, :body_html, :body_text) do
+      def success?
+        status == :success
+      end
+    end
+
+    def self.call(subject:, body_html:, body_text:)
+      new(subject: subject, body_html: body_html, body_text: body_text).call
+    end
+
+    def initialize(subject:, body_html:, body_text:)
+      @subject = subject.to_s
+      @body_html = body_html.to_s
+      @body_text = body_text.to_s
+    end
+
+    def call
+      profile = AiOllamaProfile.find_by(key: 'email_rewriting')
+      return Result.new(:failure, 'Email Rewriting AI profile is disabled.') unless profile&.enabled?
+
+      base_url = profile.effective_base_url
+      model = profile.effective_model
+      return Result.new(:failure, 'Email Rewriting AI profile is not configured.') if base_url.blank? || model.blank?
+
+      system_prompt = [profile.prompt.to_s.strip, JSON_INSTRUCTION].compact_blank.join("\n\n")
+      completion = Ollama::ChatCompletion.call(
+        base_url: base_url,
+        model: model,
+        system: system_prompt,
+        user: build_user_prompt,
+        format_json: true
+      )
+      return Result.new(:failure, completion.error.presence || 'Rewrite failed.') unless completion.ok
+
+      parsed = parse_json(completion.assistant_content)
+      return Result.new(:failure, 'AI response was not valid JSON.') unless parsed
+
+      Result.new(:success, 'Template rewritten.', parsed[:subject], parsed[:body_html], parsed[:body_text])
+    rescue StandardError => e
+      Result.new(:failure, "Rewrite failed: #{e.message}")
+    end
+
+    private
+
+    def build_user_prompt
+      <<~PROMPT
+        Rewrite this email template.
+
+        Subject:
+        #{@subject}
+
+        Current HTML body:
+        #{@body_html}
+
+        Current plain text body:
+        #{@body_text}
+      PROMPT
+    end
+
+    def parse_json(raw)
+      json = JSON.parse(raw.to_s)
+      return nil unless json.is_a?(Hash)
+
+      {
+        subject: json['subject'].to_s,
+        body_html: json['body_html'].to_s,
+        body_text: json['body_text'].to_s
+      }
+    rescue JSON::ParserError
+      nil
+    end
+  end
+end

--- a/app/views/email_templates/edit.html.erb
+++ b/app/views/email_templates/edit.html.erb
@@ -13,7 +13,12 @@
   <div class="col-lg-8">
     <div class="card shadow-sm border-0">
       <div class="card-body">
-        <%= form_with model: @email_template, local: true do |f| %>
+        <%= form_with model: @email_template,
+                      local: true,
+                      data: {
+                        controller: "email-template-rewrite",
+                        email_template_rewrite_url_value: rewrite_with_ai_email_template_path(@email_template)
+                      } do |f| %>
           <% if @email_template.errors.any? %>
             <div class="alert alert-danger">
               <h5 class="alert-heading">Please fix the following errors:</h5>
@@ -38,7 +43,7 @@
 
           <div class="mb-3">
             <%= f.label :subject, class: "form-label" %>
-            <%= f.text_field :subject, class: "form-control" %>
+            <%= f.text_field :subject, class: "form-control", data: { email_template_rewrite_target: "subject" } %>
             <div class="form-text">You can use template variables like <code>{{member_name}}</code> and <code>{{organization_name}}</code>.</div>
           </div>
 
@@ -48,14 +53,39 @@
             <div class="d-flex justify-content-between align-items-center mb-2">
               <small class="text-muted">Use the toolbar to format, or click "Source Code" (&lt;&gt;) to edit raw HTML.</small>
             </div>
-            <%= f.text_area :body_html, class: "form-control", rows: 15, data: { rich_editor_target: "editor" } %>
+            <%= f.text_area :body_html,
+                            class: "form-control",
+                            rows: 15,
+                            data: { rich_editor_target: "editor", email_template_rewrite_target: "bodyHtml" } %>
             <div class="form-text">HTML content for email clients that support it. Use "Insert Variable" to add template variables.</div>
           </div>
 
           <div class="mb-3">
             <%= f.label :body_text, "Plain Text Body", class: "form-label" %>
-            <%= f.text_area :body_text, class: "form-control font-monospace", rows: 10 %>
+            <%= f.text_area :body_text, class: "form-control font-monospace", rows: 10,
+                                           data: { email_template_rewrite_target: "bodyText" } %>
             <div class="form-text">Plain text version for email clients that don't support HTML.</div>
+          </div>
+
+          <div class="mb-3 border rounded bg-body-tertiary p-3">
+            <div class="d-flex flex-wrap gap-2 align-items-center">
+              <button type="button"
+                      class="btn btn-outline-primary"
+                      data-action="email-template-rewrite#rewrite"
+                      data-email-template-rewrite-target="rewriteButton">
+                Rewrite With AI
+                <span class="spinner-border spinner-border-sm ms-2 d-none" role="status" aria-hidden="true"
+                      data-email-template-rewrite-target="spinner"></span>
+              </button>
+              <button type="button"
+                      class="btn btn-outline-secondary d-none"
+                      data-action="email-template-rewrite#undo"
+                      data-email-template-rewrite-target="undoButton">
+                Undo AI Rewrite
+              </button>
+              <span class="small text-muted"
+                    data-email-template-rewrite-target="status">Rewrites subject, HTML body, and plain text in place.</span>
+            </div>
           </div>
 
           <div class="mb-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -275,6 +275,7 @@ Rails.application.routes.draw do
       get :preview
       post :toggle
       post :test_send
+      post :rewrite_with_ai
       post :mark_reviewed
       post :mark_needs_review
     end

--- a/test/controllers/email_templates_controller_test.rb
+++ b/test/controllers/email_templates_controller_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+    sign_in_as_admin
+    @template = EmailTemplate.create!(
+      key: 'rewrite_test_template',
+      name: 'Rewrite Test Template',
+      subject: 'Initial Subject',
+      body_html: '<p>Initial HTML</p>',
+      body_text: 'Initial text',
+      enabled: true
+    )
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+  end
+
+  test 'rewrite_with_ai rewrites subject and body' do
+    ai_ollama_profiles(:default).update!(base_url: 'http://ollama.test:11434', model: 'llama3.2')
+    ai_ollama_profiles(:email_rewriting).update!(enabled: true, base_url: '', model: '', prompt: 'Rewrite template.')
+
+    response_json = {
+      subject: 'Improved Subject',
+      body_html: '<p>Improved HTML</p>',
+      body_text: 'Improved text'
+    }
+    stub_result = Ollama::ChatCompletion::Result.new(true, JSON.generate(response_json), nil)
+
+    original_call = Ollama::ChatCompletion.method(:call)
+    Ollama::ChatCompletion.define_singleton_method(:call) { |**_kwargs| stub_result }
+    begin
+      post rewrite_with_ai_email_template_path(@template), params: {
+        rewrite: {
+          subject: @template.subject,
+          body_html: @template.body_html,
+          body_text: @template.body_text
+        }
+      }, as: :json
+    ensure
+      Ollama::ChatCompletion.define_singleton_method(:call, original_call)
+    end
+
+    assert_response :success
+    parsed = response.parsed_body
+    assert_equal 'Improved Subject', parsed['subject']
+    assert_equal '<p>Improved HTML</p>', parsed['body_html']
+    assert_equal 'Improved text', parsed['body_text']
+  end
+
+  private
+
+  def sign_in_as_admin
+    account = local_accounts(:active_admin)
+    post local_login_path, params: {
+      session: {
+        email: account.email,
+        password: 'localpassword123'
+      }
+    }
+  end
+end


### PR DESCRIPTION
Allow admins to rewrite template subject/body in place with spinner and undo controls, backed by a new rewrite endpoint and shared Email Rewriting AI profile behavior.

Made-with: Cursor