### PR TITLE
Add member training request workflow with trainer response tools.

### DIFF
--- a/app/controllers/training_requests_controller.rb
+++ b/app/controllers/training_requests_controller.rb
@@ -2,6 +2,10 @@ class TrainingRequestsController < AuthenticatedController
   before_action :set_training_request, only: %i[edit update]
   before_action :authorize_responder!, only: %i[edit update]
 
+  def edit
+    @requester = @training_request.user
+  end
+
   def create
     topic = TrainingTopic.available_for_member_requests.find_by(id: training_request_params[:training_topic_id])
     if topic.nil?
@@ -25,10 +29,6 @@ class TrainingRequestsController < AuthenticatedController
     else
       redirect_to user_path(current_user), alert: request.errors.full_messages.to_sentence
     end
-  end
-
-  def edit
-    @requester = @training_request.user
   end
 
   def update
@@ -61,7 +61,9 @@ class TrainingRequestsController < AuthenticatedController
 
   def authorize_responder!
     return if current_user_admin?
-    return if @training_request.pending? && current_user.training_topics.exists?(id: @training_request.training_topic_id)
+    if @training_request.pending? && current_user.training_topics.exists?(id: @training_request.training_topic_id)
+      return
+    end
 
     redirect_to user_path(current_user), alert: 'You are not allowed to respond to that request.'
   end
@@ -73,17 +75,8 @@ class TrainingRequestsController < AuthenticatedController
   def queue_training_request_emails!(request)
     topic = request.training_topic
     requester = request.user
-    trainer_names = topic.trainers.order(:full_name, :email).map(&:display_name).join(', ')
-
-    requester_args = {
-      training_topic: topic.name,
-      requester_name: requester.display_name,
-      requester_email: requester.email.to_s,
-      requester_slack: requester.slack_handle.to_s,
-      share_contact_info: request.share_contact_info,
-      recipient_role: 'member',
-      trainer_names: trainer_names
-    }
+    trainer_names = trainer_display_names_for(topic)
+    requester_args = training_request_mail_args(request, recipient_role: 'member', trainer_names: trainer_names)
 
     QueuedMail.enqueue(
       :training_requested,
@@ -93,21 +86,35 @@ class TrainingRequestsController < AuthenticatedController
     )
 
     topic.trainers.find_each do |trainer|
-      next if trainer.email.blank?
-
-      QueuedMail.enqueue(
-        :training_requested,
-        trainer,
-        to: trainer.email,
-        reason: "Training request notification for #{topic.name}",
-        training_topic: topic.name,
-        requester_name: requester.display_name,
-        requester_email: requester.email.to_s,
-        requester_slack: requester.slack_handle.to_s,
-        share_contact_info: request.share_contact_info,
-        recipient_role: 'trainer',
-        trainer_names: trainer_names
-      )
+      enqueue_trainer_training_request_mail(request, trainer, trainer_names: trainer_names)
     end
+  end
+
+  def trainer_display_names_for(topic)
+    topic.trainers.order(:full_name, :email).map(&:display_name).join(', ')
+  end
+
+  def training_request_mail_args(request, recipient_role:, trainer_names:)
+    {
+      training_topic: request.training_topic.name,
+      requester_name: request.user.display_name,
+      requester_email: request.user.email.to_s,
+      requester_slack: request.user.slack_handle.to_s,
+      share_contact_info: request.share_contact_info,
+      recipient_role: recipient_role,
+      trainer_names: trainer_names
+    }
+  end
+
+  def enqueue_trainer_training_request_mail(request, trainer, trainer_names:)
+    return if trainer.email.blank?
+
+    QueuedMail.enqueue(
+      :training_requested,
+      trainer,
+      to: trainer.email,
+      reason: "Training request notification for #{request.training_topic.name}",
+      **training_request_mail_args(request, recipient_role: 'trainer', trainer_names: trainer_names)
+    )
   end
 end

--- a/app/controllers/training_requests_controller.rb
+++ b/app/controllers/training_requests_controller.rb
@@ -1,0 +1,113 @@
+class TrainingRequestsController < AuthenticatedController
+  before_action :set_training_request, only: %i[edit update]
+  before_action :authorize_responder!, only: %i[edit update]
+
+  def create
+    topic = TrainingTopic.available_for_member_requests.find_by(id: training_request_params[:training_topic_id])
+    if topic.nil?
+      redirect_to user_path(current_user), alert: 'Please select a valid training topic.'
+      return
+    end
+
+    if training_request_params[:share_contact_info] != '1'
+      redirect_to user_path(current_user), alert: 'Please confirm contact sharing to submit your request.'
+      return
+    end
+
+    request = current_user.training_requests.build(
+      training_topic: topic,
+      share_contact_info: true
+    )
+
+    if request.save
+      queue_training_request_emails!(request)
+      redirect_to user_path(current_user), notice: "Your training request for #{topic.name} has been sent."
+    else
+      redirect_to user_path(current_user), alert: request.errors.full_messages.to_sentence
+    end
+  end
+
+  def edit
+    @requester = @training_request.user
+  end
+
+  def update
+    body = params[:training_request][:response_body].to_s.strip
+    if body.blank?
+      redirect_to edit_training_request_path(@training_request), alert: 'Response message cannot be blank.'
+      return
+    end
+
+    message = current_user.sent_messages.build(
+      recipient: @training_request.user,
+      subject: "Training request response: #{@training_request.training_topic.name}",
+      body: body
+    )
+
+    if message.save
+      MemberMailer.message_received(message).deliver_later
+      @training_request.respond!(current_user)
+      redirect_to user_path(current_user), notice: 'Response sent to member.'
+    else
+      redirect_to edit_training_request_path(@training_request), alert: message.errors.full_messages.to_sentence
+    end
+  end
+
+  private
+
+  def set_training_request
+    @training_request = TrainingRequest.find(params[:id])
+  end
+
+  def authorize_responder!
+    return if current_user_admin?
+    return if @training_request.pending? && current_user.training_topics.exists?(id: @training_request.training_topic_id)
+
+    redirect_to user_path(current_user), alert: 'You are not allowed to respond to that request.'
+  end
+
+  def training_request_params
+    params.expect(training_request: %i[training_topic_id share_contact_info])
+  end
+
+  def queue_training_request_emails!(request)
+    topic = request.training_topic
+    requester = request.user
+    trainer_names = topic.trainers.order(:full_name, :email).map(&:display_name).join(', ')
+
+    requester_args = {
+      training_topic: topic.name,
+      requester_name: requester.display_name,
+      requester_email: requester.email.to_s,
+      requester_slack: requester.slack_handle.to_s,
+      share_contact_info: request.share_contact_info,
+      recipient_role: 'member',
+      trainer_names: trainer_names
+    }
+
+    QueuedMail.enqueue(
+      :training_requested,
+      requester,
+      reason: "Training requested for #{topic.name}",
+      **requester_args
+    )
+
+    topic.trainers.find_each do |trainer|
+      next if trainer.email.blank?
+
+      QueuedMail.enqueue(
+        :training_requested,
+        trainer,
+        to: trainer.email,
+        reason: "Training request notification for #{topic.name}",
+        training_topic: topic.name,
+        requester_name: requester.display_name,
+        requester_email: requester.email.to_s,
+        requester_slack: requester.slack_handle.to_s,
+        share_contact_info: request.share_contact_info,
+        recipient_role: 'trainer',
+        trainer_names: trainer_names
+      )
+    end
+  end
+end

