### PR TITLE
Show unread messages as urgent on dashboards

### DIFF
--- a/app/controllers/concerns/member_home_tabs.rb
+++ b/app/controllers/concerns/member_home_tabs.rb
@@ -16,13 +16,9 @@ module MemberHomeTabs
   end
 
   def set_home_messages_data
-    messages_query = @home_user.received_messages.includes(:sender).newest_first
-    @home_messages_count = messages_query.count
-    @home_unread_messages_count = @home_user.received_messages.unread.count
-
-    return unless @active_tab == :messages
-
-    @pagy_messages, @home_messages = pagy(messages_query, limit: 20, page_key: 'messages_page')
+    base = @home_user.received_messages.not_deleted_by_recipient
+    @home_messages_count = base.count
+    @home_unread_messages_count = base.unread.count
   end
 
   def set_home_payments_data

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -164,8 +164,8 @@ class DashboardController < AdminController
 
     @emergency_active_override_count = User.non_service_accounts.where(emergency_active_override: true).count
 
-    # Urgent: Current user's unread messages (own inbox)
-    @admin_unread_messages_count = @home_user.received_messages.unread.count
+    # Urgent: Current user's unread messages (own inbox, excluding trashed)
+    @admin_unread_messages_count = Message.folder(@home_user, :unread).count
 
     @dashboard_attention_items = build_dashboard_attention_items
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -164,11 +164,15 @@ class DashboardController < AdminController
 
     @emergency_active_override_count = User.non_service_accounts.where(emergency_active_override: true).count
 
