### PR TITLE
Upgrade pagy from 9.4 to 43.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'prawn', '~> 2.5'
 gem 'prawn-table', '~> 0.2'
 
 # Pagination
-gem 'pagy', '~> 9.0'
+gem 'pagy', '~> 43.0'
 
 # QR code generation
 gem 'rqrcode', '~> 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,10 @@ GEM
       validate_url
       webfinger (~> 2.0)
     os (1.1.4)
-    pagy (9.4.0)
+    pagy (43.5.1)
+      json
+      uri
+      yaml
     parallel (2.0.1)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -479,6 +482,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yaml (0.4.0)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -510,7 +514,7 @@ DEPENDENCIES
   omniauth (~> 2.1)
   omniauth-rails_csrf_protection
   omniauth_openid_connect (~> 0.8.0)
-  pagy (~> 9.0)
+  pagy (~> 43.0)
   pg (~> 1.1)
   prawn (~> 2.5)
   prawn-table (~> 0.2)
@@ -538,4 +542,4 @@ RUBY VERSION
    ruby 3.3.11p205
 
 BUNDLED WITH
-   2.6.7
+   2.5.22

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,12 @@
 class ApplicationController < ActionController::Base
-  include Pagy::Backend
+  include Pagy::Method
 
   protect_from_forgery with: :exception
 
   add_flash_types :success, :info
 
   helper_method :current_user, :user_signed_in?, :local_auth_enabled?, :authentik_enabled?,
-                :current_user_admin?, :true_user_admin?, :pagy_nav, :impersonating?, :true_user
+                :current_user_admin?, :true_user_admin?, :impersonating?, :true_user
 
   private
 

--- a/app/controllers/cash_payments_controller.rb
+++ b/app/controllers/cash_payments_controller.rb
@@ -1,5 +1,5 @@
 class CashPaymentsController < AdminController
-  include Pagy::Backend
+  include Pagy::Method
 
   before_action :set_cash_payment, only: %i[show edit update destroy]
 

--- a/app/controllers/concerns/member_home_tabs.rb
+++ b/app/controllers/concerns/member_home_tabs.rb
@@ -22,7 +22,7 @@ module MemberHomeTabs
 
     return unless @active_tab == :messages
 
-    @pagy_messages, @home_messages = pagy(messages_query, limit: 20, page_param: :messages_page)
+    @pagy_messages, @home_messages = pagy(messages_query, limit: 20, page_key: 'messages_page')
   end
 
   def set_home_payments_data
@@ -31,7 +31,7 @@ module MemberHomeTabs
 
     return unless @active_tab == :payments
 
-    @pagy_payments, @home_payments = pagy(payments_query, limit: 20, page_param: :payments_page)
+    @pagy_payments, @home_payments = pagy(payments_query, limit: 20, page_key: 'payments_page')
   end
 
   def set_self_service_training_data

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -1,7 +1,7 @@
 class MembershipApplicationsController < ApplicationController
   require 'csv'
 
-  include Pagy::Backend
+  include Pagy::Method
   include MembershipApplicationWizard
   include MembershipApplicationWizard::Actions
 

--- a/app/controllers/parking_notices_controller.rb
+++ b/app/controllers/parking_notices_controller.rb
@@ -1,5 +1,5 @@
 class ParkingNoticesController < AdminController
-  include Pagy::Backend
+  include Pagy::Method
 
   before_action :set_parking_notice,
                 only: %i[show edit update clear download_pdf print_notice remove_photo download_photo]

--- a/app/controllers/payment_events_controller.rb
+++ b/app/controllers/payment_events_controller.rb
@@ -1,5 +1,5 @@
 class PaymentEventsController < ApplicationController
-  include Pagy::Backend
+  include Pagy::Method
 
   before_action :require_admin!
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,5 @@
 class ReportsController < AdminController
-  include Pagy::Backend
+  include Pagy::Method
 
   LIMIT = 20
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -181,7 +181,7 @@ class UsersController < AuthenticatedController
       messages_query = @user.received_messages.includes(:sender).newest_first
       @messages_count = messages_query.count
       @unread_messages_count = @user.received_messages.unread.count
-      @pagy_messages, @messages = pagy(messages_query, limit: 20, page_param: :messages_page)
+      @pagy_messages, @messages = pagy(messages_query, limit: 20, page_key: 'messages_page')
 
       if @view_level == :self && @active_tab == :messages
         @user.received_messages.unread.update_all(read_at: Time.current)