--- a/app/controllers/training_topics_controller.rb
+++ b/app/controllers/training_topics_controller.rb
@@ -99,6 +99,6 @@ class TrainingTopicsController < AuthenticatedController
   end
 
   def training_topic_params
-    params.expect(training_topic: [:name])
+    params.expect(training_topic: %i[name offered_to_members])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -582,12 +582,13 @@ class UsersController < AuthenticatedController
     @member_requestable_topics = TrainingTopic.available_for_member_requests
 
     trainer_topic_ids = current_user.training_topics.select(:id)
+    ordering = 'training_topics.name ASC, training_requests.created_at DESC'
     @trainer_training_requests_by_topic = TrainingRequest.pending
-                                                       .where(training_topic_id: trainer_topic_ids)
-                                                       .joins(:training_topic)
-                                                       .includes(:training_topic, :user)
-                                                       .order('training_topics.name ASC, training_requests.created_at DESC')
-                                                       .group_by(&:training_topic)
+                                                         .where(training_topic_id: trainer_topic_ids)
+                                                         .joins(:training_topic)
+                                                         .includes(:training_topic, :user)
+                                                         .order(ordering)
+                                                         .group_by(&:training_topic)
   end
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -182,6 +182,8 @@ class UsersController < AuthenticatedController
       end
     end
 
+    set_self_service_training_data if @view_level == :self
+
     # Load payment history for admin and self views (paginated)
     if @view_level == :admin || @view_level == :self
       @payment_event_filter = params[:event_type].presence
@@ -574,6 +576,18 @@ class UsersController < AuthenticatedController
       admin: 'Admin'
     }.freeze
     @available_views = allowed_preview_views.map { |level| [view_labels[level], level] }
+  end
+
+  def set_self_service_training_data
+    @member_requestable_topics = TrainingTopic.available_for_member_requests
+
+    trainer_topic_ids = current_user.training_topics.select(:id)
+    @trainer_training_requests_by_topic = TrainingRequest.pending
+                                                       .where(training_topic_id: trainer_topic_ids)
+                                                       .joins(:training_topic)
+                                                       .includes(:training_topic, :user)
+                                                       .order('training_topics.name ASC, training_requests.created_at DESC')
+                                                       .group_by(&:training_topic)
   end
 
   def user_params

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -156,35 +156,9 @@ class MemberMailer < ApplicationMailer
   end
 
   def training_requested(user, opts = {})
-    @user = user
-    @organization = organization_name
-    @training_topic = opts[:training_topic] || opts['training_topic']
-    @requester_name = opts[:requester_name] || opts['requester_name'] || @user.display_name
-    @requester_email = opts[:requester_email] || opts['requester_email'] || @user.email.to_s
-    @requester_slack = opts[:requester_slack] || opts['requester_slack'] || @user.slack_handle.to_s
-    @share_contact_info = ActiveModel::Type::Boolean.new.cast(opts[:share_contact_info] || opts['share_contact_info'])
-    @recipient_role = opts[:recipient_role] || opts['recipient_role'] || 'trainer'
-    @trainer_names = opts[:trainer_names] || opts['trainer_names'] || ''
-
-    contact_block = if @share_contact_info
-                      [
-                        ('Email: ' + @requester_email if @requester_email.present?),
-                        ('Slack: ' + @requester_slack if @requester_slack.present?)
-                      ].compact.join('<br>')
-                    else
-                      'The member did not consent to sharing contact details.'
-                    end
-
-    extra_vars = {
-      training_topic: @training_topic,
-      requester_name: @requester_name,
-      requester_email: @requester_email,
-      requester_slack: @requester_slack,
-      recipient_role: @recipient_role,
-      trainer_names: @trainer_names,
-      contact_details: contact_block
-    }
-    to_address = opts[:to] || opts['to'] || @user.email
+    assign_training_requested_instance_vars(user, opts)
+    extra_vars = training_requested_template_vars
+    to_address = training_requested_to_address(user, opts)
 
     if send_from_template('training_requested', user, extra_vars, to: to_address)
       # Email sent from database template
