### PR TITLE
Add Under Review status and Delay for review for Executive Directors

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -76,9 +76,10 @@ class DashboardController < AdminController
     # Important: Member-suggested interests needing review
     @interests_needing_review_count = Interest.needs_review.count
 
-    # Important: Pending membership applications
+    # Important: Pending membership applications (open or under review)
     @pending_applications_count = MembershipApplication.pending.count
     @submitted_applications_count = MembershipApplication.submitted_apps.count
+    @under_review_applications_count = MembershipApplication.under_review_apps.count
 
     # Important: Parking notices
     @active_parking_permit_count = ParkingNotice.permits.active_notices.count

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -6,17 +6,18 @@ class MembershipApplicationsController < ApplicationController
   include MembershipApplicationWizard::Actions
 
   ADMIN_ACTIONS = %i[
-    index show import approve reject link_user unlink_user vote_ai_feedback
+    index show import approve reject delay_for_review link_user unlink_user vote_ai_feedback
     save_tour_feedback vote_acceptance
   ].freeze
   APPLICATION_MEMBER_ACTIONS = %i[
-    show approve reject link_user unlink_user vote_ai_feedback
+    show approve reject delay_for_review link_user unlink_user vote_ai_feedback
     save_tour_feedback vote_acceptance
   ].freeze
 
   before_action :require_admin!, only: ADMIN_ACTIONS
   before_action :set_application_admin, only: APPLICATION_MEMBER_ACTIONS
-  before_action :require_executive_director_for_final_decision!, only: %i[approve reject]
+  before_action :require_executive_director_for_final_decision!, only: %i[approve reject delay_for_review]
+  before_action :require_submitted_for_delay!, only: :delay_for_review
   before_action :require_pending_application_for_acceptance_vote!, only: :vote_acceptance
 
   # --- Admin actions ---
@@ -56,6 +57,7 @@ class MembershipApplicationsController < ApplicationController
     @status_counts = {
       all: MembershipApplication.where.not(status: 'draft').count,
       submitted: MembershipApplication.submitted_apps.count,
+      under_review: MembershipApplication.under_review_apps.count,
       approved: MembershipApplication.approved.count,
       rejected: MembershipApplication.rejected.count,
       unlinked: MembershipApplication.where(status: 'approved').where(user_id: nil).count
@@ -165,6 +167,13 @@ class MembershipApplicationsController < ApplicationController
     end
   end
 
+  def delay_for_review
+    notes = params[:admin_notes]
+    @application.delay_for_review!(current_user, notes: notes)
+    redirect_to membership_application_path(@application),
+                notice: 'Application marked as under review.'
+  end
+
   def vote_ai_feedback
     unless @application.ai_feedback_processed?
       redirect_to membership_application_path(@application),
@@ -189,7 +198,14 @@ class MembershipApplicationsController < ApplicationController
     return if true_user&.can_finalize_membership_application?
 
     redirect_to membership_application_path(@application),
-                alert: 'Only members trained as Executive Director may approve or reject applications.'
+                alert: 'Only members trained as Executive Director may approve, reject, or delay applications.'
+  end
+
+  def require_submitted_for_delay!
+    return if @application.submitted?
+
+    redirect_to membership_application_path(@application),
+                alert: 'Only open applications can be marked for delayed review.'
   end
 
   def require_pending_application_for_acceptance_vote!

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -30,6 +30,7 @@ class Journal < ApplicationRecord
     application_submitted
     application_approved
     application_rejected
+    application_delayed_for_review
   ].freeze
 
   # Fields whose changes should trigger a highlight

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -1,5 +1,5 @@
 class MembershipApplication < ApplicationRecord
-  STATUSES = %w[draft submitted approved rejected].freeze
+  STATUSES = %w[draft submitted under_review approved rejected].freeze
 
   # Training topic name (TrainingTopic.name) — viewers with this training see applicant PII without masking.
   EXECUTIVE_DIRECTOR_TRAINING_TOPIC_NAME = 'Executive Director'.freeze
@@ -39,9 +39,11 @@ class MembershipApplication < ApplicationRecord
     where.not(status: 'draft').where(ai_feedback_processed_at: nil)
   }
   scope :submitted_apps, -> { where(status: 'submitted') }