+    # Urgent: Current user's unread messages (own inbox)
+    @admin_unread_messages_count = @home_user.received_messages.unread.count
+
     @dashboard_attention_items = build_dashboard_attention_items
   end
 
   def build_dashboard_attention_items
     [
+      { tier: :urgent, id: :unread_messages, ok: @admin_unread_messages_count.zero? },
       { tier: :urgent, id: :ac_issues, ok: @ac_issue_count.zero? },
       { tier: :urgent, id: :payment_processors, ok: @payment_processors_sync_unhealthy.empty? },
       { tier: :urgent, id: :authentik, ok: authentik_dashboard_ok? },

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,79 @@
 class MessagesController < AuthenticatedController
-  before_action :require_admin!
+  before_action :load_message, only: %i[show destroy mark_unread restore]
+
+  rescue_from ActiveRecord::RecordNotFound, with: :message_not_found
+
+  def index
+    @folder = sanitized_folder(params[:folder])
+    @pagy, @messages = pagy(
+      Message.folder(current_user, @folder).includes(:sender, :recipient).newest_first,
+      limit: 20
+    )
+  end
+
+  def show
+    if current_user.id == @message.recipient_id && @message.unread? && !@message.deleted_by?(current_user)
+      @message.read!
+    end
+    @return_folder = sanitized_folder(params[:folder])
+  end
 
   def create
+    if params[:in_reply_to_id].present?
+      create_reply
+    else
+      create_new
+    end
+  end
+
+  def destroy
+    @message.delete_for(current_user)
+    folder = sanitized_folder(params[:return_folder])
+    redirect_to messages_path(folder: folder), notice: 'Message moved to trash.'
+  end
+
+  def mark_unread
+    unless current_user.id == @message.recipient_id
+      redirect_to message_path(@message), alert: 'Only the recipient can mark a message unread.'
+      return
+    end
+
+    @message.unread!
+    redirect_to messages_path(folder: :unread), notice: 'Message marked as unread.'
+  end
+
+  def restore
+    unless @message.in_trash_for?(current_user)
+      redirect_to messages_path(folder: :trash), alert: 'Message cannot be restored.'
+      return
+    end
+
+    @message.restore_for(current_user)
+    redirect_to messages_path(folder: :all), notice: 'Message restored from trash.'
+  end
+
+  private
+
+  def load_message
+    scope = Message.visible_to(current_user).or(Message.trash_for(current_user))
+    @message = scope.find(params[:id])
+  end
+
+  def message_not_found
+    redirect_to messages_path, alert: 'Message not found.'
+  end
+
+  def sanitized_folder(value)
+    symbol = value&.to_sym
+    Message::FOLDERS.include?(symbol) ? symbol : :unread
+  end
+
+  def create_new
+    unless true_user&.is_admin?
+      redirect_to messages_path, alert: 'You are not authorized to send messages.'
+      return
+    end
+
     recipient = User.find(params[:recipient_id])
     message = current_user.sent_messages.build(
       recipient: recipient,
@@ -18,5 +90,29 @@ class MessagesController < AuthenticatedController
     end
   rescue ActiveRecord::RecordNotFound
     redirect_to users_path, alert: 'Recipient not found.'
+  end
+
+  def create_reply
+    original = Message.find(params[:in_reply_to_id])
+    unless original.recipient_id == current_user.id
+      redirect_to messages_path, alert: 'You can only reply to messages addressed to you.'
+      return
+    end
+
+    message = current_user.sent_messages.build(
+      recipient: original.sender,
+      subject: params[:subject],
+      body: params[:body]
+    )
+
+    if message.save
+      MemberMailer.message_received(message).deliver_later
+      redirect_to messages_path(folder: :sent), notice: 'Reply sent.'
+    else
+      redirect_to message_path(original),
+                  alert: "Failed to send reply: #{message.errors.full_messages.join(', ')}"
+    end
+  rescue ActiveRecord::RecordNotFound
+    redirect_to messages_path, alert: 'Original message not found.'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -178,17 +178,15 @@ class UsersController < AuthenticatedController
       @parking_notices_list = parking_query.limit(50)
     end
 
-    # Messages for admin and self views
+    # Messages for admin and self views (not deleted by the recipient)
     if @view_level == :admin || @view_level == :self
-      messages_query = @user.received_messages.includes(:sender).newest_first
+      messages_query = @user.received_messages
+                            .not_deleted_by_recipient
+                            .includes(:sender)
+                            .newest_first
       @messages_count = messages_query.count
-      @unread_messages_count = @user.received_messages.unread.count
+      @unread_messages_count = @user.received_messages.not_deleted_by_recipient.unread.count
       @pagy_messages, @messages = pagy(messages_query, limit: 20, page_key: 'messages_page')
-
-      if @view_level == :self && @active_tab == :messages
-        @user.received_messages.unread.update_all(read_at: Time.current)
-        @unread_messages_count = 0
-      end
     end
 
     if @view_level == :self
@@ -615,7 +613,7 @@ class UsersController < AuthenticatedController
   end
 
   def append_member_dashboard_messages_item
-    unread_count = @user.received_messages.unread.count
+    unread_count = Message.folder(@user, :unread).count
     if unread_count.positive?
       add_member_dashboard_item(
         ok: false,
@@ -623,8 +621,8 @@ class UsersController < AuthenticatedController
         tier: :urgent,
         title: 'Unread messages',
         detail: "You have #{unread_count} unread message#{'s' unless unread_count == 1}.",
-        action_label: 'Open Messages tab',
-        action_path: user_path(@user, tab: :messages, view_as: params[:view_as])
+        action_label: 'Open Messages',
+        action_path: messages_path(folder: :unread)
       )
       return
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -608,9 +608,34 @@ class UsersController < AuthenticatedController
     @member_dashboard_ok_items = []
 
     append_member_dashboard_payment_item
+    append_member_dashboard_messages_item
     append_member_dashboard_training_item
     append_member_dashboard_slack_item
     append_member_dashboard_parking_item
+  end
+
+  def append_member_dashboard_messages_item
+    unread_count = @user.received_messages.unread.count
+    if unread_count.positive?
+      add_member_dashboard_item(
+        ok: false,
+        id: :unread_messages,
+        tier: :urgent,
+        title: 'Unread messages',
+        detail: "You have #{unread_count} unread message#{'s' unless unread_count == 1}.",
+        action_label: 'Open Messages tab',
+        action_path: user_path(@user, tab: :messages, view_as: params[:view_as])
+      )
+      return
+    end
+
+    add_member_dashboard_item(
+      ok: true,
+      id: :unread_messages,
+      tier: :none,
+      title: 'Unread messages',
+      detail: 'You have no unread messages.'
+    )
   end
 
   def append_member_dashboard_payment_item

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,0 +1,9 @@
+module MessagesHelper
+  def viewer_deletion_time(message, viewer)
+    if message.sender_id == viewer.id && message.deleted_by_sender_at.present?
+      message.deleted_by_sender_at
+    elsif message.recipient_id == viewer.id && message.deleted_by_recipient_at.present?
+      message.deleted_by_recipient_at
+    end
+  end
+end

--- a/app/jobs/message_trash_cleanup_job.rb
+++ b/app/jobs/message_trash_cleanup_job.rb
@@ -1,0 +1,12 @@
+class MessageTrashCleanupJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    cutoff = Message::TRASH_RETENTION.ago
+    Message.where.not(deleted_by_sender_at: nil)
+           .where.not(deleted_by_recipient_at: nil)
+           .where(deleted_by_sender_at: ...cutoff)
+           .where(deleted_by_recipient_at: ...cutoff)
+           .find_each(&:destroy)
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,7 @@
 class Message < ApplicationRecord
+  TRASH_RETENTION = 30.days
+  FOLDERS = %i[unread read sent all trash].freeze
+
   belongs_to :sender, class_name: 'User'
   belongs_to :recipient, class_name: 'User'
 
@@ -9,11 +12,99 @@ class Message < ApplicationRecord
   scope :unread, -> { where(read_at: nil) }
   scope :for_user, ->(user) { where(recipient: user) }
 
+  scope :not_deleted_by_sender,    -> { where(deleted_by_sender_at: nil) }
+  scope :not_deleted_by_recipient, -> { where(deleted_by_recipient_at: nil) }
+
+  scope :visible_to, lambda { |user|
+    where(
+      '(recipient_id = :id AND deleted_by_recipient_at IS NULL) OR ' \
+      '(sender_id = :id AND deleted_by_sender_at IS NULL)',
+      id: user.id
+    )
+  }
+
+  scope :trash_for, lambda { |user, cutoff: TRASH_RETENTION.ago|
+    where(
+      '(recipient_id = :id AND deleted_by_recipient_at > :t) OR ' \
+      '(sender_id = :id AND deleted_by_sender_at > :t)',
+      id: user.id, t: cutoff
+    )
+  }
+
+  # Returns a relation scoped to the user and a named folder.
+  # Valid folders: :unread, :read, :sent, :all, :trash
+  def self.folder(user, folder)
+    case folder.to_sym
+    when :unread then where(recipient: user, deleted_by_recipient_at: nil, read_at: nil)
+    when :read   then where(recipient: user, deleted_by_recipient_at: nil).where.not(read_at: nil)
+    when :sent   then where(sender: user, deleted_by_sender_at: nil)
+    when :all    then visible_to(user)
+    when :trash  then trash_for(user)
+    else none
+    end
+  end
+
   def unread?
     read_at.nil?
   end
 
   def read!
     update!(read_at: Time.current) if read_at.nil?
+  end
+
+  def unread!
+    update!(read_at: nil) unless read_at.nil?
+  end
+
+  # Soft-deletes the message for the given user (the user's side only).
+  # If user is both sender and recipient (self-message), both sides are marked.
+  def delete_for(user)
+    updates = {}
+    now = Time.current
+    updates[:deleted_by_sender_at]    = now if sender_id    == user.id && deleted_by_sender_at.nil?
+    updates[:deleted_by_recipient_at] = now if recipient_id == user.id && deleted_by_recipient_at.nil?
+    return false if updates.empty?
+
+    update!(updates)
+  end
+
+  # Restores the message from the user's trash (only while within retention window).
+  def restore_for(user)
+    updates = {}
+    updates[:deleted_by_sender_at]    = nil if can_restore?(user, :sender)
+    updates[:deleted_by_recipient_at] = nil if can_restore?(user, :recipient)
+    return false if updates.empty?
+
+    update!(updates)
+  end
+
+  # True if the user can currently see this message in one of their folders
+  # (inbox / sent / all). Does not include trash.
+  def visible_to?(user)
+    (recipient_id == user.id && deleted_by_recipient_at.nil?) ||
+      (sender_id == user.id && deleted_by_sender_at.nil?)
+  end
+
+  # True if the message is currently in the user's trash window.
+  def in_trash_for?(user, cutoff: TRASH_RETENTION.ago)
+    (recipient_id == user.id && deleted_by_recipient_at.present? && deleted_by_recipient_at > cutoff) ||
+      (sender_id == user.id && deleted_by_sender_at.present? && deleted_by_sender_at > cutoff)
+  end
+
+  # True if the user has soft-deleted the message from their side.
+  def deleted_by?(user)
+    (sender_id == user.id && deleted_by_sender_at.present?) ||
+      (recipient_id == user.id && deleted_by_recipient_at.present?)
+  end
+
+  private
+
+  def can_restore?(user, role, cutoff: TRASH_RETENTION.ago)
+    case role
+    when :sender
+      sender_id == user.id && deleted_by_sender_at.present? && deleted_by_sender_at > cutoff
+    when :recipient
+      recipient_id == user.id && deleted_by_recipient_at.present? && deleted_by_recipient_at > cutoff
+    end
   end
 end

--- a/app/services/member_dashboard_builder.rb
+++ b/app/services/member_dashboard_builder.rb
@@ -89,7 +89,7 @@ class MemberDashboardBuilder
   end
 
   def messages_item
-    unread_count = user.received_messages.unread.count
+    unread_count = Message.folder(user, :unread).count
     return messages_unread_item(unread_count) if unread_count.positive?
 
     ok_item(:unread_messages, 'Unread messages', 'You have no unread messages.')
@@ -102,8 +102,8 @@ class MemberDashboardBuilder
       title: 'Unread messages',
       detail: "You have #{unread_count} unread message#{'s' unless unread_count == 1}.",
       action: {
-        label: 'Open Messages tab',
-        path: tab_path(:messages)
+        label: 'Open Messages',
+        path: Rails.application.routes.url_helpers.messages_path(folder: :unread)
       }
     )
   end

--- a/app/services/member_dashboard_builder.rb
+++ b/app/services/member_dashboard_builder.rb
@@ -8,6 +8,7 @@ class MemberDashboardBuilder
   def build
     items = [
       payment_item,
+      messages_item,
       training_item,
       slack_item,
       parking_item
@@ -84,6 +85,26 @@ class MemberDashboardBuilder
       :cash_payment_due,
       'Cash payment due',
       "Your next cash payment is due in #{days_until} days (#{date_text(due_on)})."
+    )
+  end
+
+  def messages_item
+    unread_count = user.received_messages.unread.count
+    return messages_unread_item(unread_count) if unread_count.positive?
+
+    ok_item(:unread_messages, 'Unread messages', 'You have no unread messages.')
+  end
+
+  def messages_unread_item(unread_count)
+    attention_item(
+      tier: :urgent,
+      id: :unread_messages,
+      title: 'Unread messages',
+      detail: "You have #{unread_count} unread message#{'s' unless unread_count == 1}.",
+      action: {
+        label: 'Open Messages tab',
+        path: tab_path(:messages)
+      }
     )
   end
 

--- a/app/views/dashboard/_attention_item_body.html.erb
+++ b/app/views/dashboard/_attention_item_body.html.erb
@@ -8,7 +8,7 @@ when :unread_messages %>
   <% else %>
     <div>
       <i class="bi bi-x-circle-fill text-danger me-1"></i>
-      <%= link_to root_path(tab: :messages), class: "text-decoration-none fw-semibold" do %>
+      <%= link_to messages_path(folder: :unread), class: "text-decoration-none fw-semibold" do %>
         <strong><%= @admin_unread_messages_count %></strong> unread <%= 'message'.pluralize(@admin_unread_messages_count) %>
       <% end %>
     </div>

--- a/app/views/dashboard/_attention_item_body.html.erb
+++ b/app/views/dashboard/_attention_item_body.html.erb
@@ -1,5 +1,19 @@
 <% case item_id
-when :ac_issues %>
+when :unread_messages %>
+  <% if @admin_unread_messages_count.zero? %>
+    <div>
+      <i class="bi bi-check-circle-fill text-success me-1"></i>
+      No unread messages
+    </div>
+  <% else %>
+    <div>
+      <i class="bi bi-x-circle-fill text-danger me-1"></i>
+      <%= link_to root_path(tab: :messages), class: "text-decoration-none fw-semibold" do %>
+        <strong><%= @admin_unread_messages_count %></strong> unread <%= 'message'.pluralize(@admin_unread_messages_count) %>
+      <% end %>
+    </div>
+  <% end %>
+<% when :ac_issues %>
   <% if @ac_issue_count == 0 %>
     <div>
       <i class="bi bi-check-circle-fill text-success me-1"></i>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -32,7 +32,7 @@
       </li>
     <% end %>
     <li class="nav-item" role="presentation">
-      <%= link_to root_path(tab: :messages), class: "nav-link #{'active' if @active_tab == :messages}", role: "tab" do %>
+      <%= link_to messages_path(folder: :unread), class: 'nav-link', role: 'tab' do %>
         <i class="bi bi-chat-dots me-1"></i> Messages
         <% if @home_unread_messages_count.to_i > 0 %>
           <span class="badge bg-danger ms-1"><%= @home_unread_messages_count %></span>
@@ -226,8 +226,6 @@
     <%= render 'users/tab_payments', payments: @home_payments, pagy: @pagy_payments, user: @home_user, show_payment_links: false, dashboard_mode: true %>
   <% elsif @active_tab == :parking %>
     <%= render 'users/tab_parking', parking_notices: @home_parking_notices_list, show_actions: false %>
-  <% elsif @active_tab == :messages %>
-    <%= render 'users/tab_messages', messages: @home_messages, pagy: @pagy_messages, user: @home_user, show_send: false %>
   <% else %>
     <%= render 'users/tab_dashboard_self', user: @home_user %>
   <% end %>

--- a/app/views/messages/_row_list.html.erb
+++ b/app/views/messages/_row_list.html.erb
@@ -1,0 +1,58 @@
+<%# locals: messages, folder, viewer %>
+<% folder = local_assigns.fetch(:folder, :inbox) %>
+<% viewer = local_assigns.fetch(:viewer) %>
+
+<% if messages.any? %>
+  <div class="list-group list-group-flush">
+    <% messages.each do |message| %>
+      <%
+        is_sender = message.sender_id == viewer.id
+        is_recipient = message.recipient_id == viewer.id
+        show_as_sent = folder == :sent || (folder == :all && is_sender && !is_recipient)
+        counterpart = show_as_sent ? message.recipient : message.sender
+        counterpart_label = show_as_sent ? 'To' : 'From'
+        unread_for_viewer = is_recipient && message.unread? && !message.deleted_by_recipient_at
+      %>
+      <div class="list-group-item list-group-item-action py-2 px-3">
+        <div class="d-flex align-items-start gap-2">
+          <div class="flex-grow-1 min-w-0">
+            <%= link_to message_path(message, folder: folder), class: 'text-decoration-none text-body d-block' do %>
+              <div class="d-flex justify-content-between align-items-baseline gap-2">
+                <div class="text-truncate">
+                  <span class="<%= 'fw-bold' if unread_for_viewer %>">
+                    <%= counterpart_label %>: <%= counterpart&.display_name || '(unknown)' %>
+                  </span>
+                  <span class="mx-2 text-muted">&middot;</span>
+                  <span class="<%= 'fw-bold' if unread_for_viewer %>">
+                    <%= message.subject %>
+                  </span>
+                  <% if unread_for_viewer %>
+                    <span class="badge bg-primary ms-1">New</span>
+                  <% end %>
+                </div>
+                <small class="text-muted text-nowrap">
+                  <%= l(message.created_at, format: :short) %>
+                </small>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <div class="p-4 text-center text-muted">
+    <% case folder
+       when :unread %>
+      No unread messages.
+    <% when :read %>
+      No read messages.
+    <% when :sent %>
+      No sent messages.
+    <% when :trash %>
+      Trash is empty.
+    <% else %>
+      No messages.
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,0 +1,39 @@
+<% content_for(:page_title, 'Messages') %>
+
+<div class="py-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h3 mb-0"><i class="bi bi-chat-dots me-2"></i>Messages</h1>
+  </div>
+
+  <ul class="nav nav-pills mb-3" role="tablist">
+    <% Message::FOLDERS.each do |folder| %>
+      <li class="nav-item">
+        <%= link_to messages_path(folder: folder),
+                    class: "nav-link #{'active' if @folder == folder}" do %>
+          <%= folder.to_s.titleize %>
+          <% if folder == :unread %>
+            <% unread_count = Message.folder(current_user, :unread).count %>
+            <% if unread_count.positive? %>
+              <span class="badge bg-danger ms-1"><%= unread_count %></span>
+            <% end %>
+          <% end %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+
+  <div class="card shadow-sm border-0">
+    <div class="card-body p-0">
+      <%= render 'messages/row_list',
+                 messages: @messages,
+                 folder: @folder,
+                 viewer: current_user %>
+    </div>
+  </div>
+
+  <% if @pagy.pages > 1 %>
+    <div class="mt-3">
+      <%== @pagy.series_nav(:bootstrap) %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -1,0 +1,101 @@
+<% content_for(:page_title, @message.subject) %>
+
+<%
+  viewer = current_user
+  is_recipient = @message.recipient_id == viewer.id
+  is_sender = @message.sender_id == viewer.id
+  in_trash = @message.in_trash_for?(viewer)
+%>
+
+<div class="py-4">
+  <div class="mb-3">
+    <%= link_to messages_path(folder: @return_folder || :unread),
+                class: 'btn btn-sm btn-outline-secondary' do %>
+      <i class="bi bi-arrow-left me-1"></i> Back to <%= (@return_folder || :unread).to_s.titleize %>
+    <% end %>
+  </div>
+
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-body-tertiary">
+      <h1 class="h5 mb-1"><%= @message.subject %></h1>
+      <div class="text-muted small">
+        <strong>From:</strong> <%= @message.sender&.display_name || '(unknown)' %><br>
+        <strong>To:</strong> <%= @message.recipient&.display_name || '(unknown)' %><br>
+        <strong>Sent:</strong> <%= l(@message.created_at, format: :long) %>
+        <% if @message.read_at.present? %>
+          &middot; Read <%= time_ago_in_words(@message.read_at) %> ago
+        <% end %>
+        <% if in_trash %>
+          <br><span class="badge bg-secondary">In trash &mdash; expires
+            <%= time_ago_in_words(viewer_deletion_time(@message, viewer) + Message::TRASH_RETENTION) %>
+            from now</span>
+        <% end %>
+      </div>
+    </div>
+    <div class="card-body">
+      <%= simple_format(@message.body) %>
+    </div>
+    <div class="card-footer d-flex flex-wrap gap-2">
+      <% if in_trash %>
+        <%= button_to restore_message_path(@message),
+                      method: :post,
+                      class: 'btn btn-outline-success' do %>
+          <i class="bi bi-arrow-counterclockwise me-1"></i> Restore
+        <% end %>
+      <% else %>
+        <% if is_recipient %>
+          <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#replyModal">
+            <i class="bi bi-reply me-1"></i> Reply
+          </button>
+          <% if !@message.unread? %>
+            <%= button_to mark_unread_message_path(@message),
+                          method: :patch,
+                          class: 'btn btn-outline-secondary' do %>
+              <i class="bi bi-envelope me-1"></i> Mark unread
+            <% end %>
+          <% end %>
+        <% end %>
+        <%= button_to message_path(@message, return_folder: @return_folder),
+                      method: :delete,
+                      form: { data: { turbo_confirm: 'Move this message to trash?' } },
+                      class: 'btn btn-outline-danger' do %>
+          <i class="bi bi-trash me-1"></i> Delete
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<% if is_recipient && !in_trash %>
+  <div class="modal fade" id="replyModal" tabindex="-1" aria-labelledby="replyModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <%= form_with url: messages_path, method: :post, local: true do %>
+          <div class="modal-header">
+            <h5 class="modal-title" id="replyModalLabel">Reply to <%= @message.sender&.display_name %></h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <input type="hidden" name="in_reply_to_id" value="<%= @message.id %>">
+            <div class="mb-3">
+              <label for="reply_subject" class="form-label">Subject</label>
+              <input type="text" name="subject" id="reply_subject" class="form-control"
+                     value="<%= @message.subject.to_s.start_with?('Re: ') ? @message.subject : "Re: #{@message.subject}" %>"
+                     required>
+            </div>
+            <div class="mb-3">
+              <label for="reply_body" class="form-label">Message</label>
+              <textarea name="body" id="reply_body" class="form-control" rows="6" required></textarea>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-primary">
+              <i class="bi bi-send me-1"></i> Send reply
+            </button>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/_tab_messages.html.erb
+++ b/app/views/users/_tab_messages.html.erb
@@ -14,25 +14,24 @@
     <% if messages.any? %>
       <div class="list-group list-group-flush">
         <% messages.each do |message| %>
-          <div class="list-group-item px-0 <%= 'border-start border-primary border-3 ps-3' if message.unread? %>">
-            <div class="d-flex justify-content-between align-items-start mb-1">
-              <div>
-                <strong><%= message.subject %></strong>
+          <div class="list-group-item px-0 py-2">
+            <div class="d-flex justify-content-between align-items-baseline gap-2">
+              <div class="text-truncate">
+                <span class="<%= 'fw-bold' if message.unread? %>">
+                  From: <%= message.sender.display_name %>
+                </span>
+                <span class="mx-2 text-muted">&middot;</span>
+                <span class="<%= 'fw-bold' if message.unread? %>">
+                  <%= message.subject %>
+                </span>
                 <% if message.unread? %>
                   <span class="badge bg-primary ms-1">New</span>
                 <% end %>
               </div>
-              <small class="text-muted text-nowrap ms-2"><%= time_ago_in_words(message.created_at) %> ago</small>
+              <small class="text-muted text-nowrap">
+                <%= l(message.created_at, format: :short) %>
+              </small>
             </div>
-            <div class="text-muted small mb-2">
-              From: <strong><%= message.sender.display_name %></strong>
-            </div>
-            <div class="text-body">
-              <%= simple_format(message.body) %>
-            </div>
-            <% if message.read_at.present? %>
-              <small class="text-muted">Read <%= time_ago_in_words(message.read_at) %> ago</small>
-            <% end %>
           </div>
         <% end %>
       </div>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -77,6 +77,14 @@ Sidekiq.configure_server do |config|
     class: 'LoginLinkExpirationJob',
     active_job: true
   )
