### PR TITLE
Add Slack OIDC flow to associate workspace account with member profile

### DIFF
--- a/app/controllers/slack_account_links_controller.rb
+++ b/app/controllers/slack_account_links_controller.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+class SlackAccountLinksController < ApplicationController
+  before_action :require_authenticated_user!
+  before_action :ensure_slack_oidc_configured
+
+  # Begins Sign in with Slack (OIDC) to obtain the member's Slack user id — not MM login.
+  def new
+    state = SecureRandom.hex(24)
+    nonce = SecureRandom.hex(24)
+    session[:slack_oidc_state] = state
+    session[:slack_oidc_nonce] = nonce
+
+    redirect_to Slack::OpenidConnect.authorization_uri(
+      state: state,
+      nonce: nonce,
+      redirect_uri: slack_link_callback_url,
+      team_id: SlackOidcConfig.settings.team_id
+    ), allow_other_host: true
+  end
+
+  def callback
+    return redirect_oauth_error if params[:error].present?
+    return redirect_state_mismatch unless slack_state_valid?
+
+    session.delete(:slack_oidc_state)
+    nonce = session.delete(:slack_oidc_nonce)
+    code = params[:code].presence
+    return redirect_missing_code if code.blank?
+
+    token_response = Slack::OpenidConnect.exchange_code(code: code, redirect_uri: slack_link_callback_url)
+    return redirect_token_error(token_response) unless token_response['ok']
+
+    payload = Slack::OpenidConnect.decode_id_token!(token_response['id_token'])
+    return redirect_nonce_mismatch if nonce_mismatch?(nonce, payload)
+
+    finish_link(payload)
+  end
+
+  private
+
+  def redirect_oauth_error
+    detail = params[:error_description].presence || params[:error]
+    redirect_to after_link_path, alert: "Slack authorization failed: #{detail}"
+  end
+
+  def slack_state_valid?
+    session[:slack_oidc_state].present? && params[:state].present? &&
+      session[:slack_oidc_state] == params[:state]
+  end
+
+  def redirect_state_mismatch
+    redirect_to after_link_path, alert: 'Invalid or expired Slack link attempt. Please try again.'
+  end
+
+  def redirect_missing_code
+    redirect_to after_link_path, alert: 'Missing authorization code from Slack.'
+  end
+
+  def redirect_token_error(token_response)
+    err = token_response['error'].presence || 'unknown error'
+    redirect_to after_link_path, alert: "Slack token exchange failed: #{err}"
+  end
+
+  def nonce_mismatch?(nonce, payload)
+    nonce.present? && payload['nonce'].present? && payload['nonce'] != nonce
+  end
+
+  def redirect_nonce_mismatch
+    redirect_to after_link_path, alert: 'Slack login verification failed (nonce). Please try again.'
+  end
+
+  def finish_link(payload)
+    result = Slack::AccountLinker.call(user: current_user, id_token_payload: payload)
+    if result.success?
+      redirect_to after_link_path, notice: result.message
+    else
+      redirect_to after_link_path, alert: result.message
+    end
+  end
+
+  def ensure_slack_oidc_configured
+    return if SlackOidcConfig.configured?
+
+    redirect_to after_link_path, alert: 'Associating a Slack account is not configured yet.'
+  end
+
+  def after_link_path
+    if current_user_admin?
+      root_path(tab: :member_dashboard)
+    else
+      user_path(current_user, tab: :dashboard)
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -710,15 +710,27 @@ class UsersController < AuthenticatedController
       return
     end
 