+  scope :under_review_apps, -> { where(status: 'under_review') }
   scope :approved, -> { where(status: 'approved') }
   scope :rejected, -> { where(status: 'rejected') }
-  scope :pending, -> { submitted_apps }
+  # Applications awaiting a final decision (Open or Under Review).
+  scope :pending, -> { where(status: %w[submitted under_review]) }
   scope :newest_first, -> { order(created_at: :desc) }
   scope :admin_search, lambda { |query|
     raw = query.to_s.strip
@@ -78,6 +80,10 @@ class MembershipApplication < ApplicationRecord
 
   def submitted?
     status == 'submitted'
+  end
+
+  def under_review?
+    status == 'under_review'
   end
 
   def approved?
@@ -124,8 +130,23 @@ class MembershipApplication < ApplicationRecord
     queued_mail
   end
 
+  # Marks the application as delayed for executive review (no applicant email).
+  def delay_for_review!(admin, notes: nil)
+    raise ArgumentError, 'Only open applications can be delayed for review' unless submitted?
+
+    update!(
+      status: 'under_review',
+      reviewed_by: admin,
+      reviewed_at: Time.current,
+      admin_notes: notes
+    )
+    Journal.record_application_event!(application: self, action: 'application_delayed_for_review', actor: admin)
+  end
+
   def status_display
     return 'Open' if submitted?
+
+    return 'Under Review' if under_review?
 
     status&.titleize
   end
@@ -133,6 +154,7 @@ class MembershipApplication < ApplicationRecord
   def status_badge_color
     case status
     when 'submitted' then 'primary'
+    when 'under_review' then 'warning'
     when 'approved' then 'success'
     when 'rejected' then 'danger'
     else 'secondary'

--- a/app/services/membership_applications/csv_importer.rb
+++ b/app/services/membership_applications/csv_importer.rb
@@ -90,7 +90,7 @@ module MembershipApplications
       attrs = {}
       attrs[:submitted_at] = submitted_at if submitted_at.present? && app.submitted_at.blank?
 
-      if app.submitted?
+      if app.submitted? || app.under_review?
         attrs[:status] = status
         if status.in?(%w[approved rejected])
           attrs[:reviewed_at] = reviewed_at

--- a/app/views/dashboard/_attention_item_body.html.erb
+++ b/app/views/dashboard/_attention_item_body.html.erb
@@ -85,7 +85,10 @@ when :ac_issues %>
         <strong><%= @pending_applications_count %></strong> pending membership <%= 'application'.pluralize(@pending_applications_count) %>
       <% end %>
       <div class="text-muted small mt-1">
-        <%= "#{@submitted_applications_count} open" if @submitted_applications_count > 0 %>
+        <% parts = [] %>
+        <% parts << "#{@submitted_applications_count} open" if @submitted_applications_count.to_i > 0 %>
+        <% parts << "#{@under_review_applications_count} under review" if @under_review_applications_count.to_i > 0 %>
+        <%= parts.join(', ') if parts.any? %>
       </div>
     </div>
   <% end %>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -55,6 +55,7 @@
                                when 'application_submitted' then 'text-bg-info'
                                when 'application_approved' then 'text-bg-success'
                                when 'application_rejected' then 'text-bg-danger'
+                               when 'application_delayed_for_review' then 'text-bg-warning'
                                else 'text-bg-secondary'
                                end %>
               <span class="badge <%= badge_class %>"><%= j.action.humanize %></span>

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -46,6 +46,12 @@
       <% end %>
     </li>
     <li class="nav-item">
+      <%= link_to membership_applications_path(ma_nav.merge(status: 'under_review')),
+          class: "nav-link #{@current_status == 'under_review' ? 'active' : ''}" do %>
+        Under Review <span class="badge bg-warning text-dark"><%= @status_counts[:under_review] %></span>
+      <% end %>
+    </li>
+    <li class="nav-item">
       <%= link_to membership_applications_path(ma_nav.merge(status: 'approved')),
           class: "nav-link #{@current_status == 'approved' ? 'active' : ''}" do %>
         Approved <span class="badge bg-success"><%= @status_counts[:approved] %></span>
@@ -121,7 +127,7 @@
                             data: { turbo_frame: '_top' } %>
               </td>
               <td>
-                <span class="badge bg-<%= app.status_badge_color %>"><%= app.status_display %></span>
+                <span class="badge bg-<%= app.status_badge_color %><%= ' text-dark' if app.under_review? %>"><%= app.status_display %></span>
               </td>
               <td><%= app.submitted_at&.strftime('%b %d, %Y') || '—' %></td>
               <td class="text-nowrap">

--- a/app/views/membership_applications/show.html.erb
+++ b/app/views/membership_applications/show.html.erb
@@ -16,7 +16,7 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
   <h1 class="h3 mb-0">
     Application #<%= @application.id %>
-    <span class="badge bg-<%= @application.status_badge_color %>"><%= @application.status_display %></span>
+    <span class="badge bg-<%= @application.status_badge_color %><%= ' text-dark' if @application.under_review? %>"><%= @application.status_display %></span>
   </h1>
   <div>
     <%= link_to membership_applications_path, class: "btn btn-outline-secondary" do %>
@@ -41,7 +41,7 @@
 
           <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
             <dt>Status</dt>
-            <dd class="mb-0"><span class="badge bg-<%= @application.status_badge_color %>"><%= @application.status_display %></span></dd>
+            <dd class="mb-0"><span class="badge bg-<%= @application.status_badge_color %><%= ' text-dark' if @application.under_review? %>"><%= @application.status_display %></span></dd>
           </div>
 
           <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
@@ -163,7 +163,7 @@
           <textarea id="admin_notes" class="form-control" rows="3"
                     placeholder="Reason for approval or rejection…"><%= @application.admin_notes %></textarea>
         </div>
-        <div class="d-flex gap-2">
+        <div class="d-flex flex-wrap gap-2">
           <%= form_with url: approve_membership_application_path(@application), method: :post, local: true do %>
             <input type="hidden" name="admin_notes" id="approve_admin_notes" value="">
             <button type="submit" class="btn btn-success review-btn"
@@ -178,10 +178,19 @@
               <i class="bi bi-x-circle me-1"></i> Reject
             </button>
           <% end %>
+          <% if @application.submitted? %>
+            <%= form_with url: delay_for_review_membership_application_path(@application), method: :post, local: true do %>
+              <input type="hidden" name="admin_notes" id="delay_admin_notes" value="">
+              <button type="submit" class="btn btn-outline-warning review-btn"
+                      data-turbo-confirm="Mark this application as under review?">
+                <i class="bi bi-hourglass-split me-1"></i> Delay for review
+              </button>
+            <% end %>
+          <% end %>
         </div>
       <% else %>
         <p class="text-muted mb-0">
-          Only members trained as <strong>Executive Director</strong> may approve or reject applications.
+          Only members trained as <strong>Executive Director</strong> may approve, reject, or delay applications.
           Use admin acceptance votes above to record your recommendation.
         </p>
       <% end %>

--- a/app/views/users/_tab_profile_admin.html.erb
+++ b/app/views/users/_tab_profile_admin.html.erb
@@ -89,6 +89,7 @@
               <ul class="list-unstyled mb-0">
                 <% user.membership_applications.each do |app| %>
                   <% status_class = { 'draft' => 'text-bg-secondary', 'submitted' => 'text-bg-warning text-dark',
+                                      'under_review' => 'text-bg-warning text-dark',
                                       'approved' => 'text-bg-success', 'rejected' => 'text-bg-danger' }[app.status] || 'text-bg-secondary' %>
                   <li class="mb-1">
                     <%= link_to membership_application_path(app), class: "text-decoration-none" do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -400,6 +400,7 @@ Rails.application.routes.draw do
     member do
       post :approve
       post :reject
+      post :delay_for_review
       post :link_user
       post :unlink_user
       post :vote_ai_feedback

--- a/db/migrate/20260419120000_backfill_under_review_membership_applications.rb
+++ b/db/migrate/20260419120000_backfill_under_review_membership_applications.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BackfillUnderReviewMembershipApplications < ActiveRecord::Migration[8.1]
+  def up
+    cutoff = Time.zone.local(2026, 4, 1).beginning_of_day
+    MembershipApplication.where(status: 'submitted')
+                         .where('COALESCE(submitted_at, created_at) < ?', cutoff)
+                         .update_all(status: 'under_review', updated_at: Time.current)
+  end
+
+  def down
+    cutoff = Time.zone.local(2026, 4, 1).beginning_of_day
+    MembershipApplication.where(status: 'under_review')
+                         .where('COALESCE(submitted_at, created_at) < ?', cutoff)
+                         .update_all(status: 'submitted', updated_at: Time.current)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_120100) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_19_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -325,6 +325,55 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal app.user, qm.recipient
   end
 
