### PR TITLE
Add member dashboard tabs and self-service actions.

### DIFF
--- a/app/controllers/concerns/member_home_tabs.rb
+++ b/app/controllers/concerns/member_home_tabs.rb
@@ -1,0 +1,60 @@
+module MemberHomeTabs
+  private
+
+  def prepare_member_home_tabs_data
+    set_member_dashboard_data
+    set_self_service_training_data
+    set_home_parking_data
+    set_home_messages_data
+    set_home_payments_data
+  end
+
+  def set_home_parking_data
+    parking_query = @home_user.parking_notices.not_cleared.newest_first
+    @home_parking_notices_count = parking_query.count
+    @home_parking_notices_list = parking_query.limit(50)
+  end
+
+  def set_home_messages_data
+    messages_query = @home_user.received_messages.includes(:sender).newest_first
+    @home_messages_count = messages_query.count
+    @home_unread_messages_count = @home_user.received_messages.unread.count
+
+    return unless @active_tab == :messages
+
+    @pagy_messages, @home_messages = pagy(messages_query, limit: 20, page_param: :messages_page)
+  end
+
+  def set_home_payments_data
+    payments_query = PaymentHistory.for_user(@home_user, event_type: params[:event_type].presence)
+    @home_payments_count = payments_query.count
+
+    return unless @active_tab == :payments
+
+    @pagy_payments, @home_payments = pagy(payments_query, limit: 20, page_param: :payments_page)
+  end
+
+  def set_self_service_training_data
+    @member_requestable_topics = TrainingTopic.available_for_member_requests
+
+    trainer_topic_ids = @home_user.training_topics.select(:id)
+    ordering = 'training_topics.name ASC, training_requests.created_at DESC'
+    trainer_requests = TrainingRequest.pending
+                                      .where(training_topic_id: trainer_topic_ids)
+                                      .joins(:training_topic)
+                                      .includes(:training_topic, :user)
+                                      .order(ordering)
+    @trainer_training_requests_by_topic = trainer_requests.group_by(&:training_topic)
+  end
+
+  def set_member_dashboard_data
+    items = MemberDashboardBuilder.new(
+      user: @home_user,
+      due_soon_days: MembershipSetting.manual_payment_due_soon_days,
+      path_for_tab: ->(tab) { root_path(tab: tab) }
+    ).build
+
+    @member_dashboard_attention_items = items[:attention_items]
+    @member_dashboard_ok_items = items[:ok_items]
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,10 @@
 class DashboardController < AdminController
+  include MemberHomeTabs
+
   def index
+    @home_user = true_user || current_user
+    @active_tab = params[:tab]&.to_sym || :admin_dashboard
+
     @user_count = User.non_legacy.count
     @active_user_count = User.active.count
     @last_synced_at = User.maximum(:last_synced_at)
@@ -29,6 +34,8 @@ class DashboardController < AdminController
                                 .where(changed_at: 2.weeks.ago..)
                                 .order(changed_at: :desc)
                                 .limit(50)
+
+    prepare_member_home_tabs_data
   end
 
   private

--- a/app/controllers/member_parking_permits_controller.rb
+++ b/app/controllers/member_parking_permits_controller.rb
@@ -1,0 +1,30 @@
+class MemberParkingPermitsController < AuthenticatedController
+  def new
+    @parking_notice = ParkingNotice.new(
+      notice_type: 'permit',
+      expires_at: 7.days.from_now
+    )
+  end
+
+  def create
+    @parking_notice = current_user.parking_notices.build(member_parking_permit_params)
+    @parking_notice.notice_type = 'permit'
+    @parking_notice.issued_by = current_user
+    @parking_notice.status = 'active'
+
+    if @parking_notice.save
+      @parking_notice.record_journal_entry!('parking_permit_issued', actor: current_user)
+      redirect_to user_path(current_user, tab: :parking), notice: 'Parking permit created successfully.'
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def member_parking_permit_params
+    params.expect(
+      parking_notice: %i[description location location_detail expires_at]
+    )
+  end
+end

--- a/app/controllers/training_requests_controller.rb
+++ b/app/controllers/training_requests_controller.rb
@@ -2,6 +2,10 @@ class TrainingRequestsController < AuthenticatedController
   before_action :set_training_request, only: %i[edit update]
   before_action :authorize_responder!, only: %i[edit update]
 
+  def new
+    @member_requestable_topics = TrainingTopic.available_for_member_requests
+  end
+
   def edit
     @requester = @training_request.user
   end
@@ -9,12 +13,12 @@ class TrainingRequestsController < AuthenticatedController
   def create
     topic = TrainingTopic.available_for_member_requests.find_by(id: training_request_params[:training_topic_id])
     if topic.nil?
-      redirect_to user_path(current_user), alert: 'Please select a valid training topic.'
+      redirect_to new_training_request_path, alert: 'Please select a valid training topic.'
       return
     end
 
     if training_request_params[:share_contact_info] != '1'
-      redirect_to user_path(current_user), alert: 'Please confirm contact sharing to submit your request.'
+      redirect_to new_training_request_path, alert: 'Please confirm contact sharing to submit your request.'
       return
     end
 
@@ -25,9 +29,10 @@ class TrainingRequestsController < AuthenticatedController
 
     if request.save
       queue_training_request_emails!(request)
-      redirect_to user_path(current_user), notice: "Your training request for #{topic.name} has been sent."
+      redirect_to user_path(current_user, tab: :profile),
+                  notice: "Your training request for #{topic.name} has been sent."
     else