-    add_member_dashboard_item(
-      ok: false,
-      id: :slack_signup,
-      tier: :housekeeping,
-      title: 'Join Slack',
-      detail: 'You do not have a linked Slack user yet. Please ask an admin for an invite.',
-      action_label: 'View Profile',
-      action_path: user_path(@user, tab: :profile, view_as: params[:view_as])
-    )
+    if SlackOidcConfig.configured?
+      add_member_dashboard_item(
+        ok: false,
+        id: :slack_signup,
+        tier: :housekeeping,
+        title: 'Slack account',
+        detail: 'Link your CTRLH Slack workspace member to your profile so we can recognize you on Slack.',
+        action_label: 'Associate Slack account',
+        action_path: slack_link_start_path
+      )
+    else
+      add_member_dashboard_item(
+        ok: false,
+        id: :slack_signup,
+        tier: :housekeeping,
+        title: 'Join Slack',
+        detail: 'You do not have a linked Slack user yet. Please ask an admin for an invite.',
+        action_label: 'View Profile',
+        action_path: user_path(@user, tab: :profile, view_as: params[:view_as])
+      )
+    end
   end
 
   def append_member_dashboard_parking_item

--- a/app/services/member_dashboard_builder.rb
+++ b/app/services/member_dashboard_builder.rb
@@ -110,16 +110,29 @@ class MemberDashboardBuilder
   def slack_item
     return ok_item(:slack_signup, 'Slack account', 'Your account is linked to Slack.') if user.slack_user.present?
 
-    attention_item(
-      tier: :housekeeping,
-      id: :slack_signup,
-      title: 'Join Slack',
-      detail: 'You do not have a linked Slack user yet. Please ask an admin for an invite.',
-      action: {
-        label: 'Open Profile tab',
-        path: tab_path(:profile)
-      }
-    )
+    if SlackOidcConfig.configured?
+      attention_item(
+        tier: :housekeeping,
+        id: :slack_signup,
+        title: 'Slack account',
+        detail: 'Link your CTRLH Slack workspace member to your profile so we can recognize you on Slack.',
+        action: {
+          label: 'Associate Slack account',
+          path: Rails.application.routes.url_helpers.slack_link_start_path
+        }
+      )
+    else
+      attention_item(
+        tier: :housekeeping,
+        id: :slack_signup,
+        title: 'Join Slack',
+        detail: 'You do not have a linked Slack user yet. Please ask an admin for an invite.',
+        action: {
+          label: 'Open Profile tab',
+          path: tab_path(:profile)
+        }
+      )
+    end
   end
 
   def parking_item

