### PR TITLE
Fix membership application CSV re-import and Unlinked tab behavior

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -47,7 +47,7 @@ class MembershipApplicationsController < ApplicationController
                     when 'all'
                       @applications
                     when 'unlinked'
-                      @applications.where(user_id: nil).where.not(status: 'rejected')
+                      @applications.where(user_id: nil).where(status: 'approved')
                     else
                       @applications.where(status: @current_status)
                     end
@@ -58,7 +58,7 @@ class MembershipApplicationsController < ApplicationController
       submitted: MembershipApplication.submitted_apps.count,
       approved: MembershipApplication.approved.count,
       rejected: MembershipApplication.rejected.count,
-      unlinked: MembershipApplication.where.not(status: %w[draft rejected]).where(user_id: nil).count
+      unlinked: MembershipApplication.where(status: 'approved').where(user_id: nil).count
     }
 
     @pagy, @applications = pagy(@applications, limit: 25)

--- a/app/services/membership_applications/csv_importer.rb
+++ b/app/services/membership_applications/csv_importer.rb
@@ -6,7 +6,8 @@ module MembershipApplications
   # Imports historical membership application rows from CSV exports.
   # Does not call +submit!+, +approve!+, or +reject!+ — no journal entries and no mail side effects.
   class CsvImporter
-    RESERVED_HEADERS = %w[Approved Timestamp Email Address].freeze
+    # Full header strings as they appear in CSVs (do not use %w[Email Address] — that splits).
+    RESERVED_HEADERS = ['Approved', 'Timestamp', 'Email Address'].freeze
 
     def initialize(imported_by: nil, logger: Rails.logger)
       @imported_by = imported_by
@@ -52,14 +53,58 @@ module MembershipApplications
       end
 
       submitted_at = parse_timestamp(row_hash['Timestamp'])
-      status, reviewed_at = interpret_approved(row_hash['Approved'])
-      reviewed_at = finalize_reviewed_at(status, reviewed_at, submitted_at)
+      status, rev_at, approved_notes = interpret_approved(row_hash['Approved'])
+      reviewed_at = finalize_reviewed_at(status, rev_at, submitted_at)
+      row_meta = {
+        submitted_at: submitted_at, status: status, reviewed_at: reviewed_at, approved_notes: approved_notes
+      }
 
-      app = build_application(row_hash, email:, status:, submitted_at:, reviewed_at:)
-      app.save!
-      create_answers!(row_hash, app)
+      existing = find_existing_non_draft_application(email)
+      if existing
+        merge_application!(existing, row_hash, row_meta)
+        create_or_update_answers!(row_hash, existing)
+      else
+        app = build_application(row_hash, email, row_meta)
+        app.save!
+        create_or_update_answers!(row_hash, app)
+      end
 
       counts[:imported] += 1
+    end
+
+    def find_existing_non_draft_application(email)
+      MembershipApplication.where.not(status: 'draft')
+                           .where('LOWER(email) = ?', email.downcase)
+                           .order(created_at: :desc)
+                           .first
+    end
+
+    def merge_application!(app, row_hash, row_meta)
+      submitted_at = row_meta[:submitted_at]
+      status = row_meta[:status]
+      reviewed_at = row_meta[:reviewed_at]
+      approved_notes = row_meta[:approved_notes]
+
+      extras = unmapped_column_notes(row_hash)
+      new_notes = compose_admin_notes(approved_notes, extras)
+      attrs = {}
+      attrs[:submitted_at] = submitted_at if submitted_at.present? && app.submitted_at.blank?
+
+      if app.submitted?
+        attrs[:status] = status
+        if status.in?(%w[approved rejected])
+          attrs[:reviewed_at] = reviewed_at
+          attrs[:reviewed_by] = @imported_by if app.reviewed_by.nil?
+        end
+      end
+
+      attrs[:admin_notes] = merge_note_segments(app.admin_notes, new_notes) if new_notes.present?
+
+      app.update!(attrs) if attrs.any?
+    end
+
+    def merge_note_segments(*parts)
+      parts.flatten.compact.map(&:strip).compact_blank.uniq.join("\n\n").presence
     end
 
     def finalize_reviewed_at(status, reviewed_at, submitted_at)
@@ -68,7 +113,12 @@ module MembershipApplications
       reviewed_at || submitted_at || Time.current
     end
 
-    def build_application(row_hash, email:, status:, submitted_at:, reviewed_at:)
+    def build_application(row_hash, email, row_meta)
+      status = row_meta[:status]
+      submitted_at = row_meta[:submitted_at]
+      reviewed_at = row_meta[:reviewed_at]
+      approved_notes = row_meta[:approved_notes]
+
       extras = unmapped_column_notes(row_hash)
       app = MembershipApplication.new(
         email: email,
@@ -76,7 +126,7 @@ module MembershipApplications
         submitted_at: submitted_at,
         reviewed_at: reviewed_at,
         reviewed_by: (@imported_by if status.in?(%w[approved rejected])),
-        admin_notes: extras.join("\n\n").presence
+        admin_notes: compose_admin_notes(approved_notes, extras)
       )
       if submitted_at
         app.created_at = submitted_at
