### PR TITLE
Set training topics offered-to-members default to true.

### DIFF
--- a/db/migrate/20260414110000_default_training_topics_offered_to_members_true.rb
+++ b/db/migrate/20260414110000_default_training_topics_offered_to_members_true.rb
@@ -1,0 +1,10 @@
+class DefaultTrainingTopicsOfferedToMembersTrue < ActiveRecord::Migration[8.1]
+  def up
+    change_column_default :training_topics, :offered_to_members, from: false, to: true
+    execute 'UPDATE training_topics SET offered_to_members = TRUE'
+  end
+
+  def down
+    change_column_default :training_topics, :offered_to_members, from: true, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -904,7 +904,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_120100) do
     t.datetime "created_at", null: false
     t.text "description"
     t.string "name", null: false
-    t.boolean "offered_to_members", default: false, null: false
+    t.boolean "offered_to_members", default: true, null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_training_topics_on_name", unique: true
     t.index ["offered_to_members"], name: "index_training_topics_on_offered_to_members"


### PR DESCRIPTION
This updates the database default and backfills existing training topics so member-request visibility is enabled by default in production.

Made-with: Cursor