### PR TITLE
Sync email template text from HTML

### DIFF
--- a/app/controllers/email_templates_controller.rb
+++ b/app/controllers/email_templates_controller.rb
@@ -1,4 +1,7 @@
 class EmailTemplatesController < AdminController
+  HTML_BLOCK_TAGS = %w[p div h1 h2 h3 h4 h5 h6 li tr].freeze
+  HTML_SPACED_TAGS = %w[td th].freeze
+
   before_action :set_email_template,
                 only: %i[show edit update preview toggle mark_reviewed mark_needs_review rewrite_with_ai]
 
@@ -20,7 +23,7 @@ class EmailTemplatesController < AdminController
   def edit; end
 
   def update
-    if @email_template.update(email_template_params)
+    if @email_template.update(email_template_update_params)
       redirect_to email_templates_path, notice: "Email template '#{@email_template.name}' was successfully updated."
     else
       render :edit, status: :unprocessable_content
@@ -106,6 +109,35 @@ class EmailTemplatesController < AdminController
 
   def email_template_params
     params.expect(email_template: %i[name description subject body_html body_text enabled])
+  end
+
+  def email_template_update_params
+    attrs = email_template_params.to_h
+    attrs['body_text'] = html_to_plain_text(attrs['body_html']) if sync_body_text?
+    attrs
+  end
+
+  def sync_body_text?
+    params[:sync_body_text].present?
+  end
+
+  def html_to_plain_text(html)
+    fragment = Nokogiri::HTML.fragment(html.to_s)
+    node_to_plain_text(fragment)
+      .gsub("\u00a0", ' ')
+      .gsub(/[ \t]+\n/, "\n")
+      .gsub(/\n{3,}/, "\n\n")
+      .strip
+  end
+
+  def node_to_plain_text(node)
+    return node.text if node.text?
+    return "\n" if node.element? && node.name == 'br'
+
+    text = node.children.map { |child| node_to_plain_text(child) }.join
+    text += "\n" if node.element? && HTML_BLOCK_TAGS.include?(node.name)
+    text += ' ' if node.element? && HTML_SPACED_TAGS.include?(node.name)
+    text
   end
 
   def rewrite_params