@@ -97,7 +147,12 @@ module MembershipApplications
       extras
     end
 
-    def create_answers!(row_hash, app)
+    def compose_admin_notes(approved_notes, extras_lines)
+      extra_text = extras_lines.join("\n\n").presence
+      merge_note_segments(approved_notes, extra_text)
+    end
+
+    def create_or_update_answers!(row_hash, app)
       row_hash.each do |header, value|
         next if RESERVED_HEADERS.include?(header)
         next if value.blank?
@@ -105,32 +160,57 @@ module MembershipApplications
         qid = @question_ids_by_label[header]
         next unless qid
 
-        ApplicationAnswer.create!(
-          membership_application: app,
-          application_form_question_id: qid,
-          value: value.to_s.strip
-        )
+        answer = app.application_answers.find_by(application_form_question_id: qid)
+        v = value.to_s.strip
+        if answer
+          answer.update!(value: v)
+        else
+          ApplicationAnswer.create!(
+            membership_application: app,
+            application_form_question_id: qid,
+            value: v
+          )
+        end
       end
     end
 
+    # Returns [status, reviewed_at, notes_from_approved_cell]
     def interpret_approved(raw)
       s = raw.to_s.strip
-      return ['submitted', nil] if s.blank?
+      return ['submitted', nil, nil] if s.blank?
 
-      return ['approved', nil] if s.match?(/\A(yes|true|1|y|approved|x)\z/i)
+      return ['approved', nil, nil] if s.match?(/\A(yes|true|1|y|approved|x)\z/i)
 
-      return ['rejected', nil] if s.match?(/\A(no|false|0|n|rejected)\z/i)
+      return ['rejected', nil, nil] if s.match?(/\A(no|false|0|n|rejected)\z/i)
+
+      return ['rejected', nil, s[1..].to_s.strip] if s.match?(/\An/i)
+
+      return ['approved', nil, nil] if s.match?(/\Ay/i)
 
       t = parse_timestamp(s)
-      return ['approved', t] if t
+      return ['approved', t, nil] if t
 
-      ['submitted', nil]
+      ['submitted', nil, s]
     end
 
+    # Parses export timestamps; uses US month/day for slash dates (e.g. 5/4/2023) so they are not read as D/M.
+    # Does not pass arbitrary prose to +Time.zone.parse+ (which can treat phrases like "next month" as valid times).
     def parse_timestamp(val)
       return nil if val.blank?
 
-      Time.zone.parse(val.to_s)
+      raw = val.to_s.strip
+
+      us = raw.match(%r{\A(\d{1,2})/(\d{1,2})/(\d{4})(?:\s+(\d{1,2}):(\d{1,2})(?::(\d{1,2}))?)?\z})
+      if us
+        return Time.zone.local(
+          us[3].to_i, us[1].to_i, us[2].to_i,
+          (us[4] || 0).to_i, (us[5] || 0).to_i, (us[6] || 0).to_i
+        )
+      end
+
+      return Time.zone.parse(raw) if raw.match?(/\A\d{4}-\d{2}-\d{2}/)
+
+      nil
     rescue ArgumentError, TypeError
       nil
     end

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -111,9 +111,15 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', membership_application_path(closed_app), count: 0
   end
 