-      redirect_to user_path(current_user), alert: request.errors.full_messages.to_sentence
+      redirect_to new_training_request_path, alert: request.errors.full_messages.to_sentence
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -160,7 +160,14 @@ class UsersController < AuthenticatedController
     setup_view_preview_options
 
     # Default tab
-    @active_tab = params[:tab]&.to_sym || :profile
+    requested_tab = params[:tab]&.to_sym
+    @active_tab = if requested_tab.present?
+                    requested_tab
+                  elsif @view_level == :self
+                    :dashboard
+                  else
+                    :profile
+                  end
 
     # Parking notices for admin and self views
     if @view_level == :admin || @view_level == :self
@@ -182,7 +189,10 @@ class UsersController < AuthenticatedController
       end
     end
 
-    set_self_service_training_data if @view_level == :self
+    if @view_level == :self
+      set_self_service_training_data
+      set_member_dashboard_data
+    end
 
     # Load payment history for admin and self views (paginated)
     if @view_level == :admin || @view_level == :self
@@ -589,6 +599,182 @@ class UsersController < AuthenticatedController
                                                          .includes(:training_topic, :user)
                                                          .order(ordering)
                                                          .group_by(&:training_topic)
+  end
+
+  def set_member_dashboard_data
+    @member_dashboard_attention_items = []
+    @member_dashboard_ok_items = []
+
+    append_member_dashboard_payment_item
+    append_member_dashboard_training_item
+    append_member_dashboard_slack_item
+    append_member_dashboard_parking_item
+  end
+
+  def append_member_dashboard_payment_item
+    unless member_manual_payment?
+      add_member_dashboard_item(
+        ok: true,
+        id: :cash_payment_due,
+        tier: :none,
+        title: 'Cash payment due',
+        detail: 'You are not on a manual/cash payment plan.'
+      )
+      return
+    end
+
+    due_on = @user.next_payment_date
+    if due_on.blank?
+      add_member_dashboard_item(
+        ok: false,
+        id: :cash_payment_due,
+        tier: :housekeeping,
+        title: 'Cash payment due',
+        detail: 'No next payment due date is recorded yet. Please contact an admin.',
+        action_label: 'View payment history',
+        action_path: user_path(@user, tab: :payments, view_as: params[:view_as])
+      )
+      return
+    end
+
+    days_until = (due_on - Date.current).to_i
+    if days_until.negative?
+      add_member_dashboard_item(
+        ok: false,
+        id: :cash_payment_due,
+        tier: :urgent,
+        title: 'Cash payment due',
+        detail: "Your next cash payment was due #{due_on.strftime('%B %-d, %Y')} (#{days_until.abs} days overdue).",
+        action_label: 'View payment history',
+        action_path: user_path(@user, tab: :payments, view_as: params[:view_as])
+      )
+      return
+    end
+
+    due_soon_days = MembershipSetting.manual_payment_due_soon_days
+    if days_until <= due_soon_days
+      add_member_dashboard_item(
+        ok: false,
+        id: :cash_payment_due,
+        tier: :important,
+        title: 'Cash payment due soon',
+        detail: "Your next cash payment is due in #{days_until} days (#{due_on.strftime('%B %-d, %Y')}).",
+        action_label: 'View payment history',
+        action_path: user_path(@user, tab: :payments, view_as: params[:view_as])
+      )
+      return
+    end
+
+    add_member_dashboard_item(
+      ok: true,
+      id: :cash_payment_due,
+      tier: :none,
+      title: 'Cash payment due',
+      detail: "Your next cash payment is due in #{days_until} days (#{due_on.strftime('%B %-d, %Y')})."
+    )
+  end
+
+  def append_member_dashboard_training_item
+    pending_count = @user.training_requests.pending.count
+    if pending_count.positive?
+      add_member_dashboard_item(
+        ok: false,
+        id: :training_requests,
+        tier: :important,
+        title: 'Open training requests',
+        detail: "You have #{pending_count} open training request#{'s' unless pending_count == 1}.",
+        action_label: 'Open Profile tab',
+        action_path: user_path(@user, tab: :profile, view_as: params[:view_as])
+      )
+      return
+    end
+
+    add_member_dashboard_item(
+      ok: true,
+      id: :training_requests,
+      tier: :none,
+      title: 'Open training requests',
+      detail: 'You have no open training requests.'
+    )
+  end
+
+  def append_member_dashboard_slack_item
+    if @user.slack_user.present?
+      add_member_dashboard_item(
+        ok: true,
+        id: :slack_signup,
+        tier: :none,
+        title: 'Slack account',
+        detail: 'Your account is linked to Slack.'
+      )
+      return
+    end
+
+    add_member_dashboard_item(
+      ok: false,
+      id: :slack_signup,
+      tier: :housekeeping,
+      title: 'Join Slack',
+      detail: 'You do not have a linked Slack user yet. Please ask an admin for an invite.',
+      action_label: 'View Profile',
+      action_path: user_path(@user, tab: :profile, view_as: params[:view_as])
+    )
+  end
+
+  def append_member_dashboard_parking_item
+    notices = @user.parking_notices.not_cleared
+    expired_count = notices.expired_notices.count
+    active_count = notices.active_notices.count
+    open_count = expired_count + active_count
+
+    if expired_count.positive?
+      detail = "#{expired_count} expired and #{active_count} active open parking notice#{'s' unless open_count == 1}."
+      add_member_dashboard_item(
+        ok: false,
+        id: :parking_notices,
+        tier: :urgent,
+        title: 'Open parking permits/tickets',
+        detail: detail,
+        action_label: 'Open Parking tab',
+        action_path: user_path(@user, tab: :parking, view_as: params[:view_as])
+      )
+      return
+    end
+
+    if active_count.positive?
+      add_member_dashboard_item(
+        ok: false,
+        id: :parking_notices,
+        tier: :important,
+        title: 'Open parking permits/tickets',
+        detail: "#{active_count} active open parking notice#{'s' unless active_count == 1}.",
+        action_label: 'Open Parking tab',
+        action_path: user_path(@user, tab: :parking, view_as: params[:view_as])
+      )
+      return
+    end
+
+    add_member_dashboard_item(
+      ok: true,
+      id: :parking_notices,
+      tier: :none,
+      title: 'Open parking permits/tickets',
+      detail: 'You have no open parking permits or tickets.'
+    )
+  end
+
+  def member_manual_payment?
+    return true if @user.payment_type == 'cash'
+
+    @user.all_membership_plans.any?(&:manual?)
+  end
+
+  def add_member_dashboard_item(item)
+    if item[:ok]
+      @member_dashboard_ok_items << item
+    else
+      @member_dashboard_attention_items << item
+    end
   end
 
   def user_params