+  test 'delay_for_review blocked when executive director topic exists and admin lacks training' do
+    TrainingTopic.create!(name: 'Executive Director')
+    app = MembershipApplication.create!(
+      email: 'delay-gate@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    assert_no_changes -> { app.reload.status } do
+      post delay_for_review_membership_application_path(app), params: { admin_notes: 'Later' }
+    end
+    assert_redirected_to membership_application_path(app)
+    assert_match(/Executive Director/i, flash[:alert].to_s)
+  end
+
+  test 'delay_for_review sets under_review when executive director' do
+    topic = TrainingTopic.create!(name: 'Executive Director')
+    admin = User.find(session[:user_id])
+    Training.create!(trainee: admin, training_topic: topic, trained_at: Time.current)
+    app = MembershipApplication.create!(
+      email: 'delay-ok@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+
+    assert_difference -> { Journal.where(action: 'application_delayed_for_review').count }, 1 do
+      post delay_for_review_membership_application_path(app), params: { admin_notes: 'Deferred' }
+    end
+    assert_redirected_to membership_application_path(app)
+    assert_match(/under review/i, flash[:notice].to_s)
+    assert_equal 'under_review', app.reload.status
+    assert_equal 'Deferred', app.admin_notes
+  end
+
+  test 'delay_for_review redirects when application already under review' do
+    topic = TrainingTopic.create!(name: 'Executive Director')
+    admin = User.find(session[:user_id])
+    Training.create!(trainee: admin, training_topic: topic, trained_at: Time.current)
+    app = MembershipApplication.create!(
+      email: 'delay-twice@example.com',
+      status: 'under_review',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+
+    post delay_for_review_membership_application_path(app), params: { admin_notes: 'x' }
+    assert_redirected_to membership_application_path(app)
+    assert_match(/open applications/i, flash[:alert].to_s)
+  end
+
   test 'reject redirects to edit queued mail when executive director' do
     topic = TrainingTopic.create!(name: 'Executive Director')
     admin = User.find(session[:user_id])

--- a/test/models/membership_application_test.rb
+++ b/test/models/membership_application_test.rb
@@ -29,6 +29,30 @@ class MembershipApplicationTest < ActiveSupport::TestCase
     assert_enqueued_jobs 1, only: MembershipApplicationAiFeedbackJob
   end
 
+  test 'delay_for_review! moves open application to under_review and journals' do
+    app = MembershipApplication.create!(email: 'delay-review@example.com', status: 'submitted')
+    admin = users(:one)
+
+    assert_difference -> { Journal.where(action: 'application_delayed_for_review').count }, 1 do
+      app.delay_for_review!(admin, notes: 'Need board input')
+    end
+
+    app.reload
+    assert_equal 'under_review', app.status
+    assert_equal admin, app.reviewed_by
+    assert app.reviewed_at.present?
+    assert_equal 'Need board input', app.admin_notes
+  end
+
+  test 'delay_for_review! raises when not open' do
+    app = MembershipApplication.create!(email: 'delay-bad@example.com', status: 'approved',
+                                        submitted_at: Time.current, reviewed_at: Time.current)
+
+    assert_raises(ArgumentError) do
+      app.delay_for_review!(users(:one))
+    end
+  end
+
   test 'reject! creates pending queued rejection mail' do
     app = MembershipApplication.create!(email: 'reject-mail-test@example.com', status: 'submitted')
     admin = users(:one)


### PR DESCRIPTION
Introduce under_review status with list tab, badges, and journal entries. Executive Directors can mark open applications as delayed for review; approve and reject still apply from open or under review. Pending counts and dashboard attention include both open and under review.

Backfill submitted applications before April 2026 to under_review. Extend CSV merge to update status when the existing application is under review.

Add controller and model tests; bump schema version for the data migration.

Made-with: Cursor