-  test 'index unlinked tab lists only unlinked non-rejected applications' do
+  test 'index unlinked tab lists only approved applications without a linked member' do
     linked_member = users(:member_with_local_account)
     keep = MembershipApplication.create!(
+      email: 'unlinked-approved@example.com',
+      status: 'approved',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+    filtered_open = MembershipApplication.create!(
       email: 'unlinked-open@example.com',
       status: 'submitted',
       submitted_at: Time.current
@@ -125,9 +131,10 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
       reviewed_at: Time.current
     )
     filtered_linked = MembershipApplication.create!(
-      email: 'linked-open@example.com',
-      status: 'submitted',
+      email: 'linked-approved@example.com',
+      status: 'approved',
       submitted_at: Time.current,
+      reviewed_at: Time.current,
       user: linked_member
     )
 
@@ -136,11 +143,12 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'a.nav-link.active', text: /Unlinked/
     assert_select 'a[href=?]', membership_application_path(keep)
+    assert_select 'a[href=?]', membership_application_path(filtered_open), count: 0
     assert_select 'a[href=?]', membership_application_path(filtered_rejected), count: 0
     assert_select 'a[href=?]', membership_application_path(filtered_linked), count: 0
   end
 
-  test 'index unlinked count excludes rejected applications' do
+  test 'index unlinked count includes only approved without a linked member' do
     MembershipApplication.create!(
       email: 'badge-open-unlinked@example.com',
       status: 'submitted',
@@ -162,7 +170,7 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     get membership_applications_path(status: 'all')
 
     assert_response :success
-    expected_count = MembershipApplication.where.not(status: %w[draft rejected]).where(user_id: nil).count
+    expected_count = MembershipApplication.where(status: 'approved').where(user_id: nil).count
     assert_select "a[href='#{membership_applications_path(status: 'unlinked')}'] span.badge",
                   text: expected_count.to_s
   end

--- a/test/services/membership_applications/csv_importer_test.rb
+++ b/test/services/membership_applications/csv_importer_test.rb
@@ -76,5 +76,111 @@ module MembershipApplications
       assert_equal 1, result[:skipped]
       assert_match(/missing Email Address/, result[:errors].join)
     end
+
+    test 'parses US-style timestamp in Timestamp column' do
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        Yes,5/4/2023 16:13:19,us-date@example.com,Pat
+      CSV
+
+      CsvImporter.new.call(StringIO.new(csv))
+      app = MembershipApplication.find_by!(email: 'us-date@example.com')
+      assert_equal Time.zone.local(2023, 5, 4, 16, 13, 19), app.submitted_at
+    end
+
+    test 'merge fills submitted_at when missing and does not create duplicate application' do
+      existing = MembershipApplication.create!(
+        email: 'merge-submitted@example.com',
+        status: 'submitted',
+        submitted_at: nil
+      )
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        ,5/4/2023 16:13:19,merge-submitted@example.com,Pat
+      CSV
+
+      assert_no_difference 'MembershipApplication.count' do
+        result = CsvImporter.new.call(StringIO.new(csv))
+        assert_equal 1, result[:imported]
+      end
+
+      assert_equal Time.zone.local(2023, 5, 4, 16, 13, 19), existing.reload.submitted_at
+    end
+
+    test 'merge leaves submitted_at unchanged when already set' do
+      t = Time.zone.parse('2022-06-01 12:00:00')
+      existing = MembershipApplication.create!(
+        email: 'merge-keep-ts@example.com',
+        status: 'submitted',
+        submitted_at: t
+      )
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        ,5/4/2023 16:13:19,merge-keep-ts@example.com,Pat
+      CSV
+
+      CsvImporter.new.call(StringIO.new(csv))
+      assert_equal t, existing.reload.submitted_at
+    end
+
+    test 'merge updates answers without duplicate answer rows' do
+      existing = MembershipApplication.create!(
+        email: 'merge-answers@example.com',
+        status: 'submitted',
+        submitted_at: Time.current
+      )
+      existing.application_answers.create!(
+        application_form_question: @page.questions.find_by!(label: 'Name'),
+        value: 'Old'
+      )
+
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        ,2024-01-01,merge-answers@example.com,New Name
+      CSV
+
+      assert_no_difference -> { ApplicationAnswer.count } do
+        CsvImporter.new.call(StringIO.new(csv))
+      end
+
+      assert_equal 'New Name', existing.reload.application_answers
+                                       .joins(:application_form_question)
+                                       .find_by(application_form_questions: { label: 'Name' }).value
+    end
+
+    test 'Approved starting with n sets rejected and notes after n' do
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        nDid not follow up,2024-01-01,n-prefix@example.com,X
+      CSV
+
+      CsvImporter.new.call(StringIO.new(csv))
+      app = MembershipApplication.find_by!(email: 'n-prefix@example.com')
+      assert_equal 'rejected', app.status
+      assert_includes app.admin_notes, 'Did not follow up'
+    end
+
+    test 'Approved free text not starting with n or y sets submitted and stores column in admin_notes' do
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        Deferred — ask next month,2024-01-01,freetext@example.com,X
+      CSV
+
+      CsvImporter.new.call(StringIO.new(csv))
+      app = MembershipApplication.find_by!(email: 'freetext@example.com')
+      assert_equal 'submitted', app.status
+      assert_includes app.admin_notes, 'Deferred — ask next month'
+    end
+
+    test 'Email Address column is not copied into admin_notes as unmapped' do
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        Yes,2024-01-01,email-col-notes@example.com,Sam
+      CSV
+
+      CsvImporter.new.call(StringIO.new(csv))
+      app = MembershipApplication.find_by!(email: 'email-col-notes@example.com')
+      assert_nil app.admin_notes.presence
+    end
   end
 end


### PR DESCRIPTION
Match existing applications by email and merge rows without duplicates: fill submitted_at when missing, upsert answers, apply Approved column rules (n-prefix rejection with notes, free text to admin notes), and parse US M/D/YYYY timestamps.

Reserve the Email Address header so it is not treated as unmapped. Limit the Unlinked tab to approved applications without a linked member (exclude Open).

Add tests for importer merge paths, timestamp parsing, and index filters.

Made-with: Cursor