--- a/app/services/member_dashboard_builder.rb
+++ b/app/services/member_dashboard_builder.rb
@@ -1,0 +1,202 @@
+class MemberDashboardBuilder
+  def initialize(user:, due_soon_days:, path_for_tab:)
+    @user = user
+    @due_soon_days = due_soon_days
+    @path_for_tab = path_for_tab
+  end
+
+  def build
+    items = [
+      payment_item,
+      training_item,
+      slack_item,
+      parking_item
+    ]
+
+    {
+      attention_items: items.reject { |item| item[:ok] },
+      ok_items: items.select { |item| item[:ok] }
+    }
+  end
+
+  private
+
+  attr_reader :user, :due_soon_days, :path_for_tab
+
+  def payment_item
+    return payment_not_manual_item unless manual_payment?
+
+    due_on = user.next_payment_date
+    return payment_missing_due_date_item if due_on.blank?
+
+    days_until = (due_on - Date.current).to_i
+    return payment_overdue_item(due_on, days_until) if days_until.negative?
+    return payment_due_soon_item(due_on, days_until) if days_until <= due_soon_days
+
+    payment_ok_item(due_on, days_until)
+  end
+
+  def payment_not_manual_item
+    ok_item(:cash_payment_due, 'Cash payment due', 'You are not on a manual/cash payment plan.')
+  end
+
+  def payment_missing_due_date_item
+    attention_item(
+      tier: :housekeeping,
+      id: :cash_payment_due,
+      title: 'Cash payment due',
+      detail: 'No next payment due date is recorded yet. Please contact an admin.',
+      action: {
+        label: 'Open Payments tab',
+        path: tab_path(:payments)
+      }
+    )
+  end
+
+  def payment_overdue_item(due_on, days_until)
+    attention_item(
+      tier: :urgent,
+      id: :cash_payment_due,
+      title: 'Cash payment due',
+      detail: "Your next cash payment was due #{date_text(due_on)} (#{days_until.abs} days overdue).",
+      action: {
+        label: 'Open Payments tab',
+        path: tab_path(:payments)
+      }
+    )
+  end
+
+  def payment_due_soon_item(due_on, days_until)
+    attention_item(
+      tier: :important,
+      id: :cash_payment_due,
+      title: 'Cash payment due soon',
+      detail: "Your next cash payment is due in #{days_until} days (#{date_text(due_on)}).",
+      action: {
+        label: 'Open Payments tab',
+        path: tab_path(:payments)
+      }
+    )
+  end
+
+  def payment_ok_item(due_on, days_until)
+    ok_item(
+      :cash_payment_due,
+      'Cash payment due',
+      "Your next cash payment is due in #{days_until} days (#{date_text(due_on)})."
+    )
+  end
+
+  def training_item
+    pending_count = user.training_requests.pending.count
+    return training_pending_item(pending_count) if pending_count.positive?
+
+    ok_item(:training_requests, 'Open training requests', 'You have no open training requests.')
+  end
+
+  def training_pending_item(pending_count)
+    attention_item(
+      tier: :important,
+      id: :training_requests,
+      title: 'Open training requests',
+      detail: "You have #{pending_count} open training request#{'s' unless pending_count == 1}.",
+      action: {
+        label: 'Open Profile tab',
+        path: tab_path(:profile)
+      }
+    )
+  end
+
+  def slack_item
+    return ok_item(:slack_signup, 'Slack account', 'Your account is linked to Slack.') if user.slack_user.present?
+
+    attention_item(
+      tier: :housekeeping,
+      id: :slack_signup,
+      title: 'Join Slack',
+      detail: 'You do not have a linked Slack user yet. Please ask an admin for an invite.',
+      action: {
+        label: 'Open Profile tab',
+        path: tab_path(:profile)
+      }
+    )
+  end
+
+  def parking_item
+    notices = user.parking_notices.not_cleared
+    expired_count = notices.expired_notices.count
+    active_count = notices.active_notices.count
+
+    return parking_expired_item(expired_count, active_count) if expired_count.positive?
+    return parking_active_item(active_count) if active_count.positive?
+
+    ok_item(
+      :parking_notices,
+      'Open parking permits/tickets',
+      'You have no open parking permits or tickets.'
+    )
+  end
+
+  def parking_expired_item(expired_count, active_count)
+    total_count = expired_count + active_count
+    attention_item(
+      tier: :urgent,
+      id: :parking_notices,
+      title: 'Open parking permits/tickets',
+      detail: "#{expired_count} expired and #{active_count} active open parking notice#{'s' unless total_count == 1}.",
+      action: {
+        label: 'Open Parking tab',
+        path: tab_path(:parking)
+      }
+    )
+  end
+
+  def parking_active_item(active_count)
+    attention_item(
+      tier: :important,
+      id: :parking_notices,
+      title: 'Open parking permits/tickets',
+      detail: "#{active_count} active open parking notice#{'s' unless active_count == 1}.",
+      action: {
+        label: 'Open Parking tab',
+        path: tab_path(:parking)
+      }
+    )
+  end
+
+  def manual_payment?
+    return true if user.payment_type == 'cash'
+
+    user.all_membership_plans.any?(&:manual?)
+  end
+
+  def attention_item(tier:, id:, title:, detail:, action:)
+    {
+      ok: false,
+      tier: tier,
+      id: id,
+      title: title,
+      detail: detail,
+      action_label: action[:label],
+      action_path: action[:path]
+    }
+  end
+
+  def ok_item(id, title, detail)
+    {
+      ok: true,
+      tier: :none,
+      id: id,
+      title: title,
+      detail: detail
+    }
+  end
+
+  def date_text(date)
+    date.strftime('%B %-d, %Y')
+  end
+
+  def tab_path(tab)
+    path_for_tab.call(tab)
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,4 +1,49 @@
 <div class="py-4">
