### PR TITLE
Fix training request form parameter scoping.

### DIFF
--- a/app/views/users/_tab_profile_self.html.erb
+++ b/app/views/users/_tab_profile_self.html.erb
@@ -3,7 +3,7 @@
   <div class="card-body">
     <h2 class="h5 mb-3"><i class="bi bi-mortarboard me-2"></i>Request Training</h2>
     <% if @member_requestable_topics.any? %>
-      <%= form_with url: training_requests_path, local: true do |f| %>
+      <%= form_with scope: :training_request, url: training_requests_path, local: true do |f| %>
         <div class="row g-3 align-items-end">
           <div class="col-md-6">
             <%= f.label :training_topic_id, 'Training topic', class: 'form-label' %>

--- a/test/controllers/training_requests_controller_test.rb
+++ b/test/controllers/training_requests_controller_test.rb
@@ -82,6 +82,16 @@ class TrainingRequestsControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil request.responded_at
   end
 
+  test 'member profile renders training request fields under training_request scope' do
+    sign_in_as_member
+    member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
+
+    get user_path(member)
+    assert_response :success
+    assert_match 'name="training_request[training_topic_id]"', response.body
+    assert_match 'name="training_request[share_contact_info]"', response.body
+  end
+
   private
 
   def sign_in_as_member


### PR DESCRIPTION
This scopes the dashboard request form under training_request params and adds a controller test to prevent regressions where members cannot submit requests.

Made-with: Cursor