### PR TITLE
Paginate PayPal payments and Members indexes

### DIFF
--- a/app/controllers/paypal_payments_controller.rb
+++ b/app/controllers/paypal_payments_controller.rb
@@ -1,4 +1,6 @@
 class PaypalPaymentsController < AdminController
+  include Pagy::Method
+
   def index
     # Determine if we're showing unmatched payments
     @show_unmatched = params[:show_unmatched] == 'true'
@@ -31,6 +33,8 @@ class PaypalPaymentsController < AdminController
     @payments = @payments.ordered
     @payment_count = @payments.count
     @total_amount = @payments.sum(:amount)
+
+    @pagy, @payments = pagy(@payments.includes(:user), limit: 100)
 
     # Track filter state
     @filter_active = params[:linked].present?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -149,6 +149,8 @@ class UsersController < AuthenticatedController
     @recent_members = User.non_service_accounts.non_legacy
                           .where(created_at: 1.week.ago..)
                           .ordered_by_display_name
+
+    @pagy, @users = pagy(@users, limit: 100)
   end
 
   def show

--- a/app/views/paypal_payments/index.html.erb
+++ b/app/views/paypal_payments/index.html.erb
@@ -120,7 +120,7 @@
         </tr>
       </thead>
       <tbody id="paypal_payments_table_body">
-        <% @payments.includes(:user).each do |payment| %>
+        <% @payments.each do |payment| %>
           <tr class="paypal-payment-row"
               data-live-filter-target="item"
               data-search-text="<%= [
@@ -157,5 +157,13 @@
     </table>
   </div>
 </div>
+<% if @pagy.pages > 1 %>
+  <div class="mt-3">
+    <%== @pagy.series_nav(:bootstrap) %>
+    <div class="text-center text-muted small mt-2">
+      Showing <%= @pagy.from %>-<%= @pagy.to %> of <%= @pagy.count %>
+    </div>
+  </div>
+<% end %>
 </div><%# /data-controller="live-filter" %>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -299,5 +299,13 @@
     </table>
   </div>
 </div>
+<% if @pagy.pages > 1 %>
+  <div class="mt-3">
+    <%== @pagy.series_nav(:bootstrap) %>
+    <div class="text-center text-muted small mt-2">
+      Showing <%= @pagy.from %>-<%= @pagy.to %> of <%= @pagy.count %>
+    </div>
+  </div>
+<% end %>
 </div><%# /data-controller="live-filter" %>
 


### PR DESCRIPTION
Both pages previously loaded every record into a single HTML response (2,397 PayPal payments, 479 users), which was slow and hard to navigate. Paginate at 100 per page using pagy, preserving existing filter/sort state, counts, and the client-side live-filter behavior on the visible page.

Made-with: Cursor