@@ -199,7 +199,7 @@ class UsersController < AuthenticatedController
       @payment_event_filter = params[:event_type].presence
       payments_query = PaymentHistory.for_user(@user, event_type: @payment_event_filter)
       @payments_count = payments_query.count
-      @pagy_payments, @payments = pagy(payments_query, limit: 20, page_param: :payments_page)
+      @pagy_payments, @payments = pagy(payments_query, limit: 20, page_key: 'payments_page')
     end
 
     # Admin-only data (true admins, even when impersonating)
@@ -208,23 +208,23 @@ class UsersController < AuthenticatedController
       if @view_level == :admin
         journals_query = @user.journals.includes(:actor_user).order(changed_at: :desc, created_at: :desc)
         @journals_count = journals_query.count
-        @pagy_journals, @journals = pagy(journals_query, limit: 20, page_param: :journal_page)
+        @pagy_journals, @journals = pagy(journals_query, limit: 20, page_key: 'journal_page')
 
         # Access logs (paginated)
         access_query = @user.access_logs.order(logged_at: :desc)
         @access_count = access_query.count
         @most_recent_access = access_query.first
-        @pagy_accesses, @recent_accesses = pagy(access_query, limit: 20, page_param: :access_page)
+        @pagy_accesses, @recent_accesses = pagy(access_query, limit: 20, page_key: 'access_page')
 
         # Incidents (paginated)
         incidents_query = @user.incident_reports.includes(:reporter).ordered
         @incidents_count = incidents_query.count
-        @pagy_incidents, @user_incidents = pagy(incidents_query, limit: 20, page_param: :incidents_page)
+        @pagy_incidents, @user_incidents = pagy(incidents_query, limit: 20, page_key: 'incidents_page')
 
         # Mail (queued mails for this recipient, with log entries)
         mail_query = @user.queued_mails.includes(:email_template, :reviewed_by, :mail_log_entries).newest_first
         @mail_count = mail_query.count
-        @pagy_mails, @queued_mails = pagy(mail_query, limit: 20, page_param: :mail_page)
+        @pagy_mails, @queued_mails = pagy(mail_query, limit: 20, page_key: 'mail_page')
       end
 
       # Find previous and next users for navigation (always for admin toolbar)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,4 @@
 module ApplicationHelper
-  include Pagy::Frontend
-
   require 'digest'
 
   def bootstrap_class_for(flash_type)

--- a/app/views/cash_payments/index.html.erb
+++ b/app/views/cash_payments/index.html.erb
@@ -60,7 +60,7 @@
   </div>
   <% if @pagy.pages > 1 %>
     <div class="mt-3">
-      <%== pagy_bootstrap_nav(@pagy) %>
+      <%== @pagy.series_nav(:bootstrap) %>
     </div>
   <% end %>
 <% else %>

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -181,7 +181,7 @@
   </div>
 
   <div class="mt-3">
-    <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
+    <%== @pagy.series_nav(:bootstrap) if @pagy.pages > 1 %>
   </div>
 <% else %>
   <div class="text-center text-muted py-5">

--- a/app/views/parking_notices/index.html.erb
+++ b/app/views/parking_notices/index.html.erb
@@ -101,7 +101,7 @@
   </div>
 
   <div class="mt-3">
-    <%== pagy_bootstrap_nav(@pagy) %>
+    <%== @pagy.series_nav(:bootstrap) %>
   </div>
 <% else %>
   <div class="text-center text-muted py-5">

--- a/app/views/payment_events/index.html.erb
+++ b/app/views/payment_events/index.html.erb
@@ -61,7 +61,7 @@
 
       <% if @pagy.pages > 1 %>
         <div class="mt-3">
-          <%== pagy_bootstrap_nav(@pagy) %>
+          <%== @pagy.series_nav(:bootstrap) %>
         </div>
       <% end %>
     <% else %>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,46 +1,11 @@
 <%# Pagination controls %>
-<%# Params: pagy, user, tab, extra_params (optional hash) %>
+<%# Params: pagy (required). user/tab/extra_params are preserved as query params %>
+<%# automatically by Pagy 43's URL composition. %>
 <% if pagy.pages > 1 %>