@@ -351,14 +325,17 @@ class MemberMailer < ApplicationMailer
                     end
     vars[:training_topic] = extra_args[:training_topic] if extra_args[:training_topic].present?
     vars[:application_url] = extra_args[:application_url].to_s if extra_args.key?(:application_url)
+    merge_training_request_template_keys!(vars, extra_args)
+    merge_parking_notice_template_keys!(vars, extra_args)
+  end
+
+  def self.merge_training_request_template_keys!(vars, extra_args)
     vars[:requester_name] = extra_args[:requester_name].to_s if extra_args.key?(:requester_name)
     vars[:requester_email] = extra_args[:requester_email].to_s if extra_args.key?(:requester_email)
     vars[:requester_slack] = extra_args[:requester_slack].to_s if extra_args.key?(:requester_slack)
     vars[:recipient_role] = extra_args[:recipient_role].to_s if extra_args.key?(:recipient_role)
     vars[:trainer_names] = extra_args[:trainer_names].to_s if extra_args.key?(:trainer_names)
     vars[:contact_details] = extra_args[:contact_details].to_s if extra_args.key?(:contact_details)
-
-    merge_parking_notice_template_keys!(vars, extra_args)
   end
 
   def self.merge_parking_notice_template_keys!(vars, extra_args)
@@ -370,10 +347,54 @@ class MemberMailer < ApplicationMailer
   end
 
   class << self
-    private :base_template_variables, :merge_template_extras!, :merge_parking_notice_template_keys!
+    private :base_template_variables, :merge_template_extras!, :merge_training_request_template_keys!,
+            :merge_parking_notice_template_keys!
   end
 
   private
+
+  def assign_training_requested_instance_vars(user, opts)
+    normalized = normalize_training_requested_opts(opts)
+    @user = user
+    @organization = organization_name
+    @training_topic = normalized[:training_topic]
+    @requester_name = normalized[:requester_name] || @user.display_name
+    @requester_email = normalized[:requester_email] || @user.email.to_s
+    @requester_slack = normalized[:requester_slack] || @user.slack_handle.to_s
+    @share_contact_info = ActiveModel::Type::Boolean.new.cast(normalized[:share_contact_info])
+    @recipient_role = normalized[:recipient_role] || 'trainer'
+    @trainer_names = normalized[:trainer_names] || ''
+  end
+
+  def training_requested_template_vars
+    {
+      training_topic: @training_topic,
+      requester_name: @requester_name,
+      requester_email: @requester_email,
+      requester_slack: @requester_slack,
+      recipient_role: @recipient_role,
+      trainer_names: @trainer_names,
+      contact_details: training_requested_contact_block
+    }
+  end
+
+  def training_requested_contact_block
+    return 'The member did not consent to sharing contact details.' unless @share_contact_info
+
+    [
+      ("Email: #{@requester_email}" if @requester_email.present?),
+      ("Slack: #{@requester_slack}" if @requester_slack.present?)
+    ].compact.join('<br>')
+  end
+
+  def training_requested_to_address(user, opts)
+    normalized = normalize_training_requested_opts(opts)
+    normalized[:to] || user.email
+  end
+
+  def normalize_training_requested_opts(opts)
+    opts.to_h.deep_symbolize_keys
+  end
 
   def send_from_template(template_key, user, extra_variables = {}, mail_options = {})
     template = EmailTemplate.find_enabled(template_key)

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -155,6 +155,47 @@ class MemberMailer < ApplicationMailer
     end
   end
 
+  def training_requested(user, opts = {})
+    @user = user
+    @organization = organization_name
+    @training_topic = opts[:training_topic] || opts['training_topic']
+    @requester_name = opts[:requester_name] || opts['requester_name'] || @user.display_name
+    @requester_email = opts[:requester_email] || opts['requester_email'] || @user.email.to_s
+    @requester_slack = opts[:requester_slack] || opts['requester_slack'] || @user.slack_handle.to_s
+    @share_contact_info = ActiveModel::Type::Boolean.new.cast(opts[:share_contact_info] || opts['share_contact_info'])
+    @recipient_role = opts[:recipient_role] || opts['recipient_role'] || 'trainer'
+    @trainer_names = opts[:trainer_names] || opts['trainer_names'] || ''
+
+    contact_block = if @share_contact_info
+                      [
+                        ('Email: ' + @requester_email if @requester_email.present?),
+                        ('Slack: ' + @requester_slack if @requester_slack.present?)
+                      ].compact.join('<br>')
+                    else
+                      'The member did not consent to sharing contact details.'
+                    end
+
+    extra_vars = {
+      training_topic: @training_topic,
+      requester_name: @requester_name,
+      requester_email: @requester_email,
+      requester_slack: @requester_slack,
+      recipient_role: @recipient_role,
+      trainer_names: @trainer_names,
+      contact_details: contact_block
+    }
+    to_address = opts[:to] || opts['to'] || @user.email
+
+    if send_from_template('training_requested', user, extra_vars, to: to_address)
+      # Email sent from database template
+    else
+      mail(
+        to: to_address,
+        subject: "#{@organization}: Training request for #{@training_topic}"
+      )
+    end
+  end
+
   def trainer_capability_granted(user, training_topic:)
     @user = user
     @organization = organization_name
@@ -310,6 +351,12 @@ class MemberMailer < ApplicationMailer
                     end
     vars[:training_topic] = extra_args[:training_topic] if extra_args[:training_topic].present?
     vars[:application_url] = extra_args[:application_url].to_s if extra_args.key?(:application_url)