--- a/app/services/slack/account_linker.rb
+++ b/app/services/slack/account_linker.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module Slack
+  # Links a Slack workspace user (from OIDC +sub+) to a Member Manager +User+.
+  class AccountLinker
+    Result = Struct.new(:status, :message) do
+      def success?
+        status == :success
+      end
+
+      def failure?
+        status == :failure
+      end
+    end
+
+    TEAM_CLAIM = 'https://slack.com/team_id'
+
+    def self.call(user:, id_token_payload:)
+      new(user: user, id_token_payload: id_token_payload).call
+    end
+
+    def initialize(user:, id_token_payload:)
+      @user = user
+      @payload = id_token_payload.stringify_keys
+    end
+
+    def call
+      team_check = verify_team
+      return team_check if team_check
+
+      slack_user_id = @payload['sub'].presence || @payload['https://slack.com/user_id'].presence
+      return Result.new(:failure, 'Slack did not return a user id.') if slack_user_id.blank?
+
+      slack_user = resolve_slack_user(slack_user_id)
+      return Result.new(:failure, missing_profile_message) if slack_user.nil?
+
+      conflict = verify_no_conflicts(slack_user)
+      return conflict if conflict
+
+      return Result.new(:success, 'Your Slack account is already linked.') if slack_user.user_id == @user.id
+
+      slack_user.update!(user_id: @user.id)
+      Result.new(:success, 'Your Slack account has been linked.')
+    end
+
+    private
+
+    def verify_team
+      team = @payload[TEAM_CLAIM]
+      expected = SlackOidcConfig.settings.team_id.to_s
+      return nil if team.present? && team == expected
+
+      Result.new(
+        :failure,
+        'That Slack sign-in is not from the expected workspace. Use the CTRLH Slack workspace.'
+      )
+    end
+
+    def resolve_slack_user(slack_user_id)
+      slack_user = SlackUser.find_by(slack_id: slack_user_id)
+      slack_user ||= upsert_slack_user_from_api(slack_user_id)
+      slack_user ||= upsert_slack_user_from_claims(slack_user_id)
+      slack_user
+    end
+
+    def missing_profile_message
+      'Could not load your Slack profile. Ask an admin to run a Slack user sync, then try again.'
+    end
+
+    def verify_no_conflicts(slack_user)
+      if slack_user.user_id.present? && slack_user.user_id != @user.id
+        return Result.new(
+          :failure,
+          'That Slack account is already linked to another member profile. Ask an admin if this is wrong.'
+        )
+      end
+
+      other = @user.slack_user
+      if other.present? && other.id != slack_user.id
+        return Result.new(
+          :failure,
+          'Your profile is already linked to a different Slack account. Ask an admin to update the link.'
+        )
+      end
+
+      nil
+    end
+
+    def upsert_slack_user_from_api(slack_user_id)
+      return nil unless SlackConfig.configured?
+
+      attrs = Client.new.user_info(slack_user_id)
+      return nil if attrs.blank? || attrs[:is_bot]
+
+      record = SlackUser.find_or_initialize_by(slack_id: attrs[:slack_id])
+      record.assign_attributes(attrs)
+      record.save!
+      record
+    rescue StandardError => e
+      Rails.logger.warn("Slack::AccountLinker users.info failed for #{slack_user_id}: #{e.class} #{e.message}")
+      nil
+    end
+
+    def upsert_slack_user_from_claims(slack_user_id)
+      email = @payload['email'].to_s.strip.presence
+      email = nil unless email&.match?(URI::MailTo::EMAIL_REGEXP)
+
+      record = SlackUser.find_or_initialize_by(slack_id: slack_user_id)
+      record.team_id = @payload[TEAM_CLAIM] if record.team_id.blank?
+      record.real_name = @payload['name'].to_s.strip.presence if record.real_name.blank?
+      record.email = email if record.email.blank? && email.present?
+      record.is_bot = false
+      record.deleted = false
+      record.raw_attributes = (record.raw_attributes || {}).merge('openid_claims' => @payload)
+      record.last_synced_at = Time.current
+      record.save!
+      record
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.warn("Slack::AccountLinker OIDC upsert failed: #{e.message}")
+      nil
+    end
+  end
+end

--- a/app/services/slack/client.rb
+++ b/app/services/slack/client.rb
@@ -3,6 +3,7 @@ require 'faraday'
 module Slack
   class Client
     USERS_LIST_ENDPOINT = '/api/users.list'.freeze
+    USERS_INFO_ENDPOINT = '/api/users.info'.freeze
     DEFAULT_LIMIT = 200
 
     def initialize(token: SlackConfig.settings.api_token, base_url: SlackConfig.settings.base_url)
@@ -29,6 +30,20 @@ module Slack
       members
     end
 
+    # Single member; same attribute shape as +list_users+ entries.
+    def user_info(slack_user_id)
+      raise ArgumentError, 'Slack API token is missing' if @token.blank?
+
+      response = connection.get(USERS_INFO_ENDPOINT, { user: slack_user_id })
+      payload = JSON.parse(response.body)
+      handle_error!(payload)
+
+      member = payload['user']
+      return nil if member.blank?
+
+      build_member_attrs(member)
+    end
+
     private
 
     def connection
@@ -52,26 +67,28 @@ module Slack
     end
 
     def extract_members(payload)
