### PR TITLE
Fix email template preview and text links

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -404,6 +404,17 @@
 }
 .resource-link:hover { text-decoration: underline; }
 
+// Email template show previews sit on a white canvas; override low-contrast template styles there only.
+.email-template-html-body {
+  color: #212529;
+}
+.email-template-html-body :not(a) {
+  color: #212529 !important;
+}
+.email-template-html-body a {
+  color: #0a58ca !important;
+}
+
 .profile-section-header {
   display: flex;
   align-items: baseline;

--- a/app/controllers/email_templates_controller.rb
+++ b/app/controllers/email_templates_controller.rb
@@ -1,5 +1,6 @@
 class EmailTemplatesController < AdminController
   HTML_BLOCK_TAGS = %w[p div h1 h2 h3 h4 h5 h6 li tr].freeze
+  HTML_LINK_URL_TAGS = %w[p li].freeze
   HTML_SPACED_TAGS = %w[td th].freeze
 
   before_action :set_email_template,
@@ -126,6 +127,7 @@ class EmailTemplatesController < AdminController
     node_to_plain_text(fragment)
       .gsub("\u00a0", ' ')
       .gsub(/[ \t]+\n/, "\n")
+      .gsub(/\n[ \t]+/, "\n")
       .gsub(/\n{3,}/, "\n\n")
       .strip
   end
@@ -135,9 +137,23 @@ class EmailTemplatesController < AdminController
     return "\n" if node.element? && node.name == 'br'
 
     text = node.children.map { |child| node_to_plain_text(child) }.join
+    if append_link_urls?(node)
+      urls = node.css('a[href]').filter_map { |link| link['href'].presence }
+      text = append_link_urls(text, urls)
+    end
     text += "\n" if node.element? && HTML_BLOCK_TAGS.include?(node.name)
     text += ' ' if node.element? && HTML_SPACED_TAGS.include?(node.name)
     text
+  end
+
+  def append_link_urls?(node)
+    node.element? && HTML_LINK_URL_TAGS.include?(node.name) && node.css('a[href]').any?
+  end
+
+  def append_link_urls(text, urls)
+    return text if urls.blank?
+
+    [text.rstrip, '', *urls, ''].join("\n")
   end
 
   def rewrite_params

--- a/app/javascript/controllers/email_template_rewrite_controller.js
+++ b/app/javascript/controllers/email_template_rewrite_controller.js
@@ -151,6 +151,16 @@ export default class extends Controller {
       element.replaceWith("\n")
     })
 
+    container.querySelectorAll("p, li").forEach((element) => {
+      const urls = Array.from(element.querySelectorAll("a[href]"))
+        .map((link) => link.getAttribute("href"))
+        .filter((url) => url && url.trim().length > 0)
+
+      if (urls.length > 0) {
+        element.append(`\n\n${urls.join("\n")}\n`)
+      }
+    })
+
     container.querySelectorAll("p, div, h1, h2, h3, h4, h5, h6, li, tr").forEach((element) => {
       element.append("\n")
     })
@@ -162,6 +172,7 @@ export default class extends Controller {
     return container.textContent
       .replace(/\u00a0/g, " ")
       .replace(/[ \t]+\n/g, "\n")
+      .replace(/\n[ \t]+/g, "\n")
       .replace(/\n{3,}/g, "\n\n")
       .trim()
   }

--- a/app/views/email_templates/show.html.erb
+++ b/app/views/email_templates/show.html.erb
@@ -47,7 +47,7 @@
         <h5 class="card-title mb-0">HTML Body</h5>
       </div>
       <div class="card-body">
-        <div class="border rounded p-3 bg-white">
+        <div class="email-template-html-body border rounded p-3 bg-white">
           <%= @email_template.body_html.html_safe %>
         </div>
       </div>

--- a/test/controllers/email_templates_controller_test.rb
+++ b/test/controllers/email_templates_controller_test.rb
@@ -59,6 +59,13 @@ class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
     assert_select 'label[for=?]', 'email_template_sync_body_text', text: 'Keep in sync with HTML'
   end
 
+  test 'show wraps html body in high contrast preview container' do
+    get email_template_path(@template)
+
+    assert_response :success
+    assert_select '.email-template-html-body'
+  end
+
   test 'update syncs plain text from html when checkbox is checked' do
     patch email_template_path(@template), params: {
       sync_body_text: '1',
@@ -76,6 +83,37 @@ class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
     @template.reload
     assert_equal '<h1>Welcome</h1><p>Hello <strong>{{member_name}}</strong><br>Line two</p>', @template.body_html
     assert_equal "Welcome\nHello {{member_name}}\nLine two", @template.body_text
+  end
+
+  test 'update sync lists link urls under their containing paragraph' do
+    html = <<~HTML.squish
+      <p>Visit <a href="https://example.com/start">the getting started guide</a>
+      and <a href="{{application_url}}">your application</a>.</p>
+      <p>Thanks for reading.</p>
+    HTML
+
+    patch email_template_path(@template), params: {
+      sync_body_text: '1',
+      email_template: {
+        name: @template.name,
+        description: @template.description,
+        subject: 'Updated Subject',
+        body_html: html,
+        body_text: 'Stale plain text',
+        enabled: '1'
+      }
+    }
+
+    assert_redirected_to email_templates_path
+    @template.reload
+    assert_equal <<~TEXT.strip, @template.body_text
+      Visit the getting started guide and your application.
+
+      https://example.com/start
+      {{application_url}}
+
+      Thanks for reading.
+    TEXT
   end
 
   test 'update leaves plain text unchanged when checkbox is unchecked' do


### PR DESCRIPTION
Improve HTML preview contrast and preserve link destinations when syncing email templates to plain text.

Made-with: Cursor