### PR TITLE
Sync queued mail text from HTML

### DIFF
--- a/app/controllers/queued_mails_controller.rb
+++ b/app/controllers/queued_mails_controller.rb
@@ -1,4 +1,8 @@
 class QueuedMailsController < AdminController
+  HTML_BLOCK_TAGS = %w[p div h1 h2 h3 h4 h5 h6 li tr].freeze
+  HTML_LINK_URL_TAGS = %w[p li].freeze
+  HTML_SPACED_TAGS = %w[td th].freeze
+
   before_action :set_queued_mail, only: %i[show edit update approve reject regenerate retry_delivery rewrite_with_ai]
 
   def index
@@ -28,7 +32,7 @@ class QueuedMailsController < AdminController
       return
     end
 
-    if @queued_mail.update(queued_mail_params)
+    if @queued_mail.update(queued_mail_update_params)
       @queued_mail.log_edit!(current_user)
       redirect_to queued_mail_path(@queued_mail), notice: 'Message updated.'
     else
@@ -144,6 +148,50 @@ class QueuedMailsController < AdminController
 
   def queued_mail_params
     params.expect(queued_mail: %i[to subject body_html body_text])
+  end
+
+  def queued_mail_update_params
+    attrs = queued_mail_params.to_h
+    attrs['body_text'] = html_to_plain_text(attrs['body_html']) if sync_body_text?
+    attrs
+  end
+
+  def sync_body_text?
+    params[:sync_body_text].present?
+  end
+
+  def html_to_plain_text(html)
+    fragment = Nokogiri::HTML.fragment(html.to_s)
+    node_to_plain_text(fragment)
+      .gsub("\u00a0", ' ')
+      .gsub(/[ \t]+\n/, "\n")
+      .gsub(/\n[ \t]+/, "\n")
+      .gsub(/\n{3,}/, "\n\n")
+      .strip
+  end
+
+  def node_to_plain_text(node)
+    return node.text if node.text?
+    return "\n" if node.element? && node.name == 'br'
+
+    text = node.children.map { |child| node_to_plain_text(child) }.join
+    if append_link_urls?(node)
+      urls = node.css('a[href]').filter_map { |link| link['href'].presence }
+      text = append_link_urls(text, urls)
+    end
+    text += "\n" if node.element? && HTML_BLOCK_TAGS.include?(node.name)
+    text += ' ' if node.element? && HTML_SPACED_TAGS.include?(node.name)
+    text
+  end
+
+  def append_link_urls?(node)
+    node.element? && HTML_LINK_URL_TAGS.include?(node.name) && node.css('a[href]').any?
+  end
+
+  def append_link_urls(text, urls)
+    return text if urls.blank?
+
+    [text.rstrip, '', *urls, ''].join("\n")
   end
 
   def rewrite_params