-  <nav aria-label="Page navigation" class="mt-3">
-    <ul class="pagination pagination-sm justify-content-center mb-0">
-      <%# Previous %>
-      <li class="page-item <%= 'disabled' unless pagy.prev %>">
-        <% if pagy.prev %>
-          <%= link_to user_path(user, tab: tab, "#{pagy.vars[:page_param]}": pagy.prev, view_as: params[:view_as]), class: "page-link" do %>
-            <i class="bi bi-chevron-left"></i>
-          <% end %>
-        <% else %>
-          <span class="page-link"><i class="bi bi-chevron-left"></i></span>
-        <% end %>
-      </li>
-
-      <%# Page numbers %>
-      <% pagy.series.each do |item| %>
-        <% if item == :gap %>
-          <li class="page-item disabled"><span class="page-link">...</span></li>
-        <% elsif item.is_a?(Integer) %>
-          <li class="page-item">
-            <%= link_to item, user_path(user, tab: tab, "#{pagy.vars[:page_param]}": item, view_as: params[:view_as]), class: "page-link" %>
-          </li>
-        <% elsif item.is_a?(String) %>
-          <li class="page-item active"><span class="page-link"><%= item %></span></li>
-        <% end %>
-      <% end %>
-
-      <%# Next %>
-      <li class="page-item <%= 'disabled' unless pagy.next %>">
-        <% if pagy.next %>
-          <%= link_to user_path(user, tab: tab, "#{pagy.vars[:page_param]}": pagy.next, view_as: params[:view_as]), class: "page-link" do %>
-            <i class="bi bi-chevron-right"></i>
-          <% end %>
-        <% else %>
-          <span class="page-link"><i class="bi bi-chevron-right"></i></span>
-        <% end %>
-      </li>
-    </ul>
-
+  <div class="mt-3">
+    <%== pagy.series_nav(:bootstrap) %>
     <div class="text-center text-muted small mt-2">
       Showing <%= pagy.from %>-<%= pagy.to %> of <%= pagy.count %>
     </div>
-  </nav>
+  </div>
 <% end %>

--- a/app/views/users/_tab_mail.html.erb
+++ b/app/views/users/_tab_mail.html.erb
@@ -66,7 +66,7 @@
       </div>
       <% if pagy.pages > 1 %>
         <div class="mt-3">
-          <%== pagy_bootstrap_nav(pagy) %>
+          <%== pagy.series_nav(:bootstrap) %>
         </div>
       <% end %>
     <% else %>

--- a/app/views/users/_tab_messages.html.erb
+++ b/app/views/users/_tab_messages.html.erb
@@ -38,7 +38,7 @@
       </div>
       <% if pagy.pages > 1 %>
         <div class="mt-3">
-          <%== pagy_bootstrap_nav(pagy) %>
+          <%== pagy.series_nav(:bootstrap) %>
         </div>
       <% end %>
     <% else %>

--- a/app/views/users/_tab_payments.html.erb
+++ b/app/views/users/_tab_payments.html.erb
@@ -62,7 +62,7 @@
       <% if local_assigns[:pagy] && local_assigns[:user] %>
         <% if dashboard_mode %>
           <div class="mt-3">
-            <%== pagy_bootstrap_nav(pagy) %>
+            <%== pagy.series_nav(:bootstrap) %>
           </div>
         <% else %>
           <%= render 'shared/pagination', pagy: pagy, user: user, tab: :payments %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
 # Pagy configuration
-# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
+# See https://ddnexus.github.io/pagy/toolbox/configuration
 
-# Default items per page
-Pagy::DEFAULT[:limit] = 20
-
-# Use Bootstrap 5 styling
-require 'pagy/extras/bootstrap'
-
-# Array pagination (for PaymentHistory which returns an array)
-require 'pagy/extras/array'
-
-# Overflow handling - return empty page instead of raising
-require 'pagy/extras/overflow'
-Pagy::DEFAULT[:overflow] = :last_page
+Pagy::OPTIONS[:limit] = 20


### PR DESCRIPTION
Pagy 43 is a complete API redesign. Key changes:

- Replace Pagy::Backend include with Pagy::Method
- Remove Pagy::Frontend include (integrated into @pagy instance)
- Replace pagy_bootstrap_nav(@pagy) with @pagy.series_nav(:bootstrap)
- Rename page_param: :foo (symbol) to page_key: 'foo' (string)
- Replace Pagy::DEFAULT with Pagy::OPTIONS in initializer
- Drop bootstrap/array/overflow extras (now in core or discontinued); :last_page overflow behavior is discontinued, default now serves an empty page
- Rewrite shared pagination partial to use series_nav, which preserves existing query params (tab, view_as) and the per-pagy page_key automatically

Made-with: Cursor