+
+  # Message Trash Cleanup - Daily at 5am
+  Sidekiq::Cron::Job.create(
+    name: 'Message Trash Cleanup - Daily at 5am',
+    cron: '0 5 * * *',
+    class: 'MessageTrashCleanupJob',
+    active_job: true
+  )
 end
 
 Sidekiq.configure_client do |config|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,12 @@ Rails.application.routes.draw do
   post "/impersonate/:user_id", to: "impersonations#create", as: :impersonate_user, constraints: { user_id: /[^\/]+/ }
   delete "/impersonate", to: "impersonations#destroy", as: :stop_impersonation
 
-  resources :messages, only: [:create]
+  resources :messages, only: %i[index show create destroy] do
+    member do
+      patch :mark_unread
+      post :restore
+    end
+  end
   resources :training_requests, only: %i[new create edit update]
   resources :member_parking_permits, only: %i[new create]
 

--- a/db/migrate/20260422120000_add_deleted_timestamps_to_messages.rb
+++ b/db/migrate/20260422120000_add_deleted_timestamps_to_messages.rb
@@ -1,0 +1,11 @@
+class AddDeletedTimestampsToMessages < ActiveRecord::Migration[8.0]
+  def change
+    change_table :messages, bulk: true do |t|
+      t.datetime :deleted_by_sender_at
+      t.datetime :deleted_by_recipient_at
+    end
+
+    add_index :messages, %i[sender_id deleted_by_sender_at]
+    add_index :messages, %i[recipient_id deleted_by_recipient_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_19_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -589,14 +589,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_19_120000) do
   create_table "messages", force: :cascade do |t|
     t.text "body", null: false
     t.datetime "created_at", null: false