+    vars[:requester_name] = extra_args[:requester_name].to_s if extra_args.key?(:requester_name)
+    vars[:requester_email] = extra_args[:requester_email].to_s if extra_args.key?(:requester_email)
+    vars[:requester_slack] = extra_args[:requester_slack].to_s if extra_args.key?(:requester_slack)
+    vars[:recipient_role] = extra_args[:recipient_role].to_s if extra_args.key?(:recipient_role)
+    vars[:trainer_names] = extra_args[:trainer_names].to_s if extra_args.key?(:trainer_names)
+    vars[:contact_details] = extra_args[:contact_details].to_s if extra_args.key?(:contact_details)
 
     merge_parking_notice_template_keys!(vars, extra_args)
   end

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -14,7 +14,8 @@ class EmailTemplate < ApplicationRecord
     '{{invitation_expiry}}' => 'When the invitation expires (invitation emails only)',
     '{{invitation_type}}' => 'Type of membership being offered, e.g. Sponsored Member (invitation emails only)',
     '{{invitation_type_details}}' => 'Description of what the membership type includes (invitation emails only)',
-    '{{application_url}}' => 'Direct link to the membership application (admin new application & staff alert templates)',
+    '{{application_url}}' => 'Direct link to the membership application ' \
+                             '(admin new application & staff alert templates)',
     '{{requester_name}}' => 'Name of the member who requested training',
     '{{requester_email}}' => 'Email address of the member requesting training (if shared)',
     '{{requester_slack}}' => 'Slack handle of the member requesting training (if shared)',

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -14,7 +14,13 @@ class EmailTemplate < ApplicationRecord
     '{{invitation_expiry}}' => 'When the invitation expires (invitation emails only)',
     '{{invitation_type}}' => 'Type of membership being offered, e.g. Sponsored Member (invitation emails only)',
     '{{invitation_type_details}}' => 'Description of what the membership type includes (invitation emails only)',
-    '{{application_url}}' => 'Direct link to the membership application (admin new application & staff alert templates)'
+    '{{application_url}}' => 'Direct link to the membership application (admin new application & staff alert templates)',
+    '{{requester_name}}' => 'Name of the member who requested training',
+    '{{requester_email}}' => 'Email address of the member requesting training (if shared)',
+    '{{requester_slack}}' => 'Slack handle of the member requesting training (if shared)',
+    '{{recipient_role}}' => 'Whether this notification is for a member or trainer',
+    '{{trainer_names}}' => 'Comma-separated trainer names notified for a request',
+    '{{contact_details}}' => 'Rendered contact details block for training request notifications'
   }.freeze
 
   # Default templates that can be seeded
@@ -338,6 +344,45 @@ class EmailTemplate < ApplicationRecord
         Open in Member Manager: {{application_url}}
       TEXT
     },
+    'training_requested' => {
+      name: 'Training Requested',
+      description: 'Sent when a member requests training in a topic',
+      subject: '{{organization_name}}: Training request for {{training_topic}}',
+      body_html: <<~HTML,
+        <h1>Training Request: {{training_topic}}</h1>
+        <p>Hello {{member_name}},</p>
+        <p>A training request has been submitted for <strong>{{training_topic}}</strong>.</p>
+        <p><strong>Recipient role:</strong> {{recipient_role}}</p>
+        <h2>Requester details</h2>
+        <ul>
+          <li><strong>Name:</strong> {{requester_name}}</li>
+          <li><strong>Email:</strong> {{requester_email}}</li>
+          <li><strong>Slack:</strong> {{requester_slack}}</li>
+        </ul>
+        <p>{{contact_details}}</p>
+        <p>Trainers notified: {{trainer_names}}</p>
+        <p>You can respond in Member Manager from your profile dashboard.</p>
+      HTML
+      body_text: <<~TEXT
+        Training Request: {{training_topic}}
+
+        Hello {{member_name}},
+
+        A training request has been submitted for {{training_topic}}.
+        Recipient role: {{recipient_role}}
+
+        Requester details:
+        - Name: {{requester_name}}
+        - Email: {{requester_email}}
+        - Slack: {{requester_slack}}
+
+        {{contact_details}}
+
+        Trainers notified: {{trainer_names}}
+
+        You can respond in Member Manager from your profile dashboard.
+      TEXT
+    },
     'training_completed' => {
       name: 'Training Completed',
       description: 'Sent when a member completes training on a topic',
@@ -484,7 +529,13 @@ class EmailTemplate < ApplicationRecord
       invitation_expiry: 'in 3 days',
       invitation_type: 'Sponsored Member',
       invitation_type_details: 'Sponsored membership — full access including building access, no dues required.',
-      application_url: "#{ENV.fetch('APP_BASE_URL', 'http://localhost:3000')}/membership_applications/1"
+      application_url: "#{ENV.fetch('APP_BASE_URL', 'http://localhost:3000')}/membership_applications/1",
+      requester_name: 'Alex Example',
+      requester_email: 'alex@example.com',
+      requester_slack: '@alex',
+      recipient_role: 'trainer',
+      trainer_names: 'Trainer One, Trainer Two',
+      contact_details: 'Email: alex@example.com'
     }
     render(sample_variables)
   end

--- a/app/models/queued_mail.rb
+++ b/app/models/queued_mail.rb
@@ -234,6 +234,9 @@ class QueuedMail < ApplicationRecord
       [user, { reason: extra_args[:reason] }.compact]
     when 'training_completed', 'trainer_capability_granted'
       [user, { training_topic: extra_args[:training_topic] }.compact]
+    when 'training_requested'
+      [user, extra_args.slice(:training_topic, :requester_name, :requester_email, :requester_slack,
+                              :share_contact_info, :recipient_role, :trainer_names, :to)]
     when 'parking_permit_issued', 'parking_ticket_issued',
          'parking_permit_expired', 'parking_ticket_expired'
       [user, extra_args.slice(:location, :location_detail, :description, :expires_at, :notice_type)]