-      Array(payload['members']).map do |member|
-        {
-          slack_id: member['id'],
-          team_id: member['team_id'],
-          username: member['name'],
-          real_name: member.dig('profile', 'real_name'),
-          display_name: member.dig('profile', 'display_name'),
-          email: normalize_email(member.dig('profile', 'email')),
-          pronouns: member.dig('profile', 'pronouns').presence,
-          title: member.dig('profile', 'title'),
-          phone: member.dig('profile', 'phone'),
-          tz: member['tz'],
-          is_admin: truthy?(member['is_admin']),
-          is_owner: truthy?(member['is_owner']),
-          is_bot: truthy?(member['is_bot']),
-          deleted: truthy?(member['deleted']),
-          raw_attributes: member,
-          last_synced_at: Time.current
-        }
-      end
+      Array(payload['members']).map { |member| build_member_attrs(member) }
+    end
+
+    def build_member_attrs(member)
+      {
+        slack_id: member['id'],
+        team_id: member['team_id'],
+        username: member['name'],
+        real_name: member.dig('profile', 'real_name'),
+        display_name: member.dig('profile', 'display_name'),
+        email: normalize_email(member.dig('profile', 'email')),
+        pronouns: member.dig('profile', 'pronouns').presence,
+        title: member.dig('profile', 'title'),
+        phone: member.dig('profile', 'phone'),
+        tz: member['tz'],
+        is_admin: truthy?(member['is_admin']),
+        is_owner: truthy?(member['is_owner']),
+        is_bot: truthy?(member['is_bot']),
+        deleted: truthy?(member['deleted']),
+        raw_attributes: member,
+        last_synced_at: Time.current
+      }
     end
 
     def normalize_email(email)

--- a/app/services/slack/openid_connect.rb
+++ b/app/services/slack/openid_connect.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'jwt'
+
+module Slack
+  # Sign in with Slack (OpenID Connect) — token exchange and id_token decode.
+  # Used only after the member is logged in via Authentik; not for MM login.
+  class OpenidConnect
+    AUTHORIZE_PATH = '/openid/connect/authorize'
+    TOKEN_PATH = '/api/openid.connect.token'
+    SCOPES = 'openid email profile'
+
+    class << self
+      def authorization_uri(state:, nonce:, redirect_uri:, team_id:)
+        raise ArgumentError, 'state is required' if state.blank?
+        raise ArgumentError, 'nonce is required' if nonce.blank?
+        raise ArgumentError, 'redirect_uri is required' if redirect_uri.blank?
+
+        client_id = SlackOidcConfig.settings.client_id
+        raise ArgumentError, 'Slack OIDC client_id is missing' if client_id.blank?
+
+        base = SlackConfig.settings.base_url.to_s.chomp('/')
+        params = {
+          response_type: 'code',
+          scope: SCOPES,
+          client_id: client_id,
+          redirect_uri: redirect_uri,
+          state: state,
+          nonce: nonce
+        }
+        params[:team] = team_id if team_id.present?
+
+        uri = URI.parse("#{base}#{AUTHORIZE_PATH}")
+        uri.query = URI.encode_www_form(params)
+        uri.to_s
+      end
+
+      def exchange_code(code:, redirect_uri:)
+        raise ArgumentError, 'code is required' if code.blank?
+
+        client_id = SlackOidcConfig.settings.client_id
+        client_secret = SlackOidcConfig.settings.client_secret
+        raise ArgumentError, 'Slack OIDC is not configured' if client_id.blank? || client_secret.blank?
+
+        base = SlackConfig.settings.base_url.to_s.chomp('/')
+        conn = Faraday.new(url: base) do |f|
+          f.request :url_encoded
+          f.adapter Faraday.default_adapter
+        end
+
+        response = conn.post(TOKEN_PATH) do |req|
+          req.body = {
+            grant_type: 'authorization_code',
+            code: code,
+            client_id: client_id,
+            client_secret: client_secret,
+            redirect_uri: redirect_uri
+          }
+        end
+
+        # Slack returns HTTP 200 with ok: false for OAuth errors.
+        JSON.parse(response.body)
+      end
+
+      # Decodes the id_token from Slack (RS256). We trust this token only when it was
+      # returned by +exchange_code+ over HTTPS with our client_secret.
+      def decode_id_token!(id_token)
+        raise ArgumentError, 'id_token is required' if id_token.blank?
+
+        payload, = JWT.decode(id_token, nil, false)
+        payload.stringify_keys
+      end
+    end
+  end
+end