+  <ul class="nav nav-tabs mb-4" role="tablist">
+    <li class="nav-item" role="presentation">
+      <%= link_to root_path(tab: :admin_dashboard), class: "nav-link #{'active' if @active_tab == :admin_dashboard}", role: "tab" do %>
+        <i class="bi bi-speedometer2 me-1"></i> Admin Dashboard
+      <% end %>
+    </li>
+    <li class="nav-item" role="presentation">
+      <%= link_to root_path(tab: :member_dashboard), class: "nav-link #{'active' if @active_tab == :member_dashboard}", role: "tab" do %>
+        <i class="bi bi-person-badge me-1"></i> Member Dashboard
+      <% end %>
+    </li>
+    <li class="nav-item" role="presentation">
+      <%= link_to root_path(tab: :profile), class: "nav-link #{'active' if @active_tab == :profile}", role: "tab" do %>
+        <i class="bi bi-person me-1"></i> Profile
+      <% end %>
+    </li>
+    <li class="nav-item" role="presentation">
+      <%= link_to root_path(tab: :payments), class: "nav-link #{'active' if @active_tab == :payments}", role: "tab" do %>
+        <i class="bi bi-credit-card me-1"></i> Payment History
+        <% if @home_payments_count.to_i > 0 %>
+          <span class="badge bg-secondary ms-1"><%= @home_payments_count %></span>
+        <% end %>
+      <% end %>
+    </li>
+    <% if @home_parking_notices_count.to_i > 0 %>
+      <li class="nav-item" role="presentation">
+        <%= link_to root_path(tab: :parking), class: "nav-link #{'active' if @active_tab == :parking}", role: "tab" do %>
+          <i class="bi bi-car-front me-1"></i> Parking
+          <span class="badge bg-secondary ms-1"><%= @home_parking_notices_count %></span>
+        <% end %>
+      </li>
+    <% end %>
+    <li class="nav-item" role="presentation">
+      <%= link_to root_path(tab: :messages), class: "nav-link #{'active' if @active_tab == :messages}", role: "tab" do %>
+        <i class="bi bi-chat-dots me-1"></i> Messages
+        <% if @home_unread_messages_count.to_i > 0 %>
+          <span class="badge bg-danger ms-1"><%= @home_unread_messages_count %></span>
+        <% elsif @home_messages_count.to_i > 0 %>
+          <span class="badge bg-secondary ms-1"><%= @home_messages_count %></span>
+        <% end %>
+      <% end %>
+    </li>
+  </ul>
+
+  <% if @active_tab == :admin_dashboard %>
   <!-- Member Search (full width) -->
   <div class="card dashboard-panel dashboard-panel-search mb-4">
     <div class="card-body py-3">
@@ -172,8 +217,22 @@
       </div>
     </div>
   </div>
-</div>
 
+  <% elsif @active_tab == :member_dashboard %>
+    <%= render 'users/tab_dashboard_self', user: @home_user %>
+  <% elsif @active_tab == :profile %>
+    <%= render 'users/tab_profile_self', user: @home_user %>
+  <% elsif @active_tab == :payments %>
+    <%= render 'users/tab_payments', payments: @home_payments, pagy: @pagy_payments, user: @home_user, show_payment_links: false, dashboard_mode: true %>
+  <% elsif @active_tab == :parking %>
+    <%= render 'users/tab_parking', parking_notices: @home_parking_notices_list, show_actions: false %>
+  <% elsif @active_tab == :messages %>
+    <%= render 'users/tab_messages', messages: @home_messages, pagy: @pagy_messages, user: @home_user, show_send: false %>
+  <% else %>
+    <%= render 'users/tab_dashboard_self', user: @home_user %>
+  <% end %>
+
+<% if @active_tab == :admin_dashboard %>
 <script>
   (function() {
     var _debounceTimer = null;
@@ -273,3 +332,5 @@
     document.addEventListener('turbo:load', initDashboardSearch);
   })();
 </script>
