### PR TITLE
Add member-facing Training catalog with topic detail pages

### DIFF
--- a/app/controllers/training_catalog_controller.rb
+++ b/app/controllers/training_catalog_controller.rb
@@ -1,0 +1,68 @@
+# Member-facing catalog of training topics.
+#
+# Admins see every topic; non-admins only see topics with
+# `offered_to_members = true`. Each topic has a detail page showing
+# trainers, trainees, and training materials (links + documents).
+# From the detail page, both admins and non-admins can request training
+# for any topic that is offered to members and has at least one trainer.
+class TrainingCatalogController < AuthenticatedController
+  before_action :set_training_topic, only: :show
+  before_action :authorize_topic_visibility!, only: :show
+
+  def index
+    @training_topics = visible_topics.order(:name)
+    # Build a Set of topic ids that are currently open for member training requests.
+    # We avoid the `available_for_member_requests` scope here because it combines
+    # `distinct` with `order(:name)`, which Postgres rejects once we narrow the
+    # select list (e.g. via `pluck(:id)`).
+    @requestable_topic_ids = TrainingTopic.offered_for_members
+                                          .joins(:trainer_capabilities)
+                                          .distinct
+                                          .pluck(:id)
+                                          .to_set
+  end
+
+  def show
+    @trainers = @training_topic.trainers.order(:full_name, :email)
+    @trainees = User.where(id: @training_topic.trainings.select(:trainee_id).distinct)
+                    .order(:full_name, :email)
+    @topic_links = @training_topic.links.order(:title)
+    @topic_documents = visible_documents_for(@training_topic)
+    @requestable = @training_topic.offered_to_members? &&
+                   @training_topic.trainer_capabilities.exists?
+  end
+
+  private
+
+  def set_training_topic
+    @training_topic = TrainingTopic.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to training_catalog_path, alert: 'Training topic not found.'
+  end
+
+  def authorize_topic_visibility!
+    return if current_user_admin?
+    return if @training_topic.offered_to_members?
+
+    redirect_to training_catalog_path, alert: 'That training topic is not available.'
+  end
+
+  def visible_topics
+    return TrainingTopic.all if current_user_admin?
+
+    TrainingTopic.offered_for_members
+  end
+
+  # Non-admins may only see documents they are allowed to download
+  # (trained in the topic, a trainer for it, or marked `show_on_all_profiles`).
+  def visible_documents_for(topic)
+    documents = topic.documents.ordered
+    return documents if current_user_admin?
+
+    trained = Training.exists?(trainee: current_user, training_topic: topic)
+    trainer = TrainerCapability.exists?(user: current_user, training_topic: topic)
+    return documents if trained || trainer
+
+    documents.where(show_on_all_profiles: true)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,6 +87,9 @@
                   </ul>
                 </li>
                 <li class="nav-item">
+                  <%= link_to "Training", training_catalog_path, class: "nav-link #{controller_name == 'training_catalog' ? 'active' : ''}" %>
+                </li>
+                <li class="nav-item">
                   <%= link_to "Journal", journals_path, class: "nav-link #{current_page?(journals_path) ? 'active' : ''}" %>
                 </li>
                 <li class="nav-item dropdown">
@@ -133,7 +136,9 @@
                   </ul>
                 </li>
               <% else %>
-                <%# non-admins see no extra admin links %>
+                <li class="nav-item">
+                  <%= link_to "Training", training_catalog_path, class: "nav-link #{controller_name == 'training_catalog' ? 'active' : ''}" %>
+                </li>
               <% end %>
               <li class="nav-item dropdown">
                 <% help_pages = controller_name == 'pages' && %w[help help_faq help_admin_faq].include?(action_name) %>