+    t.datetime "deleted_by_recipient_at"
+    t.datetime "deleted_by_sender_at"
     t.datetime "read_at"
     t.bigint "recipient_id", null: false
     t.bigint "sender_id", null: false
     t.string "subject", null: false
     t.datetime "updated_at", null: false
     t.index ["recipient_id", "created_at"], name: "index_messages_on_recipient_id_and_created_at"
+    t.index ["recipient_id", "deleted_by_recipient_at"], name: "index_messages_on_recipient_id_and_deleted_by_recipient_at"
     t.index ["recipient_id"], name: "index_messages_on_recipient_id"
     t.index ["sender_id", "created_at"], name: "index_messages_on_sender_id_and_created_at"
+    t.index ["sender_id", "deleted_by_sender_at"], name: "index_messages_on_sender_id_and_deleted_by_sender_at"
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -15,7 +15,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
   end
 
-  # ─── Admin can send messages ───────────────────────────────────
+  # ─── Create: admin sending (existing behavior) ───────────────────
 
   test 'admin can send a message' do
     sign_in_as_local_admin
@@ -91,9 +91,9 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Recipient not found.', flash[:alert]
   end
 
-  # ─── Non-admin access ─────────────────────────────────────────
+  # ─── Non-admin initiating a new message ─────────────────────────
 