+<% end %>
+</div>

--- a/app/views/member_parking_permits/new.html.erb
+++ b/app/views/member_parking_permits/new.html.erb
@@ -1,0 +1,50 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">New Parking Permit</h1>
+  <%= link_to "&larr; Back to profile".html_safe, user_path(current_user, tab: :profile), class: "text-decoration-none" %>
+</div>
+
+<div class="card shadow-sm border-0">
+  <div class="card-body">
+    <%= form_with model: @parking_notice, url: member_parking_permits_path, local: true do |f| %>
+      <% if @parking_notice.errors.any? %>
+        <div class="alert alert-danger">
+          <h6><%= pluralize(@parking_notice.errors.count, 'error') %> prevented this parking permit from being saved:</h6>
+          <ul class="mb-0">
+            <% @parking_notice.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="mb-3">
+        <%= f.label :description, class: 'form-label' %>
+        <%= f.text_area :description, class: 'form-control', rows: 3, placeholder: 'Describe your project or item...' %>
+      </div>
+
+      <div class="row g-3">
+        <div class="col-md-6">
+          <%= f.label :location, 'Room / Location', class: 'form-label' %>
+          <%= f.text_field :location, class: 'form-control', placeholder: 'Example: Woodshop' %>
+        </div>
+        <div class="col-md-6">
+          <%= f.label :location_detail, 'Location detail', class: 'form-label' %>
+          <%= f.text_field :location_detail, class: 'form-control', placeholder: 'Example: South wall shelf' %>
+        </div>
+      </div>
+
+      <div class="mt-3 mb-4">
+        <%= f.label :expires_at, 'Expiration', class: 'form-label' %>
+        <%= f.datetime_local_field :expires_at,
+                                   class: 'form-control',
+                                   required: true,
+                                   value: @parking_notice.expires_at&.strftime('%Y-%m-%dT%H:%M') %>
+      </div>
+
+      <div class="d-flex gap-2">
+        <%= f.submit 'Create Parking Permit', class: 'btn btn-success' %>
+        <%= link_to 'Cancel', user_path(current_user, tab: :profile), class: 'btn btn-outline-secondary' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/training_requests/new.html.erb
+++ b/app/views/training_requests/new.html.erb
@@ -1,0 +1,41 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">Request Training</h1>
+  <%= link_to "&larr; Back to profile".html_safe, user_path(current_user, tab: :profile), class: "text-decoration-none" %>
+</div>
+
+<div class="card shadow-sm border-0">
+  <div class="card-body">
+    <% if @member_requestable_topics.any? %>
+      <%= form_with scope: :training_request, url: training_requests_path, local: true do |f| %>
+        <div class="row g-3 align-items-end">
+          <div class="col-md-6">
+            <%= f.label :training_topic_id, 'Training topic', class: 'form-label' %>
+            <%= f.select :training_topic_id,
+                         options_from_collection_for_select(@member_requestable_topics, :id, :name),
+                         { include_blank: 'Choose a topic' },
+                         { class: 'form-select', required: true } %>
+          </div>
+          <div class="col-md-6">
+            <div class="form-check mt-4">
+              <%= f.check_box :share_contact_info, class: 'form-check-input', required: true %>
+              <%= f.label :share_contact_info,
+                          'I consent to sharing my email and Slack handle (if available) with trainers for this topic.',
+                          class: 'form-check-label' %>
+            </div>
+          </div>
+        </div>
+
+        <div class="alert alert-secondary mt-3 mb-3">
+          If you do not see the training topic you need, please post in <strong>#help</strong> on Slack
+          or email <a href="mailto:info@pdxhackerspace.org">info@pdxhackerspace.org</a>.
+        </div>
+
+        <%= f.submit 'Request Training', class: 'btn btn-primary' %>
+      <% end %>
+    <% else %>
+      <div class="alert alert-secondary mb-0">
+        No training topics are currently available for member requests.
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/_tab_dashboard_self.html.erb
+++ b/app/views/users/_tab_dashboard_self.html.erb
@@ -1,0 +1,69 @@
+<% tier_class = {
+  urgent: 'text-bg-danger',
+  important: 'text-bg-warning',
+  housekeeping: 'text-bg-secondary'
+} %>
+<% tier_label = {
+  urgent: 'Urgent',
+  important: 'Important',
+  housekeeping: 'Housekeeping'
+} %>
+
+<div class="row g-4">
+  <div class="col-lg-6">
+    <div class="card shadow-sm border-0 h-100">
+      <div class="card-body">
+        <h2 class="h5 mb-3">
+          <i class="bi bi-exclamation-circle me-2 text-danger"></i>Needs Attention
+        </h2>
+
+        <% if @member_dashboard_attention_items.any? %>
+          <div class="list-group list-group-flush">
+            <% @member_dashboard_attention_items.each do |item| %>
+              <div class="list-group-item px-0">
+                <div class="d-flex justify-content-between align-items-start gap-2 mb-1">
+                  <strong><%= item[:title] %></strong>
+                  <span class="badge <%= tier_class[item[:tier]] %>"><%= tier_label[item[:tier]] %></span>
+                </div>
+                <p class="mb-2 text-secondary"><%= item[:detail] %></p>
+                <% if item[:action_path].present? && item[:action_label].present? %>
+                  <%= link_to item[:action_label], item[:action_path], class: 'btn btn-outline-primary btn-sm' %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="alert alert-success mb-0">
+            Everything looks good right now. Nothing needs immediate action.
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-6">
+    <div class="card shadow-sm border-0 h-100">
+      <div class="card-body">
+        <h2 class="h5 mb-3">
+          <i class="bi bi-check-circle me-2 text-success"></i>No Action Required
+        </h2>
+
+        <% if @member_dashboard_ok_items.any? %>
+          <div class="list-group list-group-flush">
+            <% @member_dashboard_ok_items.each do |item| %>
+              <div class="list-group-item px-0">
+                <div class="d-flex justify-content-between align-items-start gap-2 mb-1">
+                  <strong><%= item[:title] %></strong>
+                  <span class="badge text-bg-success">OK</span>
+                </div>
+                <p class="mb-0 text-secondary"><%= item[:detail] %></p>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="text-muted">No informational items to show.</div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/_tab_payments.html.erb
+++ b/app/views/users/_tab_payments.html.erb
@@ -2,6 +2,14 @@
 <%# Params: payments, pagy, user, show_payment_links (optional, defaults to false) %>
 <div class="card shadow-sm border-0">
   <div class="card-body">
