### PR TITLE
Add admin profile links to membership applications

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -497,7 +497,7 @@ class UsersController < AuthenticatedController
 
   def set_user_for_show
     @user = User.includes(
-      :sheet_entry, :slack_user, :rfids, :user_links,
+      :sheet_entry, :slack_user, :rfids, :user_links, :membership_applications,
       trainings_as_trainee: :training_topic, training_topics: []
     ).find_by_param(params[:id])
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   has_many :reported_incidents, class_name: 'IncidentReport', foreign_key: 'reporter_id', dependent: :nullify
   has_and_belongs_to_many :incident_reports, join_table: 'incident_report_members'
   has_many :parking_notices, dependent: :nullify
-  has_many :membership_applications, dependent: :nullify
+  has_many :membership_applications, -> { newest_first }, dependent: :nullify, inverse_of: :user
   has_many :invitations, dependent: :nullify
   has_many :sent_invitations, class_name: 'Invitation', foreign_key: 'invited_by_id', dependent: :nullify
   has_many :sent_messages, class_name: 'Message', foreign_key: 'sender_id', dependent: :destroy

--- a/app/views/users/_tab_profile_admin.html.erb
+++ b/app/views/users/_tab_profile_admin.html.erb
@@ -83,6 +83,27 @@
             <% end %>
           </dd>
 
+          <dt class="col-sm-3 text-secondary">Membership application</dt>
+          <dd class="col-sm-9">
+            <% if user.membership_applications.any? %>
+              <ul class="list-unstyled mb-0">
+                <% user.membership_applications.each do |app| %>
+                  <% status_class = { 'draft' => 'text-bg-secondary', 'submitted' => 'text-bg-warning text-dark',
+                                      'approved' => 'text-bg-success', 'rejected' => 'text-bg-danger' }[app.status] || 'text-bg-secondary' %>
+                  <li class="mb-1">
+                    <%= link_to membership_application_path(app), class: "text-decoration-none" do %>
+                      <span class="me-1">Application #<%= app.id %></span>
+                      <span class="badge <%= status_class %>"><%= app.status.titleize %></span>
+                    <% end %>
+                    <span class="text-muted small ms-1"><%= l(app.created_at, format: :long) %></span>
+                  </li>
+                <% end %>
+              </ul>
+            <% else %>
+              <span class="text-muted fst-italic">None linked</span>
+            <% end %>
+          </dd>
+
           <dt class="col-sm-3 text-secondary">Slack</dt>
           <dd class="col-sm-9">
             <% if user.slack_handle.present? || user.slack_id.present? %>

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -38,6 +38,25 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Please choose a CSV file to import.', flash[:alert]
   end
 
+  test 'non-admin cannot view membership application show' do
+    app = MembershipApplication.create!(
+      email: 'non-admin-denied@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+
+    delete logout_path
+    account = local_accounts(:regular_member)
+    post local_login_path, params: {
+      session: { email: account.email, password: 'memberpassword123' }
+    }
+
+    get membership_application_path(app)
+
+    assert_redirected_to user_path(users(:member_with_local_account))
+    assert_equal 'You do not have access to that section.', flash[:alert]
+  end
+
   test 'link_user associates member with application' do
     app = MembershipApplication.create!(
       email: 'link-app-test@example.com',

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -25,6 +25,40 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Payment Events/i, response.body)
   end
 
+  test 'admin profile tab links to linked membership applications' do
+    app = MembershipApplication.create!(
+      email: 'profile-link-test@example.com',
+      user: @user,
+      status: 'approved',
+      submitted_at: 1.day.ago,
+      reviewed_at: Time.current
+    )
+
+    get user_path(@user, tab: :profile)
+
+    assert_response :success
+    assert_select 'a[href=?]', membership_application_path(app), text: /Application ##{app.id}/
+  end
+
+  test 'member profile does not show membership application links' do
+    member = users(:member_with_local_account)
+    app = MembershipApplication.create!(
+      email: 'member-hidden-app@example.com',
+      user: member,
+      status: 'approved',
+      submitted_at: 1.day.ago,
+      reviewed_at: Time.current
+    )
+
+    delete logout_path
+    sign_in_as_regular_member
+
+    get user_path(member, tab: :profile)
+
+    assert_response :success
+    assert_select 'a[href=?]', membership_application_path(app), count: 0
+  end
+
   # ─── Disabled Source Guards ──────────────────────────────────────
 
   test 'sync from authentik redirects with alert when authentik source is disabled' do
@@ -80,6 +114,16 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       session: {
         email: account.email,
         password: 'localpassword123'
+      }
+    }
+  end
+
+  def sign_in_as_regular_member
+    account = local_accounts(:regular_member)
+    post local_login_path, params: {
+      session: {
+        email: account.email,
+        password: 'memberpassword123'
       }
     }
   end


### PR DESCRIPTION
Link each linked application from the admin member profile tab with status and date. Eager-load applications on user show and order newest first. Add tests that members cannot access application show or see profile links.

Made-with: Cursor