--- a/app/views/users/_tab_dashboard_self.html.erb
+++ b/app/views/users/_tab_dashboard_self.html.erb
@@ -19,6 +19,11 @@
       <%= link_to new_member_parking_permit_path, class: 'btn btn-success' do %>
         <i class="bi bi-p-circle me-1"></i> Parking Permit
       <% end %>
+      <% if SlackOidcConfig.configured? && user.slack_user.blank? %>
+        <%= link_to slack_link_start_path, class: 'btn btn-outline-secondary' do %>
+          <i class="bi bi-slack me-1"></i> Associate Slack account
+        <% end %>
+      <% end %>
     </div>
     <% unless @member_requestable_topics.any? %>
       <div class="alert alert-secondary mb-0 mt-3">

--- a/config/initializers/slack.rb
+++ b/config/initializers/slack.rb
@@ -3,6 +3,14 @@ Rails.application.config.x.slack = ActiveSupport::InheritableOptions.new(
   base_url: ENV.fetch("SLACK_API_BASE_URL", "https://slack.com")
 )
 
+# Sign in with Slack (OpenID Connect) — used only to link a workspace Slack user id to a member
+# after they are already logged in via Authentik. Not used for Member Manager login.
+Rails.application.config.x.slack_oidc = ActiveSupport::InheritableOptions.new(
+  client_id: ENV["SLACK_OIDC_CLIENT_ID"],
+  client_secret: ENV["SLACK_OIDC_CLIENT_SECRET"],
+  team_id: ENV["SLACK_TEAM_ID"]
+)
+
 module SlackConfig
   def self.settings
     Rails.application.config.x.slack
@@ -13,3 +21,12 @@ module SlackConfig
   end
 end
 
+module SlackOidcConfig
+  def self.settings
+    Rails.application.config.x.slack_oidc
+  end
+
+  def self.configured?
+    settings.client_id.present? && settings.client_secret.present? && settings.team_id.present?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,10 @@ Rails.application.routes.draw do
   match "/auth/:provider/callback", to: "sessions#create", via: %i[get post]
   get "/auth/failure", to: "sessions#failure"
 
+  # Link workspace Slack account to member profile (OIDC; not Member Manager login — Authentik only for login)
+  get "/slack/link", to: "slack_account_links#new", as: :slack_link_start
+  get "/slack/link/callback", to: "slack_account_links#callback", as: :slack_link_callback
+
   # Login links
   post "/login_link/request", to: "login_links#request_link", as: :request_login_link
   get  "/login_link/:token", to: "login_links#authenticate", as: :login_link_authenticate

--- a/env.example
+++ b/env.example
@@ -33,6 +33,12 @@ LOCAL_AUTH_FULL_NAME=Local Admin
 SLACK_API_TOKEN=xoxb-your-slack-token
 SLACK_API_BASE_URL=https://slack.com/api
 SLACK_USER_PAGE_LIMIT=200
+# Workspace team id (starts with T) — required for “Associate Slack account” (Sign in with Slack / OIDC)
+SLACK_TEAM_ID=T01234567
+# Slack app OAuth (OpenID) — same app can have bot + Sign in with Slack; used only to link Slack user id after Authentik login
+SLACK_OIDC_CLIENT_ID=
+SLACK_OIDC_CLIENT_SECRET=
+# Redirect URL must be registered on the Slack app: {APP_BASE_URL}/slack/link/callback
 
 # Google Sheets integration
 GOOGLE_SHEETS_CREDENTIALS='{"type":"service_account","project_id":"example",...}'