--- a/app/views/training_catalog/index.html.erb
+++ b/app/views/training_catalog/index.html.erb
@@ -1,0 +1,82 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0"><i class="bi bi-mortarboard me-2"></i>Training</h1>
+  <% if @requestable_topic_ids.any? %>
+    <%= link_to new_training_request_path, class: 'btn btn-primary' do %>
+      <i class="bi bi-mortarboard me-1"></i> Request Training
+    <% end %>
+  <% end %>
+</div>
+
+<div class="card shadow-sm border-0 mb-4">
+  <div class="card-body">
+    <p class="text-muted mb-0">
+      Browse available training topics. Click a topic for details, including trainers,
+      trainees, and materials. Topics offered to members can be requested; if you do not
+      see what you need, please post in <strong>#help</strong> on Slack or email
+      <a href="mailto:info@pdxhackerspace.org">info@pdxhackerspace.org</a>.
+    </p>
+  </div>
+</div>
+
+<% if @training_topics.any? %>
+  <div class="card shadow-sm border-0">
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-hover align-middle mb-0">
+          <thead class="bg-body-tertiary">
+            <tr>
+              <th scope="col">Topic</th>
+              <% if current_user_admin? %>
+                <th scope="col" class="text-center">Offered to members</th>
+              <% end %>
+              <th scope="col" class="text-center">Trainers</th>
+              <th scope="col" class="text-center">Trained</th>
+              <th scope="col" class="text-end">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @training_topics.each do |topic| %>
+              <tr>
+                <td>
+                  <strong><%= link_to topic.name, training_catalog_topic_path(topic), class: 'text-decoration-none' %></strong>
+                  <% if topic.description.present? %>
+                    <div class="text-muted small"><%= truncate(topic.description.to_s, length: 140) %></div>
+                  <% end %>
+                </td>
+                <% if current_user_admin? %>
+                  <td class="text-center">
+                    <% if topic.offered_to_members? %>
+                      <span class="badge text-bg-success">Yes</span>
+                    <% else %>
+                      <span class="badge text-bg-secondary">No</span>
+                    <% end %>
+                  </td>
+                <% end %>
+                <td class="text-center">
+                  <span class="badge text-bg-success"><%= topic.trainer_capabilities.select(:user_id).distinct.count %></span>
+                </td>
+                <td class="text-center">
+                  <span class="badge text-bg-primary"><%= topic.trainings.select(:trainee_id).distinct.count %></span>
+                </td>
+                <td class="text-end">
+                  <div class="d-flex gap-2 justify-content-end">
+                    <%= link_to 'Details', training_catalog_topic_path(topic), class: 'btn btn-sm btn-outline-secondary' %>
+                    <% if @requestable_topic_ids.include?(topic.id) %>
+                      <%= link_to new_training_request_path, class: 'btn btn-sm btn-primary' do %>
+                        <i class="bi bi-mortarboard"></i> Request
+                      <% end %>
+                    <% end %>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+<% else %>
+  <div class="alert alert-secondary mb-0">
+    No training topics are currently available.
+  </div>
+<% end %>

--- a/app/views/training_catalog/show.html.erb
+++ b/app/views/training_catalog/show.html.erb
@@ -1,0 +1,116 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <div>
+    <h1 class="h3 mb-0"><i class="bi bi-mortarboard me-2"></i><%= @training_topic.name %></h1>
+    <% unless @training_topic.offered_to_members? %>
+      <span class="badge text-bg-secondary mt-2">Not currently offered to members</span>
+    <% end %>
+  </div>
+  <div class="d-flex gap-2">
+    <%= link_to "&larr; Back to Training".html_safe, training_catalog_path, class: 'text-decoration-none' %>
+  </div>
+</div>
+
+<% if @training_topic.description.present? %>
+  <div class="card shadow-sm border-0 mb-4">
+    <div class="card-body">
+      <h2 class="h5 mb-2">About this topic</h2>
+      <p class="mb-0"><%= simple_format(@training_topic.description) %></p>
+    </div>
+  </div>
+<% end %>
+
+<div class="card shadow-sm border-0 mb-4">
+  <div class="card-body d-flex flex-wrap gap-2 align-items-center">
+    <% if @requestable %>
+      <%= link_to new_training_request_path, class: 'btn btn-primary' do %>
+        <i class="bi bi-mortarboard me-1"></i> Request Training
+      <% end %>
+      <span class="text-muted small">This topic is open for member training requests.</span>
+    <% else %>
+      <span class="text-muted small">
+        <i class="bi bi-info-circle me-1"></i>
+        This topic is not currently available for training requests
+        (either there are no trainers yet, or it is not offered to members).
+      </span>
+    <% end %>
+  </div>
+</div>
+
+<div class="row g-4">
+  <div class="col-lg-6">
+    <div class="card shadow-sm border-0 h-100">
+      <div class="card-body">
+        <h2 class="h5 mb-3"><i class="bi bi-person-badge me-2"></i>Trainers</h2>
+        <% if @trainers.any? %>
+          <ul class="list-unstyled mb-0">
+            <% @trainers.each do |trainer| %>
+              <li class="mb-2">
+                <%= link_to trainer.display_name, user_path(trainer), class: 'text-decoration-none' %>
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p class="text-muted mb-0">No trainers are currently listed for this topic.</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-6">
+    <div class="card shadow-sm border-0 h-100">
+      <div class="card-body">
+        <h2 class="h5 mb-3"><i class="bi bi-people me-2"></i>Trained Members</h2>
+        <% if @trainees.any? %>
+          <ul class="list-unstyled mb-0">
+            <% @trainees.each do |trainee| %>
+              <li class="mb-2">
+                <%= link_to trainee.display_name, user_path(trainee), class: 'text-decoration-none' %>
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p class="text-muted mb-0">No members have been trained in this topic yet.</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card shadow-sm border-0 mt-4">
+  <div class="card-body">
+    <h2 class="h5 mb-3"><i class="bi bi-link-45deg me-2"></i>Training Materials</h2>
+
+    <% if @topic_links.any? %>
+      <h3 class="h6 text-muted mb-2">Links</h3>
+      <ul class="list-unstyled mb-4">
+        <% @topic_links.each do |link| %>
+          <li class="mb-2">
+            <i class="bi bi-link-45deg me-1"></i>
+            <%= link_to link.title, link.url, target: '_blank', rel: 'noopener', class: 'text-decoration-none' %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <% if @topic_documents.any? %>
+      <h3 class="h6 text-muted mb-2">Documents</h3>
+      <ul class="list-unstyled mb-0">
+        <% @topic_documents.each do |doc| %>
+          <li class="mb-2 d-flex align-items-center gap-2">
+            <i class="bi bi-file-earmark"></i>
+            <% if doc.file.attached? %>
+              <%= link_to doc.title, download_document_path(doc), class: 'text-decoration-none' %>
+              <span class="text-muted small">(<%= number_to_human_size(doc.file.byte_size) %>)</span>
+            <% else %>
+              <span><%= doc.title %></span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <% if @topic_links.empty? && @topic_documents.empty? %>
+      <p class="text-muted mb-0">No training materials have been added for this topic.</p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,10 @@ Rails.application.routes.draw do
     end
   end
   resources :training_requests, only: %i[new create edit update]