-  test 'non-admin cannot send messages' do
+  test 'non-admin cannot initiate a new message' do
     sign_in_as_local_member
 
     assert_no_difference 'Message.count' do
@@ -103,6 +103,9 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
         body: 'Test'
       }
     end
+
+    assert_redirected_to messages_path
+    assert flash[:alert].present?
   end
 
   test 'unauthenticated user cannot send messages' do
@@ -113,6 +116,297 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
         body: 'Test'
       }
     end
+  end
+
+  # ─── Reply flow ─────────────────────────────────────────────────
+
+  test 'recipient can reply to a message they received (non-admin)' do
+    member_user = member_user_for_local
+    original = Message.create!(
+      sender: @sender,
+      recipient: member_user,
+      subject: 'Hello',
+      body: 'Hi'
+    )
+
+    sign_in_as_local_member
+
+    assert_difference 'Message.count', 1 do
+      post messages_path, params: {
+        in_reply_to_id: original.id,
+        subject: 'Re: Hello',
+        body: 'Reply body'
+      }
+    end
+
+    reply = Message.last
+    assert_equal member_user, reply.sender
+    assert_equal @sender, reply.recipient
+    assert_equal 'Re: Hello', reply.subject
+    assert_redirected_to messages_path(folder: :sent)
+    assert_equal 'Reply sent.', flash[:notice]
+  end
+
+  test 'non-recipient cannot reply to a message' do
+    original = Message.create!(
+      sender: @sender,
+      recipient: @recipient,
+      subject: 'Hello',
+      body: 'Hi'
+    )
+
+    sign_in_as_local_member
+
+    assert_no_difference 'Message.count' do
+      post messages_path, params: {
+        in_reply_to_id: original.id,
+        subject: 'Re: Hello',
+        body: 'Reply'
+      }
+    end
+
+    assert_redirected_to messages_path
+    assert flash[:alert].present?
+  end
+
+  # ─── Index ──────────────────────────────────────────────────────
+
+  test 'unauthenticated user cannot view messages index' do
+    get messages_path
+    assert_redirected_to login_path
+  end
+
+  test 'index default folder shows unread received messages' do
+    member_user = member_user_for_local
+    Message.create!(sender: @sender, recipient: member_user, subject: 'Unread One', body: '.')
+    read_msg = Message.create!(sender: @sender, recipient: member_user, subject: 'Read One', body: '.')
+    read_msg.read!
+    deleted = Message.create!(sender: @sender, recipient: member_user, subject: 'Deleted', body: '.')
+    deleted.update!(deleted_by_recipient_at: Time.current)
+
+    sign_in_as_local_member
+    get messages_path
+    assert_response :success
+
+    body = response.body
+    assert_includes body, 'Unread One'
+    assert_not_includes body, 'Read One'
+    assert_not_includes body, 'Deleted'
+  end
+
+  test 'index folder=read shows read received messages only' do
+    member_user = member_user_for_local
+    Message.create!(sender: @sender, recipient: member_user, subject: 'Unread One', body: '.')
+    read_msg = Message.create!(sender: @sender, recipient: member_user, subject: 'Read One', body: '.')
+    read_msg.read!
+
+    sign_in_as_local_member
+    get messages_path, params: { folder: :read }
+
+    assert_response :success
+    assert_includes response.body, 'Read One'
+    assert_not_includes response.body, 'Unread One'
+  end
+
+  test 'index folder=sent shows messages authored by viewer' do
+    member_user = member_user_for_local
+    original = Message.create!(sender: @sender, recipient: member_user, subject: 'Hi', body: '.')
+    Message.create!(sender: member_user, recipient: @sender, subject: 'From member', body: 'body')
+
+    sign_in_as_local_member
+    get messages_path, params: { folder: :sent }
+
+    assert_response :success
+    assert_includes response.body, 'From member'
+    assert_not_includes response.body, original.subject
+  end
+
+  test 'index folder=all includes inbox and sent (non-trashed)' do
+    member_user = member_user_for_local
+    inbox = Message.create!(sender: @sender, recipient: member_user, subject: 'Inbox entry', body: '.')
+    sent = Message.create!(sender: member_user, recipient: @sender, subject: 'Sent entry', body: '.')
+    trashed = Message.create!(sender: @sender, recipient: member_user, subject: 'Trashed entry', body: '.')
+    trashed.update!(deleted_by_recipient_at: Time.current)
+
+    sign_in_as_local_member
+    get messages_path, params: { folder: :all }
+
+    assert_response :success
+    assert_includes response.body, inbox.subject
+    assert_includes response.body, sent.subject
+    assert_not_includes response.body, trashed.subject
+  end
+
+  test 'index folder=trash includes deleted-within-30-days messages' do
+    member_user = member_user_for_local
+    recent = Message.create!(sender: @sender, recipient: member_user, subject: 'Recent trash', body: '.')
+    recent.update!(deleted_by_recipient_at: 2.days.ago)
+    expired = Message.create!(sender: @sender, recipient: member_user, subject: 'Expired trash', body: '.')
+    expired.update!(deleted_by_recipient_at: 60.days.ago)
+
+    sign_in_as_local_member
+    get messages_path, params: { folder: :trash }
+
+    assert_response :success
+    assert_includes response.body, recent.subject
+    assert_not_includes response.body, expired.subject
+  end
+
+  # ─── Show ───────────────────────────────────────────────────────
+
+  test 'recipient viewing an unread message marks it read' do
+    member_user = member_user_for_local
+    message = Message.create!(sender: @sender, recipient: member_user, subject: 'Hi', body: '.')
+    assert message.unread?
+
+    sign_in_as_local_member
+    get message_path(message)
+
+    assert_response :success
+    assert_not_nil message.reload.read_at
+  end
+
+  test 'sender viewing their own sent message does not change read_at' do
+    member_user = member_user_for_local
+    message = Message.create!(sender: member_user, recipient: @sender, subject: 'Mine', body: '.')
+    assert_nil message.read_at
+
+    sign_in_as_local_member
+    get message_path(message)
+
+    assert_response :success
+    assert_nil message.reload.read_at
+  end
+
+  test 'show redirects when message is not visible to the user' do
+    member_user = member_user_for_local
+    assert member_user.present?
+    other = Message.create!(sender: @sender, recipient: @recipient, subject: 'Not yours', body: '.')
+
+    sign_in_as_local_member
+    get message_path(other)
+
+    assert_redirected_to messages_path
+    assert_equal 'Message not found.', flash[:alert]
+  end
+
+  test 'show of a message in the viewer trash (within retention) succeeds' do
+    member_user = member_user_for_local
+    message = Message.create!(sender: @sender, recipient: member_user, subject: 'In trash', body: '.')
+    message.update!(deleted_by_recipient_at: 3.days.ago)
+
+    sign_in_as_local_member
+    get message_path(message, folder: :trash)
+
+    assert_response :success
+    assert_includes response.body, 'In trash'
+  end
+
+  test 'show of a message whose trash has expired is not found' do
+    member_user = member_user_for_local
+    message = Message.create!(sender: @sender, recipient: member_user, subject: 'Expired', body: '.')
+    message.update!(deleted_by_recipient_at: 60.days.ago)
+
+    sign_in_as_local_member
+    get message_path(message)
+
+    assert_redirected_to messages_path
+  end
+
+  # ─── Destroy ────────────────────────────────────────────────────
+
+  test 'recipient destroy soft-deletes for recipient only' do
+    member_user = member_user_for_local
+    message = Message.create!(sender: @sender, recipient: member_user, subject: 'Kill', body: '.')
+
+    sign_in_as_local_member
+    assert_no_difference 'Message.count' do
+      delete message_path(message)
+    end
+
+    message.reload
+    assert_not_nil message.deleted_by_recipient_at
+    assert_nil message.deleted_by_sender_at
+  end
+
+  test 'sender destroy soft-deletes for sender only' do
+    member_user = member_user_for_local
+    message = Message.create!(sender: member_user, recipient: @sender, subject: 'Mine', body: '.')
+
+    sign_in_as_local_member
+    assert_no_difference 'Message.count' do
+      delete message_path(message)
+    end
+
+    message.reload
+    assert_not_nil message.deleted_by_sender_at
+    assert_nil message.deleted_by_recipient_at
+  end
+
+  test 'destroy by unrelated user returns not found' do
+    other = Message.create!(sender: @sender, recipient: @recipient, subject: 'Nope', body: '.')
+
+    sign_in_as_local_member
+    delete message_path(other)
+
+    assert_redirected_to messages_path
+    other.reload
+    assert_nil other.deleted_by_sender_at
+    assert_nil other.deleted_by_recipient_at
+  end
+
+  # ─── Mark unread ────────────────────────────────────────────────
+
+  test 'recipient can mark a read message unread' do
+    member_user = member_user_for_local
+    message = Message.create!(sender: @sender, recipient: member_user, subject: 'Hi', body: '.')
+    message.read!
+    assert_not_nil message.read_at
+
+    sign_in_as_local_member
+    patch mark_unread_message_path(message)
+
+    assert_redirected_to messages_path(folder: :unread)
+    assert_nil message.reload.read_at
+  end
+
+  test 'sender cannot mark their own sent message unread' do
+    member_user = member_user_for_local
+    message = Message.create!(sender: member_user, recipient: @sender, subject: 'Out', body: '.')
+    message.read!
+    original_read_at = message.read_at
+
+    sign_in_as_local_member
+    patch mark_unread_message_path(message)
+
+    assert_redirected_to message_path(message)
+    assert_equal original_read_at.to_i, message.reload.read_at.to_i
+  end
+
+  # ─── Restore ────────────────────────────────────────────────────
+
+  test 'recipient can restore a message from trash within 30 days' do
+    member_user = member_user_for_local
+    message = Message.create!(sender: @sender, recipient: member_user, subject: 'Save me', body: '.')
+    message.update!(deleted_by_recipient_at: 2.days.ago)
+
+    sign_in_as_local_member
+    post restore_message_path(message)
+
+    assert_redirected_to messages_path(folder: :all)
+    assert_nil message.reload.deleted_by_recipient_at
+  end
+
+  test 'restoring a message past retention fails' do
+    member_user = member_user_for_local
+    message = Message.create!(sender: @sender, recipient: member_user, subject: 'Expired', body: '.')
+    message.update!(deleted_by_recipient_at: 60.days.ago)
+
+    sign_in_as_local_member
+    post restore_message_path(message)
+
+    assert_redirected_to messages_path
+    assert_not_nil message.reload.deleted_by_recipient_at
   end
 
   private