+    <% dashboard_mode = local_assigns[:dashboard_mode] %>
+    <% payments_tab_path = lambda do |extra = {}|
+         if dashboard_mode
+           root_path({ tab: :payments, view_as: params[:view_as] }.merge(extra))
+         else
+           user_path(user, { tab: :payments, view_as: params[:view_as] }.merge(extra))
+         end
+       end %>
     <div class="d-flex justify-content-between align-items-center mb-3">
       <h2 class="h6 mb-0">Payment Events</h2>
       <% if local_assigns[:show_payment_links] && user.personal_membership_plans.any? %>
@@ -11,12 +19,12 @@
 
     <% current_filter = @payment_event_filter %>
     <div class="btn-group btn-group-sm mb-3" role="group">
-      <%= link_to "All", user_path(user, tab: :payments), class: "btn #{current_filter.blank? ? 'btn-primary' : 'btn-outline-primary'}" %>
-      <%= link_to "Payments", user_path(user, tab: :payments, event_type: 'payment'), class: "btn #{current_filter == 'payment' ? 'btn-primary' : 'btn-outline-primary'}" %>
-      <%= link_to "Subscriptions", user_path(user, tab: :payments, event_type: 'subscription_started'), class: "btn #{current_filter == 'subscription_started' ? 'btn-primary' : 'btn-outline-primary'}" %>
-      <%= link_to "Cancellations", user_path(user, tab: :payments, event_type: 'subscription_cancelled'), class: "btn #{current_filter == 'subscription_cancelled' ? 'btn-primary' : 'btn-outline-primary'}" %>
-      <%= link_to "Paused", user_path(user, tab: :payments, event_type: 'subscription_paused'), class: "btn #{current_filter == 'subscription_paused' ? 'btn-primary' : 'btn-outline-primary'}" %>
-      <%= link_to "Resumed", user_path(user, tab: :payments, event_type: 'subscription_resumed'), class: "btn #{current_filter == 'subscription_resumed' ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <%= link_to "All", payments_tab_path.call, class: "btn #{current_filter.blank? ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <%= link_to "Payments", payments_tab_path.call(event_type: 'payment'), class: "btn #{current_filter == 'payment' ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <%= link_to "Subscriptions", payments_tab_path.call(event_type: 'subscription_started'), class: "btn #{current_filter == 'subscription_started' ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <%= link_to "Cancellations", payments_tab_path.call(event_type: 'subscription_cancelled'), class: "btn #{current_filter == 'subscription_cancelled' ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <%= link_to "Paused", payments_tab_path.call(event_type: 'subscription_paused'), class: "btn #{current_filter == 'subscription_paused' ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <%= link_to "Resumed", payments_tab_path.call(event_type: 'subscription_resumed'), class: "btn #{current_filter == 'subscription_resumed' ? 'btn-primary' : 'btn-outline-primary'}" %>
     </div>
 
     <% if payments.any? %>
@@ -52,7 +60,13 @@
         </table>
       </div>
       <% if local_assigns[:pagy] && local_assigns[:user] %>
-        <%= render 'shared/pagination', pagy: pagy, user: user, tab: :payments %>
+        <% if dashboard_mode %>
+          <div class="mt-3">
+            <%== pagy_bootstrap_nav(pagy) %>
+          </div>
+        <% else %>
+          <%= render 'shared/pagination', pagy: pagy, user: user, tab: :payments %>
+        <% end %>
       <% end %>
     <% else %>
       <p class="text-muted mb-0">

--- a/app/views/users/_tab_profile_self.html.erb
+++ b/app/views/users/_tab_profile_self.html.erb
@@ -1,35 +1,18 @@
 <%# Self Profile Tab - what the user sees on their own profile %>
 <div class="card shadow-sm border-0 mb-4">
   <div class="card-body">