--- a/app/models/training_request.rb
+++ b/app/models/training_request.rb
@@ -1,0 +1,31 @@
+class TrainingRequest < ApplicationRecord
+  STATUSES = %w[pending responded].freeze
+
+  belongs_to :user
+  belongs_to :training_topic
+  belongs_to :responded_by, class_name: 'User', optional: true
+
+  validates :status, inclusion: { in: STATUSES }
+  validates :share_contact_info, inclusion: { in: [true, false] }
+  validates :training_topic_id, uniqueness: {
+    scope: :user_id,
+    conditions: -> { where(status: 'pending') },
+    message: 'already has an active request for this member'
+  }
+
+  scope :pending, -> { where(status: 'pending') }
+  scope :responded, -> { where(status: 'responded') }
+  scope :newest_first, -> { order(created_at: :desc) }
+
+  def pending?
+    status == 'pending'
+  end
+
+  def responded?
+    status == 'responded'
+  end
+
+  def respond!(responder)
+    update!(status: 'responded', responded_by: responder, responded_at: Time.current)
+  end
+end

--- a/app/models/training_topic.rb
+++ b/app/models/training_topic.rb
@@ -2,12 +2,18 @@ class TrainingTopic < ApplicationRecord
   has_many :trainer_capabilities, dependent: :destroy
   has_many :trainers, through: :trainer_capabilities, source: :user
   has_many :trainings, dependent: :destroy
+  has_many :training_requests, dependent: :destroy
   has_many :links, class_name: 'TrainingTopicLink', dependent: :destroy
   has_many :document_training_topics, dependent: :destroy
   has_many :documents, through: :document_training_topics
   has_many :application_groups, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
+  validates :offered_to_members, inclusion: { in: [true, false] }
+
+  scope :offered_for_members, -> { where(offered_to_members: true) }
+  scope :with_trainers, -> { joins(:trainer_capabilities).distinct }
+  scope :available_for_member_requests, -> { offered_for_members.with_trainers.order(:name) }
 
   after_create_commit :provision_authentik_groups
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,8 @@ class User < ApplicationRecord
   has_many :trainer_capabilities, dependent: :destroy
   has_many :training_topics, through: :trainer_capabilities
   has_many :training_requests, dependent: :destroy
-  has_many :training_requests_responded, class_name: 'TrainingRequest', foreign_key: :responded_by_id, dependent: :nullify, inverse_of: :responded_by
+  has_many :training_requests_responded, class_name: 'TrainingRequest', foreign_key: :responded_by_id,
+                                         dependent: :nullify, inverse_of: :responded_by
   has_many :user_links,     dependent: :destroy
   has_many :user_interests, dependent: :destroy
   has_many :interests,      through: :user_interests

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,8 @@ class User < ApplicationRecord
   has_many :rfids, dependent: :destroy
   has_many :trainer_capabilities, dependent: :destroy
   has_many :training_topics, through: :trainer_capabilities
+  has_many :training_requests, dependent: :destroy
+  has_many :training_requests_responded, class_name: 'TrainingRequest', foreign_key: :responded_by_id, dependent: :nullify, inverse_of: :responded_by
   has_many :user_links,     dependent: :destroy
   has_many :user_interests, dependent: :destroy
   has_many :interests,      through: :user_interests

--- a/app/views/member_mailer/training_requested.html.erb
+++ b/app/views/member_mailer/training_requested.html.erb
@@ -1,0 +1,27 @@
+<h1>Training Request: <%= @training_topic %></h1>
+
+<p>Hello <%= @user.display_name %>,</p>
+
+<% if @recipient_role == 'member' %>
+  <p>Your request for training in <strong><%= @training_topic %></strong> has been sent to trainers.</p>
+  <p>Trainers notified: <%= @trainer_names.presence || 'No trainers with email addresses were found.' %></p>
+<% else %>
+  <p>A member requested training in <strong><%= @training_topic %></strong>.</p>
+<% end %>
+
+<h2>Requester details</h2>
+<ul>
+  <li><strong>Name:</strong> <%= @requester_name %></li>
+  <% if @share_contact_info %>
+    <% if @requester_email.present? %>
+      <li><strong>Email:</strong> <%= @requester_email %></li>
+    <% end %>
+    <% if @requester_slack.present? %>
+      <li><strong>Slack:</strong> <%= @requester_slack %></li>
+    <% end %>
+  <% else %>
+    <li>The member did not consent to sharing contact details.</li>
+  <% end %>
+</ul>
+
+<p>You can respond in Member Manager from your profile dashboard.</p>

--- a/app/views/member_mailer/training_requested.text.erb
+++ b/app/views/member_mailer/training_requested.text.erb
@@ -1,0 +1,23 @@
+Training Request: <%= @training_topic %>
+
+Hello <%= @user.display_name %>,
+
+<% if @recipient_role == 'member' %>
+Your request for training in <%= @training_topic %> has been sent to trainers.
+Trainers notified: <%= @trainer_names.presence || 'No trainers with email addresses were found.' %>
+<% else %>
+A member requested training in <%= @training_topic %>.
+<% end %>
+
+Requester details:
+- Name: <%= @requester_name %>
+<% if @share_contact_info %>
+<% if @requester_email.present? %>- Email: <%= @requester_email %>
+<% end %>
+<% if @requester_slack.present? %>- Slack: <%= @requester_slack %>
+<% end %>
+<% else %>
+- The member did not consent to sharing contact details.
+<% end %>
+
+You can respond in Member Manager from your profile dashboard.