@@ -135,5 +429,11 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
         password: 'memberpassword123'
       }
     }
+  end
+
+  # The regular_member local account email matches the member_with_local_account user fixture;
+  # signing in syncs that fixture user and sets session[:user_id] to its id.
+  def member_user_for_local
+    users(:member_with_local_account)
   end
 end

--- a/test/jobs/message_trash_cleanup_job_test.rb
+++ b/test/jobs/message_trash_cleanup_job_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+class MessageTrashCleanupJobTest < ActiveJob::TestCase
+  setup do
+    @sender = users(:one)
+    @recipient = users(:two)
+  end
+
+  def build_message(attrs = {})
+    Message.create!(
+      {
+        sender: @sender,
+        recipient: @recipient,
+        subject: 'Hi',
+        body: 'body'
+      }.merge(attrs)
+    )
+  end
+
+  test 'destroys messages where both sides deleted more than 30 days ago' do
+    message = build_message
+    message.update!(
+      deleted_by_sender_at: 45.days.ago,
+      deleted_by_recipient_at: 45.days.ago
+    )
+
+    assert_difference 'Message.count', -1 do
+      MessageTrashCleanupJob.perform_now
+    end
+
+    assert_nil Message.find_by(id: message.id)
+  end
+
+  test 'keeps messages where only one side has deleted' do
+    only_sender = build_message
+    only_sender.update!(deleted_by_sender_at: 45.days.ago)
+
+    only_recipient = build_message
+    only_recipient.update!(deleted_by_recipient_at: 45.days.ago)
+
+    assert_no_difference 'Message.count' do
+      MessageTrashCleanupJob.perform_now
+    end
+  end
+
+  test 'keeps messages where both sides deleted but one is still within retention' do
+    message = build_message
+    message.update!(
+      deleted_by_sender_at: 60.days.ago,
+      deleted_by_recipient_at: 10.days.ago
+    )
+
+    assert_no_difference 'Message.count' do
+      MessageTrashCleanupJob.perform_now
+    end
+  end
+
+  test 'keeps messages neither side deleted' do
+    build_message
+
+    assert_no_difference 'Message.count' do
+      MessageTrashCleanupJob.perform_now
+    end
+  end
+
+  test 'is idempotent across runs' do
+    message = build_message
+    message.update!(
+      deleted_by_sender_at: 45.days.ago,
+      deleted_by_recipient_at: 45.days.ago
+    )
+
+    MessageTrashCleanupJob.perform_now
+    assert_no_difference 'Message.count' do
+      MessageTrashCleanupJob.perform_now
+    end
+  end
+end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -4,7 +4,21 @@ class MessageTest < ActiveSupport::TestCase
   setup do
     @sender = users(:one)
     @recipient = users(:two)