+
+  # Member-facing catalog of training topics
+  get '/training',      to: 'training_catalog#index', as: :training_catalog
+  get '/training/:id',  to: 'training_catalog#show',  as: :training_catalog_topic, constraints: { id: /\d+/ }
   resources :member_parking_permits, only: %i[new create]
 
   resources :users, only: [:index, :show, :new, :create, :edit, :update, :destroy], constraints: { id: /[^\/]+/ } do

--- a/test/controllers/training_catalog_controller_test.rb
+++ b/test/controllers/training_catalog_controller_test.rb
@@ -1,0 +1,194 @@
+require 'test_helper'
+
+class TrainingCatalogControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @laser_topic       = training_topics(:laser_cutting)
+    @woodworking_topic = training_topics(:woodworking)
+    @electronics_topic = training_topics(:electronics)
+
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+  end
+
+  # Index
+
+  test 'unauthenticated user is redirected to login' do
+    get training_catalog_path
+    assert_response :redirect
+  end
+
+  test 'admin sees all training topics including those not offered to members' do
+    sign_in_as_admin
+    get training_catalog_path
+
+    assert_response :success
+    assert_match @laser_topic.name,       response.body
+    assert_match @woodworking_topic.name, response.body
+    assert_match @electronics_topic.name, response.body
+  end
+
+  test 'member sees only topics offered to members' do
+    sign_in_as_member
+    get training_catalog_path
+
+    assert_response :success
+    assert_match @laser_topic.name,       response.body
+    assert_match @woodworking_topic.name, response.body
+    assert_no_match(/#{Regexp.escape(@electronics_topic.name)}/, response.body)
+  end
+
+  test 'index shows request training button when a requestable topic exists' do
+    TrainerCapability.find_or_create_by!(user: users(:one), training_topic: @laser_topic)
+
+    sign_in_as_member
+    get training_catalog_path
+
+    assert_response :success
+    assert_match(/Request Training/i, response.body)
+    assert_match new_training_request_path, response.body
+  end
+
+  test 'index does not show request training button when no topic has a trainer' do
+    TrainerCapability.where(training_topic: [@laser_topic, @woodworking_topic]).delete_all
+
+    sign_in_as_member
+    get training_catalog_path
+
+    assert_response :success
+    assert_no_match(/Request Training/i, response.body)
+  end
+
+  test 'admin index marks whether each topic is offered to members' do
+    sign_in_as_admin
+    get training_catalog_path
+
+    assert_response :success
+    assert_match(/Offered to members/i, response.body)
+  end
+
+  # Show
+
+  test 'member can view a topic that is offered to members' do
+    TrainerCapability.find_or_create_by!(user: users(:one), training_topic: @laser_topic)
+
+    sign_in_as_member
+    get training_catalog_topic_path(@laser_topic)
+
+    assert_response :success
+    assert_match @laser_topic.name, response.body
+    assert_match(/Trainers/i, response.body)
+    assert_match(/Trained Members/i, response.body)
+    assert_match(/Training Materials/i, response.body)
+  end
+
+  test 'member cannot view a topic that is not offered to members' do
+    sign_in_as_member
+    get training_catalog_topic_path(@electronics_topic)
+
+    assert_redirected_to training_catalog_path
+    assert_equal 'That training topic is not available.', flash[:alert]
+  end
+
+  test 'admin can view a topic that is not offered to members' do
+    sign_in_as_admin
+    get training_catalog_topic_path(@electronics_topic)
+
+    assert_response :success
+    assert_match @electronics_topic.name, response.body
+  end
+
+  test 'show lists trainers and trainees for the topic' do
+    trainer = users(:one)
+    trainee = users(:two)
+    TrainerCapability.find_or_create_by!(user: trainer, training_topic: @laser_topic)
+    Training.find_or_create_by!(trainee: trainee, training_topic: @laser_topic) do |t|
+      t.trainer    = trainer
+      t.trained_at = Time.current
+    end
+
+    sign_in_as_admin
+    get training_catalog_topic_path(@laser_topic)
+
+    assert_response :success
+    assert_match trainer.display_name, response.body
+    assert_match trainee.display_name, response.body
+  end
+
+  test 'show lists training topic links' do
+    link = training_topic_links(:laser_safety_guide)
+
+    sign_in_as_admin
+    get training_catalog_topic_path(@laser_topic)
+
+    assert_response :success
+    assert_match link.title, response.body
+    assert_match link.url, response.body
+  end
+
+  test 'show displays request training button for a trainable topic' do
+    TrainerCapability.find_or_create_by!(user: users(:one), training_topic: @laser_topic)
+
+    sign_in_as_member
+    get training_catalog_topic_path(@laser_topic)
+
+    assert_response :success
+    assert_match(/Request Training/i, response.body)
+    assert_match new_training_request_path, response.body
+  end
+
+  test 'show does not display request training button when topic has no trainer' do
+    TrainerCapability.where(training_topic: @laser_topic).delete_all
+
+    sign_in_as_member
+    get training_catalog_topic_path(@laser_topic)
+
+    assert_response :success
+    assert_no_match(/Request Training/i, response.body)
+  end
+
+  test 'show returns friendly error for unknown topic' do
+    sign_in_as_admin
+    get training_catalog_topic_path(id: 999_999_999)
+
+    assert_redirected_to training_catalog_path
+    assert_equal 'Training topic not found.', flash[:alert]
+  end
+
+  # Navbar
+
+  test 'navbar includes training link for admin' do
+    sign_in_as_admin
+    get root_path
+
+    assert_response :success
+    assert_match(%r{>Training</a>}, response.body)
+    assert_match training_catalog_path, response.body
+  end
+
+  test 'navbar includes training link for member' do
+    sign_in_as_member
+    get training_catalog_path
+
+    assert_response :success
+    assert_match(%r{>Training</a>}, response.body)
+    assert_match training_catalog_path, response.body
+  end
+
+  private
+
+  def sign_in_as_admin
+    post local_login_path, params: {
+      session: { email: local_accounts(:active_admin).email, password: 'localpassword123' }
+    }
+  end
+
+  def sign_in_as_member
+    post local_login_path, params: {
+      session: { email: local_accounts(:regular_member).email, password: 'memberpassword123' }
+    }
+  end
+end


### PR DESCRIPTION
Adds a Training nav item for all signed-in users linking to a catalog of training topics. Admins see every topic; non-admins only see topics flagged `offered_to_members`. Each topic has a detail page listing trainers, trained members, and training materials (links plus documents, with documents scoped to what the viewer can download). Both admins and non-admins can request training for any topic that is offered to members and has at least one trainer, using the same flow as the Request Training button on the member dashboard.

For admins the nav item is placed between Payments and Journal; for non-admins it is the first entry in the main nav.

Made-with: Cursor