--- a/app/views/training_requests/edit.html.erb
+++ b/app/views/training_requests/edit.html.erb
@@ -1,0 +1,38 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">Respond to Training Request</h1>
+  <%= link_to "&larr; Back to profile".html_safe, user_path(current_user), class: "text-decoration-none" %>
+</div>
+
+<div class="card shadow-sm border-0">
+  <div class="card-body">
+    <p class="mb-1"><strong>Member:</strong> <%= link_to @requester.display_name, user_path(@requester), class: "text-decoration-none" %></p>
+    <p class="mb-3"><strong>Topic:</strong> <%= @training_request.training_topic.name %></p>
+
+    <% if @training_request.share_contact_info? %>
+      <div class="alert alert-info py-2">
+        <% if @requester.email.present? %>
+          <div><strong>Email:</strong> <%= mail_to @requester.email %></div>
+        <% end %>
+        <% if @requester.slack_handle.present? %>
+          <div><strong>Slack:</strong> <code><%= @requester.slack_handle %></code></div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="alert alert-secondary py-2">
+        This member did not share email or Slack contact details. Please respond here in Member Manager.
+      </div>
+    <% end %>
+
+    <%= form_with model: @training_request, url: training_request_path(@training_request), method: :patch, local: true do |f| %>
+      <div class="mb-3">
+        <%= f.label :response_body, 'Response message', class: 'form-label' %>
+        <%= f.text_area :response_body,
+                        class: 'form-control',
+                        rows: 6,
+                        required: true,
+                        placeholder: 'Share how the member can schedule training, prerequisites, or next steps.' %>
+      </div>
+      <%= f.submit 'Send Response', class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/training_topics/edit.html.erb
+++ b/app/views/training_topics/edit.html.erb
@@ -21,7 +21,7 @@
         </div>
       <% end %>
       <%= form_with model: @training_topic, url: training_topic_path(@training_topic), local: true, class: "row g-3" do |f| %>
-        <div class="col-md-8">
+        <div class="col-md-6">
           <%= f.text_field :name, class: "form-control #{'is-invalid' if @training_topic.errors.key?(:name)}", required: true %>
           <% if @training_topic.errors.key?(:name) %>
             <div class="invalid-feedback">
@@ -29,7 +29,13 @@
             </div>
           <% end %>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-3 d-flex align-items-center">
+          <div class="form-check mt-1">
+            <%= f.check_box :offered_to_members, class: "form-check-input" %>
+            <%= f.label :offered_to_members, "Offered to members", class: "form-check-label" %>
+          </div>
+        </div>
+        <div class="col-md-3">
           <%= f.submit "Update Topic", class: "btn btn-primary w-100" %>
         </div>
       <% end %>

--- a/app/views/training_topics/index.html.erb
+++ b/app/views/training_topics/index.html.erb
@@ -24,7 +24,13 @@
           </div>
         <% end %>
       </div>
-      <div class="col-md-4">
+      <div class="col-md-2 d-flex align-items-center">
+        <div class="form-check mt-1">
+          <%= f.check_box :offered_to_members, class: "form-check-input" %>
+          <%= f.label :offered_to_members, "Offered to members", class: "form-check-label" %>
+        </div>
+      </div>
+      <div class="col-md-2">
         <%= f.submit "Add Topic", class: "btn btn-primary w-100" %>
       </div>
     <% end %>
@@ -40,6 +46,7 @@
           <thead class="bg-body-tertiary">
             <tr>
               <th scope="col">Name</th>
+              <th scope="col" class="text-center">Member Offered</th>
               <th scope="col" class="text-center">Trained Count</th>
               <th scope="col" class="text-center">Trainer Count</th>
               <th scope="col" class="text-end">Actions</th>
@@ -49,6 +56,13 @@
             <% @training_topics.each do |topic| %>
               <tr>
                 <td><strong><%= link_to topic.name, edit_training_topic_path(topic), class: "text-decoration-none" %></strong></td>
+                <td class="text-center">
+                  <% if topic.offered_to_members? %>
+                    <span class="badge text-bg-success">Yes</span>
+                  <% else %>
+                    <span class="badge text-bg-secondary">No</span>
+                  <% end %>
+                </td>
                 <td class="text-center">
                   <span class="badge text-bg-primary"><%= topic.trainings.select(:trainee_id).distinct.count %></span>
                 </td>

--- a/app/views/users/_tab_profile_self.html.erb
+++ b/app/views/users/_tab_profile_self.html.erb
@@ -1,4 +1,83 @@
 <%# Self Profile Tab - what the user sees on their own profile %>