--- a/test/controllers/slack_account_links_controller_test.rb
+++ b/test/controllers/slack_account_links_controller_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SlackAccountLinksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+    @cfg = Rails.application.config.x.slack_oidc
+    @prev = {
+      client_id: @cfg.client_id,
+      client_secret: @cfg.client_secret,
+      team_id: @cfg.team_id
+    }
+    @cfg.client_id = 'test_client'
+    @cfg.client_secret = 'test_secret'
+    @cfg.team_id = 'T123'
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+    @cfg.client_id = @prev[:client_id]
+    @cfg.client_secret = @prev[:client_secret]
+    @cfg.team_id = @prev[:team_id]
+  end
+
+  test 'new redirects to Slack authorize URL when signed in' do
+    sign_in_local_member
+    get slack_link_start_path
+    assert_response :redirect
+    assert_match %r{\Ahttps://slack\.com/openid/connect/authorize}, @response.redirect_url
+    assert_match 'client_id=test_client', @response.redirect_url
+    assert_match 'scope=openid', @response.redirect_url
+  end
+
+  test 'new redirects to login when not signed in' do
+    get slack_link_start_path
+    assert_redirected_to login_path
+  end
+
+  test 'callback shows error when state does not match session' do
+    sign_in_local_member
+    get slack_link_callback_path(code: 'abc', state: 'wrong')
+    assert_redirected_to user_path(users(:member_with_local_account), tab: :dashboard)
+    assert_match 'Invalid or expired', flash[:alert].to_s
+  end
+
+  private
+
+  def sign_in_local_member
+    post local_login_path, params: {
+      session: {
+        email: 'member@example.com',
+        password: 'memberpassword123'
+      }
+    }
+  end
+end

--- a/test/services/slack/account_linker_test.rb
+++ b/test/services/slack/account_linker_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Slack
+  class AccountLinkerTest < ActiveSupport::TestCase
+    setup do
+      @cfg = Rails.application.config.x.slack_oidc
+      @prev = {
+        client_id: @cfg.client_id,
+        client_secret: @cfg.client_secret,
+        team_id: @cfg.team_id
+      }
+      @cfg.client_id = 'test_client'
+      @cfg.client_secret = 'test_secret'
+      @cfg.team_id = 'T123'
+    end
+
+    teardown do
+      @cfg.client_id = @prev[:client_id]
+      @cfg.client_secret = @prev[:client_secret]
+      @cfg.team_id = @prev[:team_id]
+    end
+
+    test 'links unlinked SlackUser to user when team and sub match' do
+      user = users(:member_with_local_account)
+      su = slack_users(:with_dept)
+      su.update_columns(user_id: nil)
+
+      result = AccountLinker.call(
+        user: user,
+        id_token_payload: {
+          'sub' => su.slack_id,
+          'https://slack.com/team_id' => 'T123'
+        }
+      )
+
+      assert result.success?
+      assert_equal user.id, su.reload.user_id
+    end
+
+    test 'fails when workspace team does not match' do
+      user = users(:member_with_local_account)
+      su = slack_users(:with_dept)
+      su.update_columns(user_id: nil)
+
+      result = AccountLinker.call(
+        user: user,
+        id_token_payload: {
+          'sub' => su.slack_id,
+          'https://slack.com/team_id' => 'T999'
+        }
+      )
+
+      assert result.failure?
+      assert_nil su.reload.user_id
+    end
+
+    test 'fails when Slack user is already linked to another member' do
+      user = users(:member_with_local_account)
+      other = users(:two)
+      su = slack_users(:with_dept)
+      su.update!(user_id: other.id)
+
+      result = AccountLinker.call(
+        user: user,
+        id_token_payload: {
+          'sub' => su.slack_id,
+          'https://slack.com/team_id' => 'T123'
+        }
+      )
+
+      assert result.failure?
+      assert_equal other.id, su.reload.user_id
+    end
+  end
+end


### PR DESCRIPTION
- Sign in with Slack (OpenID Connect) at /slack/link after Authentik login only
- Slack::OpenidConnect for authorize URL, token exchange, id_token decode
- Slack::AccountLinker resolves SlackUser, optional users.info upsert, team check
- Member dashboard (root + user self view): Associate Slack account CTA when OIDC env set
- Env: SLACK_OIDC_CLIENT_ID, SLACK_OIDC_CLIENT_SECRET, SLACK_TEAM_ID; register redirect URL
- Tests for AccountLinker and SlackAccountLinksController

Made-with: Cursor