-    <h2 class="h5 mb-3"><i class="bi bi-mortarboard me-2"></i>Request Training</h2>
-    <% if @member_requestable_topics.any? %>
-      <%= form_with scope: :training_request, url: training_requests_path, local: true do |f| %>
-        <div class="row g-3 align-items-end">
-          <div class="col-md-6">
-            <%= f.label :training_topic_id, 'Training topic', class: 'form-label' %>
-            <%= f.select :training_topic_id,
-                         options_from_collection_for_select(@member_requestable_topics, :id, :name),
-                         { include_blank: 'Choose a topic' },
-                         { class: 'form-select', required: true } %>
-          </div>
-          <div class="col-md-6">
-            <div class="form-check mt-4">
-              <%= f.check_box :share_contact_info, class: 'form-check-input', required: true %>
-              <%= f.label :share_contact_info,
-                          'I consent to sharing my email and Slack handle (if available) with trainers for this topic.',
-                          class: 'form-check-label' %>
-            </div>
-          </div>
-        </div>
-        <div class="alert alert-secondary mt-3 mb-3">
-          If you do not see the training topic you need, please post in <strong>#help</strong> on Slack
-          or email <a href="mailto:info@pdxhackerspace.org">info@pdxhackerspace.org</a>.
-        </div>
-        <%= f.submit 'Request Training', class: 'btn btn-primary' %>
+    <h2 class="h5 mb-3"><i class="bi bi-lightning-charge me-2"></i>Quick Actions</h2>
+    <div class="d-flex flex-wrap gap-2">
+      <%= link_to new_training_request_path, class: 'btn btn-primary' do %>
+        <i class="bi bi-mortarboard me-1"></i> Request Training
       <% end %>
-    <% else %>
-      <div class="alert alert-secondary mb-0">
-        No training topics are currently available for member requests.
+      <%= link_to new_member_parking_permit_path, class: 'btn btn-success' do %>
+        <i class="bi bi-p-circle me-1"></i> Parking Permit
+      <% end %>
+    </div>
+    <% unless @member_requestable_topics.any? %>
+      <div class="alert alert-secondary mb-0 mt-3">
+        Training requests are temporarily unavailable because no topics are currently open for member requests.
       </div>
     <% end %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -351,6 +351,13 @@
   <%# ===== SELF VIEW WITH TABS ===== %>
   <ul class="nav nav-tabs mb-4" role="tablist">
     <li class="nav-item" role="presentation">
+      <%= link_to user_path(@user, tab: :dashboard, view_as: params[:view_as]),
+          class: "nav-link #{'active' if @active_tab == :dashboard}",
+          role: "tab" do %>
+        <i class="bi bi-speedometer2 me-1"></i> Dashboard
+      <% end %>
+    </li>
+    <li class="nav-item" role="presentation">
       <%= link_to user_path(@user, tab: :profile, view_as: params[:view_as]), 
           class: "nav-link #{'active' if @active_tab == :profile}", 
           role: "tab" do %>
@@ -392,7 +399,9 @@
   </ul>
 
   <div class="tab-content">
-    <% if @active_tab == :profile %>
+    <% if @active_tab == :dashboard %>
+      <%= render 'users/tab_dashboard_self', user: @user %>
+    <% elsif @active_tab == :profile %>
       <%= render 'users/tab_profile_self', user: @user %>
     <% elsif @active_tab == :payments %>
       <%= render 'users/tab_payments', payments: @payments, pagy: @pagy_payments, user: @user, show_payment_links: false %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,8 @@ Rails.application.routes.draw do
   delete "/impersonate", to: "impersonations#destroy", as: :stop_impersonation
 
   resources :messages, only: [:create]
-  resources :training_requests, only: %i[create edit update]
+  resources :training_requests, only: %i[new create edit update]
+  resources :member_parking_permits, only: %i[new create]
 
   resources :users, only: [:index, :show, :new, :create, :edit, :update, :destroy], constraints: { id: /[^\/]+/ } do
     member do

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class DashboardControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+    sign_in_as_admin
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+  end
+
+  test 'admin home defaults to admin dashboard tab' do
+    get root_path
+    assert_response :success
+
+    assert_match(/Admin Dashboard/i, response.body)
+    assert_match(/Member Dashboard/i, response.body)
+    assert_match(/Find a member by name, email or username/i, response.body)
+    assert_match(/Recent Highlights/i, response.body)
+  end
+
+  test 'admin home member dashboard tab renders member dashboard content' do
+    get root_path(tab: :member_dashboard)
+    assert_response :success
+
+    assert_match(/Needs Attention/i, response.body)
+    assert_match(/No Action Required/i, response.body)
+    assert_match(/Open training requests/i, response.body)
+  end
+
+  test 'admin home includes normal user tabs' do
+    get root_path(tab: :payments)
+    assert_response :success
+    assert_match(/Payment Events/i, response.body)
+
+    get root_path(tab: :profile)
+    assert_response :success
+    assert_match(/Request Training/i, response.body)
+  end
+
+  private
+
+  def sign_in_as_admin
+    account = local_accounts(:active_admin)
+    post local_login_path, params: {
+      session: {
+        email: account.email,
+        password: 'localpassword123'
+      }
+    }
+  end
+end

--- a/test/controllers/member_parking_permits_controller_test.rb
+++ b/test/controllers/member_parking_permits_controller_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+  end
+
+  test 'member can open new permit form' do
+    sign_in_as_member
+
+    get new_member_parking_permit_path
+    assert_response :success
+    assert_match(/New Parking Permit/i, response.body)
+  end
+
+  test 'member can create own parking permit' do
+    sign_in_as_member
+    member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
+
+    assert_difference 'ParkingNotice.count', 1 do
+      post member_parking_permits_path, params: {
+        parking_notice: {
+          description: 'My project',
+          location: 'Woodshop',
+          location_detail: 'Bench A',
+          expires_at: 3.days.from_now.strftime('%Y-%m-%dT%H:%M')
+        }
+      }
+    end
+
+    notice = ParkingNotice.order(:created_at).last
+    assert_equal 'permit', notice.notice_type
+    assert_equal 'active', notice.status
+    assert_equal member.id, notice.user_id
+    assert_equal member.id, notice.issued_by_id
+    assert_redirected_to user_path(member, tab: :parking)
+  end
+
+  test 'anonymous user cannot access member permit form' do
+    get new_member_parking_permit_path
+    assert_redirected_to login_path
+  end
+
+  private
+
+  def sign_in_as_member
+    post local_login_path, params: {
+      session: { email: local_accounts(:regular_member).email, password: 'memberpassword123' }
+    }
+  end
+end