+    @other = users(:three)
   end
+
+  def create_message(attrs = {})
+    Message.create!(
+      {
+        sender: @sender,
+        recipient: @recipient,
+        subject: 'Hello',
+        body: 'Test'
+      }.merge(attrs)
+    )
+  end
+
+  # ─── Validations & basic lifecycle ───────────────────────────────
 
   test 'valid message saves successfully' do
     message = Message.new(sender: @sender, recipient: @recipient, subject: 'Hello', body: 'Test body')
@@ -37,59 +51,312 @@ class MessageTest < ActiveSupport::TestCase
   end
 
   test 'unread? returns true when read_at is nil' do
-    message = Message.create!(sender: @sender, recipient: @recipient, subject: 'Hello', body: 'Test')
+    message = create_message
     assert message.unread?
   end
 
   test 'unread? returns false after read!' do
-    message = Message.create!(sender: @sender, recipient: @recipient, subject: 'Hello', body: 'Test')
+    message = create_message
     message.read!
     assert_not message.unread?
     assert_not_nil message.read_at
   end
 
   test 'read! is idempotent' do
-    message = Message.create!(sender: @sender, recipient: @recipient, subject: 'Hello', body: 'Test')
+    message = create_message
     message.read!
     first_read_at = message.read_at
     message.read!
     assert_equal first_read_at, message.read_at
   end
 
-  test 'newest_first scope orders by created_at desc' do
-    Message.create!(sender: @sender, recipient: @recipient, subject: 'Old', body: 'Old message')
-    new_msg = Message.create!(sender: @sender, recipient: @recipient, subject: 'New', body: 'New message')
+  test 'unread! clears read_at' do
+    message = create_message
+    message.read!
+    assert_not_nil message.read_at
+    message.unread!
+    assert_nil message.read_at
+  end
 
-    results = Message.newest_first
-    assert_equal new_msg, results.first
+  test 'unread! is idempotent when already unread' do
+    message = create_message
+    assert_nil message.read_at
+    message.unread!
+    assert_nil message.read_at
+  end
+
+  # ─── Existing scopes ─────────────────────────────────────────────
+
+  test 'newest_first scope orders by created_at desc' do
+    create_message(subject: 'Old')
+    new_msg = create_message(subject: 'New')
+    assert_equal new_msg, Message.newest_first.first
   end
 
   test 'unread scope returns only unread messages' do
-    unread = Message.create!(sender: @sender, recipient: @recipient, subject: 'Unread', body: 'Test')
-    read_msg = Message.create!(sender: @sender, recipient: @recipient, subject: 'Read', body: 'Test')
+    unread = create_message(subject: 'Unread')
+    read_msg = create_message(subject: 'Read')
     read_msg.read!
-
     results = Message.unread
     assert_includes results, unread
     assert_not_includes results, read_msg
   end
 
   test 'for_user scope returns messages for the given recipient' do
-    msg_for_two = Message.create!(sender: @sender, recipient: @recipient, subject: 'For two', body: 'Test')
-    msg_for_one = Message.create!(sender: @recipient, recipient: @sender, subject: 'For one', body: 'Test')
-
+    msg_for_two = create_message
+    msg_for_one = Message.create!(sender: @recipient, recipient: @sender, subject: 'Other', body: 'Test')
     results = Message.for_user(@recipient)
     assert_includes results, msg_for_two
     assert_not_includes results, msg_for_one
   end
 