+<div class="card shadow-sm border-0 mb-4">
+  <div class="card-body">
+    <h2 class="h5 mb-3"><i class="bi bi-mortarboard me-2"></i>Request Training</h2>
+    <% if @member_requestable_topics.any? %>
+      <%= form_with url: training_requests_path, local: true do |f| %>
+        <div class="row g-3 align-items-end">
+          <div class="col-md-6">
+            <%= f.label :training_topic_id, 'Training topic', class: 'form-label' %>
+            <%= f.select :training_topic_id,
+                         options_from_collection_for_select(@member_requestable_topics, :id, :name),
+                         { include_blank: 'Choose a topic' },
+                         { class: 'form-select', required: true } %>
+          </div>
+          <div class="col-md-6">
+            <div class="form-check mt-4">
+              <%= f.check_box :share_contact_info, class: 'form-check-input', required: true %>
+              <%= f.label :share_contact_info,
+                          'I consent to sharing my email and Slack handle (if available) with trainers for this topic.',
+                          class: 'form-check-label' %>
+            </div>
+          </div>
+        </div>
+        <div class="alert alert-secondary mt-3 mb-3">
+          If you do not see the training topic you need, please post in <strong>#help</strong> on Slack
+          or email <a href="mailto:info@pdxhackerspace.org">info@pdxhackerspace.org</a>.
+        </div>
+        <%= f.submit 'Request Training', class: 'btn btn-primary' %>
+      <% end %>
+    <% else %>
+      <div class="alert alert-secondary mb-0">
+        No training topics are currently available for member requests.
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<% if @trainer_training_requests_by_topic.present? %>
+  <div class="card shadow-sm border-0 mb-4">
+    <div class="card-body">
+      <h2 class="h5 mb-3"><i class="bi bi-inbox me-2"></i>Training Requests for You</h2>
+      <% @trainer_training_requests_by_topic.each do |topic, requests| %>
+        <div class="border rounded p-3 mb-3">
+          <h3 class="h6 mb-2"><%= topic.name %></h3>
+          <% requests.each do |request| %>
+            <div class="d-flex justify-content-between align-items-start border-top pt-2 mt-2">
+              <div>
+                <div>
+                  <strong><%= link_to request.user.display_name, user_path(request.user), class: "text-decoration-none" %></strong>
+                  <span class="text-muted small">requested <%= time_ago_in_words(request.created_at) %> ago</span>
+                </div>
+                <% if request.share_contact_info? %>
+                  <div class="small text-muted mt-1">
+                    <% if request.user.email.present? %>
+                      Email: <%= mail_to request.user.email %><br>
+                    <% end %>
+                    <% if request.user.slack_handle.present? %>
+                      Slack: <code><%= request.user.slack_handle %></code>
+                    <% end %>
+                  </div>
+                <% else %>
+                  <div class="small text-muted mt-1">
+                    Contact details were not shared.
+                  </div>
+                <% end %>
+              </div>
+              <div class="d-flex gap-2">
+                <%= link_to 'Respond in Member Manager', edit_training_request_path(request), class: 'btn btn-sm btn-outline-primary' %>
+                <% if request.share_contact_info? && request.user.email.present? %>
+                  <%= link_to 'Email', "mailto:#{request.user.email}", class: 'btn btn-sm btn-outline-secondary' %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
 <div class="card shadow-sm border-0">
   <div class="card-body">
     <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
   delete "/impersonate", to: "impersonations#destroy", as: :stop_impersonation
 
   resources :messages, only: [:create]
+  resources :training_requests, only: %i[create edit update]
 
   resources :users, only: [:index, :show, :new, :create, :edit, :update, :destroy], constraints: { id: /[^\/]+/ } do
     member do

--- a/db/migrate/20260413100000_add_offered_to_members_to_training_topics.rb
+++ b/db/migrate/20260413100000_add_offered_to_members_to_training_topics.rb
@@ -1,0 +1,6 @@
+class AddOfferedToMembersToTrainingTopics < ActiveRecord::Migration[8.1]
+  def change
+    add_column :training_topics, :offered_to_members, :boolean, null: false, default: false
+    add_index :training_topics, :offered_to_members
+  end
+end

--- a/db/migrate/20260413101000_create_training_requests.rb
+++ b/db/migrate/20260413101000_create_training_requests.rb
@@ -1,0 +1,17 @@
+class CreateTrainingRequests < ActiveRecord::Migration[8.1]
+  def change
+    create_table :training_requests do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :training_topic, null: false, foreign_key: true
+      t.boolean :share_contact_info, null: false, default: false
+      t.string :status, null: false, default: 'pending'
+      t.datetime :responded_at
+      t.references :responded_by, null: true, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :training_requests, :status
+    add_index :training_requests, %i[user_id training_topic_id status], name: 'idx_training_requests_user_topic_status'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_11_113000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_101000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -860,6 +860,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_11_113000) do
     t.index ["user_id"], name: "index_trainer_capabilities_on_user_id"
   end
 
+  create_table "training_requests", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "responded_at"
+    t.bigint "responded_by_id"
+    t.boolean "share_contact_info", default: false, null: false
+    t.string "status", default: "pending", null: false
+    t.bigint "training_topic_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["responded_by_id"], name: "index_training_requests_on_responded_by_id"
+    t.index ["status"], name: "index_training_requests_on_status"
+    t.index ["training_topic_id"], name: "index_training_requests_on_training_topic_id"
+    t.index ["user_id", "training_topic_id", "status"], name: "idx_training_requests_user_topic_status"
+    t.index ["user_id"], name: "index_training_requests_on_user_id"
+  end
+
   create_table "training_topic_links", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "title", null: false
@@ -873,8 +889,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_11_113000) do
     t.datetime "created_at", null: false
     t.text "description"
     t.string "name", null: false
+    t.boolean "offered_to_members", default: false, null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_training_topics_on_name", unique: true
+    t.index ["offered_to_members"], name: "index_training_topics_on_offered_to_members"
   end
 
   create_table "trainings", force: :cascade do |t|
@@ -1042,6 +1060,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_11_113000) do
   add_foreign_key "slack_users", "users"
   add_foreign_key "trainer_capabilities", "training_topics"
   add_foreign_key "trainer_capabilities", "users"
+  add_foreign_key "training_requests", "training_topics"
+  add_foreign_key "training_requests", "users"
+  add_foreign_key "training_requests", "users", column: "responded_by_id"
   add_foreign_key "training_topic_links", "training_topics"
   add_foreign_key "trainings", "training_topics"
   add_foreign_key "trainings", "users", column: "trainee_id"