--- a/app/javascript/controllers/email_template_rewrite_controller.js
+++ b/app/javascript/controllers/email_template_rewrite_controller.js
@@ -1,7 +1,16 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["subject", "bodyHtml", "bodyText", "rewriteButton", "undoButton", "spinner", "status"]
+  static targets = [
+    "subject",
+    "bodyHtml",
+    "bodyText",
+    "syncBodyText",
+    "rewriteButton",
+    "undoButton",
+    "spinner",
+    "status"
+  ]
   static values = { url: String }
 
   connect() {
@@ -47,7 +56,11 @@ export default class extends Controller {
 
       this.subjectTarget.value = payload.subject || ""
       this.setHtmlBody(payload.body_html || "")
-      this.bodyTextTarget.value = payload.body_text || ""
+      if (this.shouldSyncBodyText()) {
+        this.syncBodyTextFromHtml()
+      } else {
+        this.bodyTextTarget.value = payload.body_text || ""
+      }
       this.setStatus(payload.message || "Template rewritten.", "success")
     } catch (_error) {
       this.setStatus("Rewrite failed. Please try again.", "danger")
@@ -62,10 +75,22 @@ export default class extends Controller {
 
     this.subjectTarget.value = this.previousState.subject
     this.setHtmlBody(this.previousState.bodyHtml)
-    this.bodyTextTarget.value = this.previousState.bodyText
+    if (this.shouldSyncBodyText()) {
+      this.syncBodyTextFromHtml()
+    } else {
+      this.bodyTextTarget.value = this.previousState.bodyText
+    }
     this.previousState = null
     this.toggleUndo(false)
     this.setStatus("Restored previous template text.", "secondary")
+  }
+
+  syncBodyText() {
+    this.syncBodyTextFromHtml()
+  }
+
+  syncBodyTextBeforeSubmit() {
+    this.syncBodyTextFromHtml()
   }
 
   setLoading(isLoading) {
@@ -106,6 +131,39 @@ export default class extends Controller {
   editorInstance() {
     if (typeof tinymce === "undefined") return null
     return tinymce.get(this.bodyHtmlTarget.id)
+  }
+
+  syncBodyTextFromHtml() {
+    if (!this.shouldSyncBodyText()) return
+
+    this.bodyTextTarget.value = this.htmlToPlainText(this.currentHtmlBody())
+  }
+
+  shouldSyncBodyText() {
+    return !this.hasSyncBodyTextTarget || this.syncBodyTextTarget.checked
+  }
+
+  htmlToPlainText(html) {
+    const container = document.createElement("div")
+    container.innerHTML = html || ""
+
+    container.querySelectorAll("br").forEach((element) => {
+      element.replaceWith("\n")
+    })
+
+    container.querySelectorAll("p, div, h1, h2, h3, h4, h5, h6, li, tr").forEach((element) => {
+      element.append("\n")
+    })
+
+    container.querySelectorAll("td, th").forEach((element) => {
+      element.append(" ")
+    })
+
+    return container.textContent
+      .replace(/\u00a0/g, " ")
+      .replace(/[ \t]+\n/g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
   }
 
   csrfToken() {

--- a/app/javascript/controllers/rich_editor_controller.js
+++ b/app/javascript/controllers/rich_editor_controller.js
@@ -25,6 +25,8 @@ export default class extends Controller {
     const variables = this.variablesValue || []
     const controller = this
 
+    if (typeof tinymce === "undefined") return
+
     // Build menu items for variable insertion
     const variableMenuItems = variables.map(v => ({
       type: 'menuitem',
@@ -53,6 +55,11 @@ export default class extends Controller {
       setup: function(editor) {
         controller.editor = editor
 
+        const syncTextarea = function() {
+          editor.save()
+          textarea.dispatchEvent(new CustomEvent("rich-editor:change", { bubbles: true }))
+        }
+
         // Add custom variable insertion button
         if (variableMenuItems.length > 0) {
           editor.ui.registry.addMenuButton('insertvariable', {
@@ -64,9 +71,7 @@ export default class extends Controller {
         }
 
         // Sync content to textarea on change
-        editor.on('change', function() {
-          editor.save()
-        })
+        editor.on('change keyup undo redo setcontent', syncTextarea)
 
         // Sync before form submission
         editor.on('submit', function() {

--- a/app/views/email_templates/edit.html.erb
+++ b/app/views/email_templates/edit.html.erb
@@ -17,6 +17,7 @@
                       local: true,
                       data: {
                         controller: "email-template-rewrite",
+                        action: "submit->email-template-rewrite#syncBodyTextBeforeSubmit",
                         email_template_rewrite_url_value: rewrite_with_ai_email_template_path(@email_template)
                       } do |f| %>
           <% if @email_template.errors.any? %>
@@ -56,15 +57,35 @@
             <%= f.text_area :body_html,
                             class: "form-control",
                             rows: 15,
-                            data: { rich_editor_target: "editor", email_template_rewrite_target: "bodyHtml" } %>
+                            data: {
+                              rich_editor_target: "editor",
+                              email_template_rewrite_target: "bodyHtml",
+                              action: "input->email-template-rewrite#syncBodyText change->email-template-rewrite#syncBodyText rich-editor:change->email-template-rewrite#syncBodyText"
+                            } %>
             <div class="form-text">HTML content for email clients that support it. Use "Insert Variable" to add template variables.</div>
           </div>
 
           <div class="mb-3">
-            <%= f.label :body_text, "Plain Text Body", class: "form-label" %>
+            <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+              <%= f.label :body_text, "Plain Text Body", class: "form-label mb-0" %>
+              <div class="form-check">
+                <%= check_box_tag :sync_body_text,
+                                  "1",
+                                  true,
+                                  id: "email_template_sync_body_text",
+                                  class: "form-check-input",
+                                  data: {
+                                    email_template_rewrite_target: "syncBodyText",
+                                    action: "change->email-template-rewrite#syncBodyText"
+                                  } %>
+                <%= label_tag :email_template_sync_body_text,
+                              "Keep in sync with HTML",
+                              class: "form-check-label" %>
+              </div>
+            </div>
             <%= f.text_area :body_text, class: "form-control font-monospace", rows: 10,
                                            data: { email_template_rewrite_target: "bodyText" } %>
-            <div class="form-text">Plain text version for email clients that don't support HTML.</div>
+            <div class="form-text">Plain text version for email clients that don't support HTML. Uncheck to edit it independently.</div>
           </div>
 
           <div class="mb-3 border rounded bg-body-tertiary p-3">

--- a/test/controllers/email_templates_controller_test.rb
+++ b/test/controllers/email_templates_controller_test.rb
@@ -51,6 +51,51 @@ class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Improved text', parsed['body_text']
   end
 
+  test 'edit shows text sync checkbox checked by default' do
+    get edit_email_template_path(@template)
+
+    assert_response :success
+    assert_select 'input#email_template_sync_body_text[name=?][checked]', 'sync_body_text'
+    assert_select 'label[for=?]', 'email_template_sync_body_text', text: 'Keep in sync with HTML'
+  end
+
+  test 'update syncs plain text from html when checkbox is checked' do
+    patch email_template_path(@template), params: {
+      sync_body_text: '1',
+      email_template: {
+        name: @template.name,
+        description: @template.description,
+        subject: 'Updated Subject',
+        body_html: '<h1>Welcome</h1><p>Hello <strong>{{member_name}}</strong><br>Line two</p>',
+        body_text: 'Stale plain text',
+        enabled: '1'
+      }
+    }
+
+    assert_redirected_to email_templates_path
+    @template.reload
+    assert_equal '<h1>Welcome</h1><p>Hello <strong>{{member_name}}</strong><br>Line two</p>', @template.body_html
+    assert_equal "Welcome\nHello {{member_name}}\nLine two", @template.body_text
+  end
+
+  test 'update leaves plain text unchanged when checkbox is unchecked' do
+    patch email_template_path(@template), params: {
+      email_template: {
+        name: @template.name,
+        description: @template.description,
+        subject: 'Updated Subject',
+        body_html: '<p>Replacement HTML</p>',
+        body_text: 'Custom plain text',
+        enabled: '1'
+      }
+    }
+
+    assert_redirected_to email_templates_path
+    @template.reload
+    assert_equal '<p>Replacement HTML</p>', @template.body_html
+    assert_equal 'Custom plain text', @template.body_text
+  end
+
   private
 
   def sign_in_as_admin


### PR DESCRIPTION
Keep plain-text email bodies aligned with HTML edits by default while preserving an opt-out for manual text edits.

Made-with: Cursor