--- a/app/javascript/controllers/queued_mail_rewrite_controller.js
+++ b/app/javascript/controllers/queued_mail_rewrite_controller.js
@@ -1,7 +1,16 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["subject", "bodyHtml", "bodyText", "rewriteButton", "undoButton", "spinner", "status"]
+  static targets = [
+    "subject",
+    "bodyHtml",
+    "bodyText",
+    "syncBodyText",
+    "rewriteButton",
+    "undoButton",
+    "spinner",
+    "status"
+  ]
   static values = { url: String }
 
   connect() {
@@ -45,7 +54,11 @@ export default class extends Controller {
       }
 
       this.setHtmlBody(payload.body_html || "")
-      this.bodyTextTarget.value = payload.body_text || ""
+      if (this.shouldSyncBodyText()) {
+        this.syncBodyTextFromHtml()
+      } else {
+        this.bodyTextTarget.value = payload.body_text || ""
+      }
       this.setStatus(payload.message || "Message rewritten.", "success")
     } catch (_error) {
       this.setStatus("Rewrite failed. Please try again.", "danger")
@@ -59,10 +72,22 @@ export default class extends Controller {
     if (!this.previousState) return
 
     this.setHtmlBody(this.previousState.bodyHtml)
-    this.bodyTextTarget.value = this.previousState.bodyText
+    if (this.shouldSyncBodyText()) {
+      this.syncBodyTextFromHtml()
+    } else {
+      this.bodyTextTarget.value = this.previousState.bodyText
+    }
     this.previousState = null
     this.toggleUndo(false)
     this.setStatus("Restored previous message body.", "secondary")
+  }
+
+  syncBodyText() {
+    this.syncBodyTextFromHtml()
+  }
+
+  syncBodyTextBeforeSubmit() {
+    this.syncBodyTextFromHtml()
   }
 
   setLoading(isLoading) {
@@ -103,6 +128,50 @@ export default class extends Controller {
   editorInstance() {
     if (typeof tinymce === "undefined") return null
     return tinymce.get(this.bodyHtmlTarget.id)
+  }
+
+  syncBodyTextFromHtml() {
+    if (!this.shouldSyncBodyText()) return
+
+    this.bodyTextTarget.value = this.htmlToPlainText(this.currentHtmlBody())
+  }
+
+  shouldSyncBodyText() {
+    return !this.hasSyncBodyTextTarget || this.syncBodyTextTarget.checked
+  }
+
+  htmlToPlainText(html) {
+    const container = document.createElement("div")
+    container.innerHTML = html || ""
+
+    container.querySelectorAll("br").forEach((element) => {
+      element.replaceWith("\n")
+    })
+
+    container.querySelectorAll("p, li").forEach((element) => {
+      const urls = Array.from(element.querySelectorAll("a[href]"))
+        .map((link) => link.getAttribute("href"))
+        .filter((url) => url && url.trim().length > 0)
+
+      if (urls.length > 0) {
+        element.append(`\n\n${urls.join("\n")}\n`)
+      }
+    })
+
+    container.querySelectorAll("p, div, h1, h2, h3, h4, h5, h6, li, tr").forEach((element) => {
+      element.append("\n")
+    })
+
+    container.querySelectorAll("td, th").forEach((element) => {
+      element.append(" ")
+    })
+
+    return container.textContent
+      .replace(/\u00a0/g, " ")
+      .replace(/[ \t]+\n/g, "\n")
+      .replace(/\n[ \t]+/g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
   }
 
   csrfToken() {

--- a/app/views/queued_mails/edit.html.erb
+++ b/app/views/queued_mails/edit.html.erb
@@ -17,6 +17,7 @@
           class: "needs-validation",
           data: {
             controller: "queued-mail-rewrite",
+            action: "submit->queued-mail-rewrite#syncBodyTextBeforeSubmit",
             queued_mail_rewrite_url_value: rewrite_with_ai_queued_mail_path(@queued_mail)
           }
         ) do |f| %>
@@ -48,7 +49,11 @@
             class: "form-control #{'is-invalid' if @queued_mail.errors.key?(:body_html)}",
             rows: 16,
             required: true,
-            data: { rich_editor_target: "editor", queued_mail_rewrite_target: "bodyHtml" } %>
+            data: {
+              rich_editor_target: "editor",
+              queued_mail_rewrite_target: "bodyHtml",
+              action: "input->queued-mail-rewrite#syncBodyText change->queued-mail-rewrite#syncBodyText rich-editor:change->queued-mail-rewrite#syncBodyText"
+            } %>
         <% if @queued_mail.errors.key?(:body_html) %>
           <div class="invalid-feedback"><%= @queued_mail.errors[:body_html].join(', ') %></div>
         <% end %>
@@ -56,12 +61,28 @@
       </div>
 
       <div class="mb-3">
-        <%= f.label :body_text, "Plain Text Body", class: "form-label" %>
+        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+          <%= f.label :body_text, "Plain Text Body", class: "form-label mb-0" %>
+          <div class="form-check">
+            <%= check_box_tag :sync_body_text,
+                              "1",
+                              true,
+                              id: "queued_mail_sync_body_text",
+                              class: "form-check-input",
+                              data: {
+                                queued_mail_rewrite_target: "syncBodyText",
+                                action: "change->queued-mail-rewrite#syncBodyText"
+                              } %>
+            <%= label_tag :queued_mail_sync_body_text,
+                          "Keep in sync with HTML",
+                          class: "form-check-label" %>
+          </div>
+        </div>
         <%= f.text_area :body_text,
             class: "form-control font-monospace",
             rows: 10,
             data: { queued_mail_rewrite_target: "bodyText" } %>
-        <div class="form-text">Optional plain text alternative for email clients that don't support HTML.</div>
+        <div class="form-text">Optional plain text alternative for email clients that don't support HTML. Uncheck to edit it independently.</div>
       </div>
 
       <div class="mb-3 border rounded bg-body-tertiary p-3">

--- a/test/controllers/queued_mails_controller_test.rb
+++ b/test/controllers/queued_mails_controller_test.rb
@@ -55,6 +55,8 @@ class QueuedMailsControllerTest < ActionDispatch::IntegrationTest
     get edit_queued_mail_path(@pending)
     assert_response :success
     assert_select 'form'
+    assert_select 'input#queued_mail_sync_body_text[name=?][checked]', 'sync_body_text'
+    assert_select 'label[for=?]', 'queued_mail_sync_body_text', text: 'Keep in sync with HTML'
   end
 
   test 'redirects edit for non-pending mail' do
@@ -74,6 +76,68 @@ class QueuedMailsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to queued_mail_path(@pending)
     @pending.reload
     assert_equal 'Updated Subject', @pending.subject
+  end
+
+  test 'update syncs plain text from html when checkbox is checked' do
+    patch queued_mail_path(@pending), params: {
+      sync_body_text: '1',
+      queued_mail: {
+        to: @pending.to,
+        subject: 'Updated Subject',
+        body_html: '<h1>Welcome</h1><p>Hello <strong>member</strong><br>Line two</p>',
+        body_text: 'Stale plain text'
+      }
+    }
+
+    assert_redirected_to queued_mail_path(@pending)
+    @pending.reload
+    assert_equal '<h1>Welcome</h1><p>Hello <strong>member</strong><br>Line two</p>', @pending.body_html
+    assert_equal "Welcome\nHello member\nLine two", @pending.body_text
+  end
+
+  test 'update sync lists link urls under their containing paragraph' do
+    html = <<~HTML.squish
+      <p>Review <a href="https://example.com/message">this message</a>
+      and <a href="{{application_url}}">the application</a>.</p>
+      <p>Thanks for helping.</p>
+    HTML
+
+    patch queued_mail_path(@pending), params: {
+      sync_body_text: '1',
+      queued_mail: {
+        to: @pending.to,
+        subject: 'Updated Subject',
+        body_html: html,
+        body_text: 'Stale plain text'
+      }
+    }
+
+    assert_redirected_to queued_mail_path(@pending)
+    @pending.reload
+    assert_equal <<~TEXT.strip, @pending.body_text
+      Review this message and the application.
+
+      https://example.com/message
+      {{application_url}}
+
+      Thanks for helping.
+    TEXT
+  end
+
+  test 'update leaves plain text unchanged when checkbox is unchecked' do
+    patch queued_mail_path(@pending), params: {
+      queued_mail: {
+        to: @pending.to,
+        subject: 'Updated Subject',
+        body_html: '<p>Replacement HTML</p>',
+        body_text: 'Custom plain text'
+      }
+    }
+
+    assert_redirected_to queued_mail_path(@pending)
+    @pending.reload
+    assert_equal '<p>Replacement HTML</p>', @pending.body_html
+    assert_equal 'Custom plain text', @pending.body_text
   end
 
   test 'rejects update for non-pending mail' do


### PR DESCRIPTION
Give queued mail edits the same opt-out plain-text sync behavior as email templates, preserving link destinations in generated text.

Made-with: Cursor