--- a/test/controllers/training_requests_controller_test.rb
+++ b/test/controllers/training_requests_controller_test.rb
@@ -15,6 +15,7 @@ class TrainingRequestsControllerTest < ActionDispatch::IntegrationTest
 
   test 'member can request training for offered topic' do
     sign_in_as_member
+    member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
 
     assert_difference 'TrainingRequest.count', 1 do
       assert_difference 'QueuedMail.count', 3 do
@@ -29,7 +30,7 @@ class TrainingRequestsControllerTest < ActionDispatch::IntegrationTest
 
     request = TrainingRequest.order(:created_at).last
     assert_equal 'pending', request.status
-    assert_redirected_to user_path(User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}"))
+    assert_redirected_to user_path(member, tab: :profile)
   end
 
   test 'member must consent to sharing contact info' do
@@ -44,8 +45,18 @@ class TrainingRequestsControllerTest < ActionDispatch::IntegrationTest
       }
     end
 
-    assert_redirected_to user_path(User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}"))
+    assert_redirected_to new_training_request_path
     assert_equal 'Please confirm contact sharing to submit your request.', flash[:alert]
+  end
+
+  test 'member can open new training request page' do
+    sign_in_as_member
+
+    get new_training_request_path
+    assert_response :success
+    assert_match(/Request Training/i, response.body)
+    assert_match 'name="training_request[training_topic_id]"', response.body
+    assert_match 'name="training_request[share_contact_info]"', response.body
   end
 
   test 'trainer can open response form for request in their topic' do
@@ -82,14 +93,14 @@ class TrainingRequestsControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil request.responded_at
   end
 
-  test 'member profile renders training request fields under training_request scope' do
+  test 'member profile links to training request page' do
     sign_in_as_member
     member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
 
-    get user_path(member)
+    get user_path(member, tab: :profile)
     assert_response :success
-    assert_match 'name="training_request[training_topic_id]"', response.body
-    assert_match 'name="training_request[share_contact_info]"', response.body
+    assert_match(/Request Training/i, response.body)
+    assert_match(new_training_request_path, response.body)
   end
 
   private

--- a/test/controllers/user_profile_visibility_test.rb
+++ b/test/controllers/user_profile_visibility_test.rb
@@ -121,16 +121,27 @@ class UserProfileVisibilityTest < ActionDispatch::IntegrationTest
 
     # Should see nav tabs
     assert_match(/nav-tabs/, response.body)
+    assert_match(/Dashboard/i, response.body)
     assert_match(/Profile/, response.body)
     assert_match(/Payment History/i, response.body)
   end
 
-  test 'user sees status panel on their own profile' do
+  test 'user sees dashboard tab by default on their own profile' do
     sign_in_as_member
     get user_path(@member_with_account)
     assert_response :success
 
-    # Should see status panel
+    assert_match(/Needs Attention/i, response.body)
+    assert_match(/No Action Required/i, response.body)
+    assert_match(/Open training requests/i, response.body)
+    assert_match(/Join Slack/i, response.body)
+  end
+
+  test 'user sees status panel on profile tab' do
+    sign_in_as_member
+    get user_path(@member_with_account, tab: :profile)
+    assert_response :success
+
     assert_match(/Payment Type/i, response.body)
     assert_match(/Membership Status/i, response.body)
   end
@@ -140,6 +151,42 @@ class UserProfileVisibilityTest < ActionDispatch::IntegrationTest
     get user_path(@member_with_account, tab: :payments)
     assert_response :success
     assert_match(/Payment History/i, response.body)
+  end
+
+  test 'dashboard shows due soon cash payment and urgent expired parking' do
+    @member_with_account.update!(
+      payment_type: 'cash',
+      dues_due_at: 3.days.from_now
+    )
+
+    ParkingNotice.create!(
+      notice_type: 'permit',
+      status: 'active',
+      user: @member_with_account,
+      issued_by: @members_user,
+      description: 'Active member permit',
+      location: 'Woodshop',
+      expires_at: 5.days.from_now
+    )
+    ParkingNotice.create!(
+      notice_type: 'ticket',
+      status: 'expired',
+      user: @member_with_account,
+      issued_by: @members_user,
+      description: 'Expired ticket',
+      location: 'Electronics',
+      expires_at: 2.days.ago
+    )
+
+    sign_in_as_member
+    get user_path(@member_with_account)
+    assert_response :success
+
+    assert_match(/Cash payment due soon/i, response.body)
+    assert_match(/due in 3 days/i, response.body)
+    assert_match(%r{Open parking permits/tickets}i, response.body)
+    assert_match(/expired and 1 active open parking/i, response.body)
+    assert_match(/Urgent/i, response.body)
   end
 
   test 'user sees edit button on their own profile' do


### PR DESCRIPTION
This makes admin home include member-style tabs, adds a dedicated training request page, and lets members create their own parking permits while preserving attention/urgency dashboard signals.

Made-with: Cursor