### PR TITLE
Fix membership application list order (newest first, stable)

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -41,7 +41,7 @@ class MembershipApplicationsController < ApplicationController
   end
 
   def index
-    base_scope = MembershipApplication.where.not(status: 'draft').newest_first
+    base_scope = MembershipApplication.where.not(status: 'draft')
     @applications = base_scope.includes(:user, :reviewed_by, :application_answers, :acceptance_votes)
     @current_status = params[:status].presence || 'submitted'
     @applications = case @current_status
@@ -53,6 +53,8 @@ class MembershipApplicationsController < ApplicationController
                       @applications.where(status: @current_status)
                     end
     @applications = @applications.admin_search(params[:q])
+    # Ensure stable newest-first order after search/includes (PostgreSQL + AR can otherwise return arbitrary order).
+    @applications = @applications.newest_first
 
     @status_counts = {
       all: MembershipApplication.where.not(status: 'draft').count,

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -44,7 +44,15 @@ class MembershipApplication < ApplicationRecord
   scope :rejected, -> { where(status: 'rejected') }
   # Applications awaiting a final decision (Open or Under Review).
   scope :pending, -> { where(status: %w[submitted under_review]) }
-  scope :newest_first, -> { order(created_at: :desc) }
+  # Newest by when the application was submitted (or created if not yet submitted); tie-break on id for stable ordering.
+  scope :newest_first, lambda {
+    reorder(
+      Arel.sql(
+        'COALESCE(membership_applications.submitted_at, membership_applications.created_at) DESC NULLS LAST'
+      ),
+      Arel.sql('membership_applications.id DESC')
+    )
+  }
   scope :admin_search, lambda { |query|
     raw = query.to_s.strip
     if raw.blank?

--- a/test/models/membership_application_test.rb
+++ b/test/models/membership_application_test.rb
@@ -84,6 +84,32 @@ class MembershipApplicationTest < ActiveSupport::TestCase
     assert_equal member, qm.recipient
   end
 
+  test 'newest_first orders by submitted time (fallback created_at), then id desc' do
+    travel_to Time.zone.local(2026, 4, 15, 12, 0, 0) do
+      older = MembershipApplication.create!(
+        email: 'order-old@example.com', status: 'submitted',
+        submitted_at: 5.days.ago, created_at: 5.days.ago
+      )
+      newer = MembershipApplication.create!(
+        email: 'order-new@example.com', status: 'submitted',
+        submitted_at: 1.day.ago, created_at: 2.days.ago
+      )
+      ids = MembershipApplication.where(id: [older.id, newer.id]).newest_first.pluck(:id)
+      assert_equal [newer.id, older.id], ids
+
+      t = Time.current
+      first = MembershipApplication.create!(
+        email: 'tie-a@example.com', status: 'submitted', submitted_at: t, created_at: t
+      )
+      second = MembershipApplication.create!(
+        email: 'tie-b@example.com', status: 'submitted', submitted_at: t, created_at: t
+      )
+      assert_operator second.id, :>, first.id
+      tie_ids = MembershipApplication.where(id: [first.id, second.id]).newest_first.pluck(:id)
+      assert_equal [second.id, first.id], tie_ids
+    end
+  end
+
   test 'admin_search matches email, answer text, and linked member fields' do
     page = ApplicationFormPage.create!(title: 'Search Page', position: 9988)
     q_bio = page.questions.create!(label: 'Bio', field_type: 'textarea', required: false, position: 1)


### PR DESCRIPTION
Sort by COALESCE(submitted_at, created_at) with id tiebreaker using reorder so Open and other tabs match the Submitted column. Re-apply newest_first after admin_search/includes so PostgreSQL returns a deterministic order.

Add model tests for ordering and tie-break behavior.

Made-with: Cursor