+  test 'not_deleted_by_sender filters sender-deleted rows' do
+    kept = create_message
+    deleted = create_message
+    deleted.update!(deleted_by_sender_at: Time.current)
+    assert_includes Message.not_deleted_by_sender, kept
+    assert_not_includes Message.not_deleted_by_sender, deleted
+  end
+
+  test 'not_deleted_by_recipient filters recipient-deleted rows' do
+    kept = create_message
+    deleted = create_message
+    deleted.update!(deleted_by_recipient_at: Time.current)
+    assert_includes Message.not_deleted_by_recipient, kept
+    assert_not_includes Message.not_deleted_by_recipient, deleted
+  end
+
+  # ─── visible_to scope ─────────────────────────────────────────────
+
+  test 'visible_to includes sender side when not sender-deleted' do
+    message = create_message
+    assert_includes Message.visible_to(@sender), message
+    assert_includes Message.visible_to(@recipient), message
+  end
+
+  test 'visible_to excludes sender when sender soft-deleted' do
+    message = create_message
+    message.update!(deleted_by_sender_at: Time.current)
+    assert_not_includes Message.visible_to(@sender), message
+    assert_includes Message.visible_to(@recipient), message
+  end
+
+  test 'visible_to excludes recipient when recipient soft-deleted' do
+    message = create_message
+    message.update!(deleted_by_recipient_at: Time.current)
+    assert_includes Message.visible_to(@sender), message
+    assert_not_includes Message.visible_to(@recipient), message
+  end
+
+  test 'visible_to excludes unrelated users' do
+    message = create_message
+    assert_not_includes Message.visible_to(@other), message
+  end
+
+  # ─── trash_for scope ──────────────────────────────────────────────
+
+  test 'trash_for includes rows recipient deleted within retention window' do
+    message = create_message
+    message.update!(deleted_by_recipient_at: 3.days.ago)
+    assert_includes Message.trash_for(@recipient), message
+  end
+
+  test 'trash_for excludes rows whose recipient deletion is past retention' do
+    message = create_message
+    message.update!(deleted_by_recipient_at: (Message::TRASH_RETENTION + 1.day).ago)
+    assert_not_includes Message.trash_for(@recipient), message
+  end
+
+  test 'trash_for includes sender side when sender deleted within retention' do
+    message = create_message
+    message.update!(deleted_by_sender_at: 2.days.ago)
+    assert_includes Message.trash_for(@sender), message
+  end
+
+  # ─── folder class method ──────────────────────────────────────────
+
+  test 'folder :unread returns only unread recipient messages not deleted by recipient' do
+    unread = create_message
+    read_msg = create_message(subject: 'Read')
+    read_msg.read!
+    soft_deleted = create_message(subject: 'Deleted')
+    soft_deleted.update!(deleted_by_recipient_at: Time.current)
+
+    results = Message.folder(@recipient, :unread)
+    assert_includes results, unread
+    assert_not_includes results, read_msg
+    assert_not_includes results, soft_deleted
+  end
+
+  test 'folder :read returns only read recipient messages not deleted by recipient' do
+    unread = create_message
+    read_msg = create_message(subject: 'Read')
+    read_msg.read!
+    soft_deleted_read = create_message(subject: 'Deleted')
+    soft_deleted_read.read!
+    soft_deleted_read.update!(deleted_by_recipient_at: Time.current)
+
+    results = Message.folder(@recipient, :read)
+    assert_includes results, read_msg
+    assert_not_includes results, unread
+    assert_not_includes results, soft_deleted_read
+  end
+
+  test 'folder :sent returns sender messages not deleted by sender' do
+    sent = create_message(subject: 'Sent')
+    deleted_by_sender = create_message(subject: 'Gone')
+    deleted_by_sender.update!(deleted_by_sender_at: Time.current)
+
+    results = Message.folder(@sender, :sent)
+    assert_includes results, sent
+    assert_not_includes results, deleted_by_sender
+  end
+
+  test 'folder :all includes inbox and sent for the user, excluding their soft-deletes' do
+    inbox = create_message(subject: 'Inbox')
+    sent = Message.create!(sender: @recipient, recipient: @other, subject: 'Outbox', body: 'Test')
+    deleted_by_recipient = create_message(subject: 'Gone R')
+    deleted_by_recipient.update!(deleted_by_recipient_at: Time.current)
+    deleted_by_sender = Message.create!(sender: @recipient, recipient: @other, subject: 'Gone S', body: 'Test')
+    deleted_by_sender.update!(deleted_by_sender_at: Time.current)
+
+    results = Message.folder(@recipient, :all)
+    assert_includes results, inbox
+    assert_includes results, sent
+    assert_not_includes results, deleted_by_recipient
+    assert_not_includes results, deleted_by_sender
+  end
+
+  test 'folder :trash includes only messages the user deleted within retention window' do
+    recent_del = create_message(subject: 'Recent')
+    recent_del.update!(deleted_by_recipient_at: 5.days.ago)
+    expired_del = create_message(subject: 'Expired')
+    expired_del.update!(deleted_by_recipient_at: 60.days.ago)
+    not_deleted = create_message(subject: 'Kept')
+
+    results = Message.folder(@recipient, :trash)
+    assert_includes results, recent_del
+    assert_not_includes results, expired_del
+    assert_not_includes results, not_deleted
+  end
+
+  test 'folder returns none for unknown folder names' do
+    create_message
+    assert_equal 0, Message.folder(@recipient, :garbage).count
+  end
+
+  # ─── delete_for ───────────────────────────────────────────────────
+
+  test 'delete_for(recipient) sets only deleted_by_recipient_at' do
+    message = create_message
+    message.delete_for(@recipient)
+    assert_not_nil message.reload.deleted_by_recipient_at
+    assert_nil message.deleted_by_sender_at
+  end
+
+  test 'delete_for(sender) sets only deleted_by_sender_at' do
+    message = create_message
+    message.delete_for(@sender)
+    assert_not_nil message.reload.deleted_by_sender_at
+    assert_nil message.deleted_by_recipient_at
+  end
+
+  test 'delete_for(user) on a self-message sets both timestamps' do
+    message = Message.create!(sender: @sender, recipient: @sender, subject: 'Self', body: 'Test')
+    message.delete_for(@sender)
+    message.reload
+    assert_not_nil message.deleted_by_sender_at
+    assert_not_nil message.deleted_by_recipient_at
+  end
+
+  test 'delete_for is idempotent' do
+    message = create_message
+    message.delete_for(@recipient)
+    first_ts = message.reload.deleted_by_recipient_at
+    travel 1.minute do
+      message.delete_for(@recipient)
+    end
+    assert_equal first_ts, message.reload.deleted_by_recipient_at
+  end
+
+  test 'delete_for on unrelated user is a no-op' do
+    message = create_message
+    assert_equal false, message.delete_for(@other)
+    assert_nil message.reload.deleted_by_sender_at
+    assert_nil message.reload.deleted_by_recipient_at
+  end
+
+  # ─── restore_for ──────────────────────────────────────────────────
+
+  test 'restore_for clears recipient deletion within retention window' do
+    message = create_message
+    message.update!(deleted_by_recipient_at: 5.days.ago)
+    message.restore_for(@recipient)
+    assert_nil message.reload.deleted_by_recipient_at
+  end
+
+  test 'restore_for is a no-op once past retention' do
+    message = create_message
+    deleted_at = 60.days.ago
+    message.update!(deleted_by_recipient_at: deleted_at)
+    message.restore_for(@recipient)
+    assert_in_delta deleted_at, message.reload.deleted_by_recipient_at, 1
+  end
+
+  test 'restore_for only touches the calling user side' do
+    message = create_message
+    message.update!(
+      deleted_by_sender_at: 5.days.ago,
+      deleted_by_recipient_at: 5.days.ago
+    )
+    message.restore_for(@recipient)
+    message.reload
+    assert_nil message.deleted_by_recipient_at
+    assert_not_nil message.deleted_by_sender_at
+  end
+
+  # ─── visible_to? / deleted_by? / in_trash_for? ────────────────────
+
+  test 'visible_to? true for sender and recipient until they soft-delete' do
+    message = create_message
+    assert message.visible_to?(@sender)
+    assert message.visible_to?(@recipient)
+    message.delete_for(@recipient)
+    assert message.visible_to?(@sender)
+    assert_not message.visible_to?(@recipient)
+  end
+
+  test 'visible_to? false for unrelated users' do
+    message = create_message
+    assert_not message.visible_to?(@other)
+  end
+
+  test 'deleted_by? reflects per-side deletion' do
+    message = create_message
+    assert_not message.deleted_by?(@sender)
+    assert_not message.deleted_by?(@recipient)
+    message.delete_for(@recipient)
+    assert message.deleted_by?(@recipient)
+    assert_not message.deleted_by?(@sender)
+  end
+
+  test 'in_trash_for? only within retention window' do
+    message = create_message
+    message.update!(deleted_by_recipient_at: 5.days.ago)
+    assert message.in_trash_for?(@recipient)
+    message.update!(deleted_by_recipient_at: 60.days.ago)
+    assert_not message.in_trash_for?(@recipient)
+  end
+
+  # ─── Associations ─────────────────────────────────────────────────
+
   test 'user sent_messages association' do
-    message = Message.create!(sender: @sender, recipient: @recipient, subject: 'Hello', body: 'Test')
+    message = create_message
     assert_includes @sender.sent_messages, message
   end
 
   test 'user received_messages association' do
-    message = Message.create!(sender: @sender, recipient: @recipient, subject: 'Hello', body: 'Test')
+    message = create_message
     assert_includes @recipient.received_messages, message
   end
 end


### PR DESCRIPTION
Adds an Unread messages item to the member dashboard (self tab and profile-page dashboard tab) and to the admin dashboard. When the viewing user has unread messages, it appears as Urgent in Needs Attention, linking to the Messages tab. When there are no unread messages, it appears as a green item under No Action Required.

Made-with: Cursor