### PR TITLE
Fix CSV Timestamp parsing and re-import correction for submitted_at

### DIFF
--- a/app/services/membership_applications/csv_importer.rb
+++ b/app/services/membership_applications/csv_importer.rb
@@ -88,7 +88,9 @@ module MembershipApplications
       extras = unmapped_column_notes(row_hash)
       new_notes = compose_admin_notes(approved_notes, extras)
       attrs = {}
-      attrs[:submitted_at] = submitted_at if submitted_at.present? && app.submitted_at.blank?
+      # When Timestamp parses, always set submitted_at so re-imports can fix bad values (e.g. wrong M/D order).
+      # Blank Timestamp leaves submitted_at unchanged (nil does not overwrite).
+      attrs[:submitted_at] = submitted_at if submitted_at.present?
 
       if app.submitted? || app.under_review?
         attrs[:status] = status
@@ -193,25 +195,34 @@ module MembershipApplications
       ['submitted', nil, s]
     end
 
-    # Parses export timestamps; uses US month/day for slash dates (e.g. 5/4/2023) so they are not read as D/M.
-    # Does not pass arbitrary prose to +Time.zone.parse+ (which can treat phrases like "next month" as valid times).
+    # Parses export timestamps. Slash dates use explicit US order (%m/%d/%Y) via Time.zone.strptime so month and day
+    # are never ambiguous (e.g. 3/8/2026 is March 8, not August 3). Does not pass arbitrary prose to
+    # +Time.zone.parse+ (which can treat phrases like "next month" as valid times).
     def parse_timestamp(val)
       return nil if val.blank?
 
       raw = val.to_s.strip
 
-      us = raw.match(%r{\A(\d{1,2})/(\d{1,2})/(\d{4})(?:\s+(\d{1,2}):(\d{1,2})(?::(\d{1,2}))?)?\z})
-      if us
-        return Time.zone.local(
-          us[3].to_i, us[1].to_i, us[2].to_i,
-          (us[4] || 0).to_i, (us[5] || 0).to_i, (us[6] || 0).to_i
-        )
+      if raw.match?(%r{\A\d{1,2}/\d{1,2}/\d{4}})
+        parsed = parse_us_slash_timestamp(raw)
+        return parsed if parsed
       end
 
       return Time.zone.parse(raw) if raw.match?(/\A\d{4}-\d{2}-\d{2}/)
 
       nil
     rescue ArgumentError, TypeError
+      nil
+    end
+
+    def parse_us_slash_timestamp(raw)
+      # Order matters: try longest time patterns first.
+      formats = ['%m/%d/%Y %H:%M:%S', '%m/%d/%Y %H:%M', '%m/%d/%Y']
+      formats.each do |fmt|
+        return Time.zone.strptime(raw, fmt)
+      rescue ArgumentError
+        next
+      end
       nil
     end
   end

--- a/test/services/membership_applications/csv_importer_test.rb
+++ b/test/services/membership_applications/csv_importer_test.rb
@@ -88,6 +88,17 @@ module MembershipApplications
       assert_equal Time.zone.local(2023, 5, 4, 16, 13, 19), app.submitted_at
     end
 
+    test 'parses 3/8/2026 as March 8 (US month/day), not August 3' do
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        Yes,3/8/2026 14:50:55,md-order@example.com,Pat
+      CSV
+
+      CsvImporter.new.call(StringIO.new(csv))
+      app = MembershipApplication.find_by!(email: 'md-order@example.com')
+      assert_equal Time.zone.local(2026, 3, 8, 14, 50, 55), app.submitted_at
+    end
+
     test 'merge fills submitted_at when missing and does not create duplicate application' do
       existing = MembershipApplication.create!(
         email: 'merge-submitted@example.com',
@@ -107,7 +118,23 @@ module MembershipApplications
       assert_equal Time.zone.local(2023, 5, 4, 16, 13, 19), existing.reload.submitted_at
     end
 
-    test 'merge leaves submitted_at unchanged when already set' do
+    test 'merge overwrites submitted_at from CSV Timestamp when present' do
+      wrong = Time.zone.local(2026, 8, 3, 14, 50, 55) # mis-parsed as Aug 3 instead of Mar 8
+      existing = MembershipApplication.create!(
+        email: 'merge-correct-ts@example.com',
+        status: 'submitted',
+        submitted_at: wrong
+      )
+      csv = <<~CSV
+        Approved,Timestamp,Email Address,Name
+        ,3/8/2026 14:50:55,merge-correct-ts@example.com,Pat
+      CSV
+
+      CsvImporter.new.call(StringIO.new(csv))
+      assert_equal Time.zone.local(2026, 3, 8, 14, 50, 55), existing.reload.submitted_at
+    end
+
+    test 'merge leaves submitted_at unchanged when Timestamp column is blank' do
       t = Time.zone.parse('2022-06-01 12:00:00')
       existing = MembershipApplication.create!(
         email: 'merge-keep-ts@example.com',
@@ -116,7 +143,7 @@ module MembershipApplications
       )
       csv = <<~CSV
         Approved,Timestamp,Email Address,Name
-        ,5/4/2023 16:13:19,merge-keep-ts@example.com,Pat
+        ,,merge-keep-ts@example.com,Pat
       CSV
 
       CsvImporter.new.call(StringIO.new(csv))


### PR DESCRIPTION
Parse slash dates with Time.zone.strptime using explicit %m/%d/%Y formats so US month/day order is unambiguous. On merge, apply Timestamp whenever it parses so re-imports fix previously wrong submitted_at values; leave existing dates when the Timestamp cell is blank.

Add regression tests for 3/8/2026 and merge overwrite/keep behavior.

Made-with: Cursor