--- a/test/controllers/training_requests_controller_test.rb
+++ b/test/controllers/training_requests_controller_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+class TrainingRequestsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @topic = training_topics(:woodworking)
+    TrainerCapability.find_or_create_by!(user: users(:one), training_topic: @topic)
+    TrainerCapability.find_or_create_by!(user: users(:two), training_topic: @topic)
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+  end
+
+  test 'member can request training for offered topic' do
+    sign_in_as_member
+
+    assert_difference 'TrainingRequest.count', 1 do
+      assert_difference 'QueuedMail.count', 3 do
+        post training_requests_path, params: {
+          training_request: {
+            training_topic_id: @topic.id,
+            share_contact_info: '1'
+          }
+        }
+      end
+    end
+
+    request = TrainingRequest.order(:created_at).last
+    assert_equal 'pending', request.status
+    assert_redirected_to user_path(User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}"))
+  end
+
+  test 'member must consent to sharing contact info' do
+    sign_in_as_member
+
+    assert_no_difference 'TrainingRequest.count' do
+      post training_requests_path, params: {
+        training_request: {
+          training_topic_id: @topic.id,
+          share_contact_info: '0'
+        }
+      }
+    end
+
+    assert_redirected_to user_path(User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}"))
+    assert_equal 'Please confirm contact sharing to submit your request.', flash[:alert]
+  end
+
+  test 'trainer can open response form for request in their topic' do
+    trainer = sign_in_as_trainer
+    TrainerCapability.find_or_create_by!(user: trainer, training_topic: training_topics(:laser_cutting))
+
+    get edit_training_request_path(training_requests(:pending_laser_request))
+    assert_response :success
+  end
+
+  test 'member cannot open response form for request' do
+    sign_in_as_member
+
+    get edit_training_request_path(training_requests(:pending_laser_request))
+    assert_redirected_to user_path(User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}"))
+  end
+
+  test 'trainer can respond to request in member manager' do
+    trainer = sign_in_as_trainer
+    TrainerCapability.find_or_create_by!(user: trainer, training_topic: training_topics(:laser_cutting))
+    request = training_requests(:pending_laser_request)
+
+    assert_difference 'Message.count', 1 do
+      patch training_request_path(request), params: {
+        training_request: {
+          response_body: 'Happy to help. Please message me in #help to schedule.'
+        }
+      }
+    end
+
+    request.reload
+    assert_equal 'responded', request.status
+    assert_equal trainer, request.responded_by
+    assert_not_nil request.responded_at
+  end
+
+  private
+
+  def sign_in_as_member
+    post local_login_path, params: {
+      session: { email: local_accounts(:regular_member).email, password: 'memberpassword123' }
+    }
+  end
+
+  def sign_in_as_trainer
+    post local_login_path, params: {
+      session: { email: local_accounts(:trainer_account).email, password: 'trainerpassword123' }
+    }
+    User.find_by(authentik_id: "local:#{local_accounts(:trainer_account).id}")
+  end
+end

--- a/test/controllers/training_topics_controller_test.rb
+++ b/test/controllers/training_topics_controller_test.rb
@@ -71,20 +71,22 @@ class TrainingTopicsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as_admin
     assert_difference 'TrainingTopic.count', 1 do
       post training_topics_path, params: {
-        training_topic: { name: 'New Topic' }
+        training_topic: { name: 'New Topic', offered_to_members: '1' }
       }
     end
     assert_redirected_to training_topics_path
+    assert TrainingTopic.find_by(name: 'New Topic').offered_to_members?
   end
 
   test 'admin can update (rename) a topic' do
     sign_in_as_admin
     patch training_topic_path(@laser_topic), params: {
-      training_topic: { name: 'Advanced Laser Cutting' }
+      training_topic: { name: 'Advanced Laser Cutting', offered_to_members: '0' }
     }
     assert_redirected_to edit_training_topic_path(@laser_topic)
     @laser_topic.reload
     assert_equal 'Advanced Laser Cutting', @laser_topic.name
+    assert_not @laser_topic.offered_to_members?
   end
 
   test 'admin can destroy a topic with no trainings or capabilities' do

--- a/test/fixtures/trainer_capabilities.yml
+++ b/test/fixtures/trainer_capabilities.yml
@@ -1,2 +1,2 @@
-# Empty - trainer capabilities will be created dynamically in tests
-# because the user records are created during sign-in (sync_local_account)
+# Intentionally empty.
+# Most controller tests create trainer capabilities dynamically after local-login users are created.

--- a/test/fixtures/training_requests.yml
+++ b/test/fixtures/training_requests.yml
@@ -1,0 +1,13 @@
+pending_laser_request:
+  user: member_with_local_account
+  training_topic: laser_cutting
+  share_contact_info: true
+  status: pending
+
+responded_woodworking_request:
+  user: one
+  training_topic: woodworking
+  share_contact_info: false
+  status: responded
+  responded_at: 2026-04-01 12:00:00
+  responded_by: two

--- a/test/fixtures/training_topics.yml
+++ b/test/fixtures/training_topics.yml
@@ -1,8 +1,11 @@
 laser_cutting:
   name: Laser Cutting
+  offered_to_members: true
 
 woodworking:
   name: Woodworking
+  offered_to_members: true
 
 electronics:
   name: Electronics
+  offered_to_members: false

--- a/test/models/training_request_test.rb
+++ b/test/models/training_request_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class TrainingRequestTest < ActiveSupport::TestCase
+  test 'cannot create duplicate pending request for same user and topic' do
+    existing = training_requests(:pending_laser_request)
+
+    duplicate = TrainingRequest.new(
+      user: existing.user,
+      training_topic: existing.training_topic,
+      share_contact_info: true,
+      status: 'pending'
+    )
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:training_topic_id], 'already has an active request for this member'
+  end
+
+  test 'allows new request for same user and topic when previous request was responded' do
+    responded = training_requests(:responded_woodworking_request)
+    request = TrainingRequest.new(
+      user: responded.user,
+      training_topic: responded.training_topic,
+      share_contact_info: true,
+      status: 'pending'
+    )
+
+    assert request.valid?
+  end
+end


### PR DESCRIPTION
This adds member-requestable training topics, a consented request flow, queued notifications to members and trainers, and grouped trainer request handling on profile dashboards.

Made-with: Cursor