### PR TITLE
Add immediate send controls for email templates

### DIFF
--- a/app/controllers/email_templates_controller.rb
+++ b/app/controllers/email_templates_controller.rb
@@ -109,7 +109,9 @@ class EmailTemplatesController < AdminController
   end
 
   def email_template_params
-    params.expect(email_template: %i[name description subject body_html body_text enabled])
+    params.expect(email_template: %i[
+                    name description subject body_html body_text enabled send_immediately block_send_immediately
+                  ])
   end
 
   def email_template_update_params

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -145,10 +145,14 @@ class MembershipApplicationsController < ApplicationController
       return
     end
 
-    if result.queued_mail
-      redirect_to edit_queued_mail_path(result.queued_mail),
+    delivery = result.queued_mail
+    if delivery.is_a?(QueuedMail)
+      redirect_to edit_queued_mail_path(delivery),
                   notice: 'Application approved. Review and edit the queued welcome email, ' \
                           'then approve it in the mail queue to send.'
+    elsif delivery.is_a?(QueuedMail::ImmediateDelivery)
+      redirect_to membership_application_path(@application),
+                  notice: "Application approved. The welcome email was sent immediately to #{delivery.to}."
     else
       redirect_to membership_application_path(@application),
                   notice: 'Application approved. No welcome email was queued (recipient has no email address).'
@@ -159,10 +163,13 @@ class MembershipApplicationsController < ApplicationController
     notes = params[:admin_notes]
     qm = @application.reject!(current_user, notes: notes)
 
-    if qm
+    if qm.is_a?(QueuedMail)
       redirect_to edit_queued_mail_path(qm),
                   notice: 'Application rejected. Review and edit the queued message, ' \
                           'then approve it in the mail queue to send.'
+    elsif qm.is_a?(QueuedMail::ImmediateDelivery)
+      redirect_to membership_application_path(@application),
+                  notice: "Application rejected. The rejection email was sent immediately to #{qm.to}."
     else
       redirect_to membership_application_path(@application),
                   notice: 'Application rejected. No email was queued (recipient has no email address).'

--- a/app/mailers/email_template_mailer.rb
+++ b/app/mailers/email_template_mailer.rb
@@ -1,0 +1,11 @@
+class EmailTemplateMailer < ApplicationMailer
+  def send_rendered(to:, subject:, body_html:, body_text:)
+    @body_html = body_html
+    @body_text = body_text
+
+    mail(to: to, subject: subject) do |format|
+      format.html { render html: @body_html.html_safe, layout: 'mailer' }
+      format.text { render plain: @body_text } if @body_text.present?
+    end
+  end
+end

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -494,6 +494,8 @@ class EmailTemplate < ApplicationRecord
   validates :body_html, presence: true
   validates :body_text, presence: true
 
+  before_validation :clear_send_immediately_if_blocked
+
   scope :enabled, -> { where(enabled: true) }
   scope :disabled, -> { where(enabled: false) }
   scope :needs_review, -> { where(needs_review: true) }
@@ -551,6 +553,10 @@ class EmailTemplate < ApplicationRecord
   end
 
   private
+
+  def clear_send_immediately_if_blocked
+    self.send_immediately = false if block_send_immediately?
+  end
 
   def substitute_variables(text, variables)
     result = text.dup

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -121,8 +121,8 @@ class MembershipApplication < ApplicationRecord
     Journal.record_application_event!(application: self, action: 'application_approved', actor: admin)
   end
 
-  # Marks the application rejected, journals, and queues the applicant rejection email (pending mail queue).
-  # Returns the new +QueuedMail+ or +nil+ if no message was queued (e.g. no destination email).
+  # Marks the application rejected, journals, and queues or immediately sends the applicant rejection email.
+  # Returns the new +QueuedMail+, +QueuedMail::ImmediateDelivery+, or +nil+ if no message was sent.
   def reject!(admin, notes: nil)
     queued_mail = nil
     MembershipApplication.transaction do

--- a/app/models/queued_mail.rb
+++ b/app/models/queued_mail.rb
@@ -3,6 +3,7 @@ class QueuedMail < ApplicationRecord
 
   # Stand-in for +MemberMailer.build_template_variables+ when the applicant has no User yet
   ApplicantMailRecipient = Data.define(:display_name, :email, :username)
+  ImmediateDelivery = Data.define(:to, :subject, :email_template)
 
   belongs_to :email_template, optional: true
   belongs_to :recipient, class_name: 'User', optional: true
@@ -42,35 +43,19 @@ class QueuedMail < ApplicationRecord
     template = EmailTemplate.find_enabled(action.to_s)
     variables = enqueue_render_variables(action, user, extra_args, template)
 
+    return deliver_immediately(template, dest, variables) if template&.send_immediately?
+
     record = if template
-               rendered = template.render(variables)
-               create!(
-                 to: dest,
-                 subject: rendered[:subject],
-                 body_html: rendered[:body_html],
-                 body_text: rendered[:body_text] || '',
-                 reason: reason || action.to_s.humanize,
-                 email_template: template,
-                 recipient: user,
-                 mailer_action: action.to_s,
-                 mailer_args: extra_args
+               create_queued_mail_from_template(
+                 template,
+                 variables,
+                 queued_mail_attrs(dest, reason || action.to_s.humanize, user, action.to_s, extra_args)
                )
              else
                message = MemberMailer.public_send(action, *build_mailer_args(action, user, to, extra_args))
-               msg = message.message
-
-               html_body = msg.multipart? ? msg.html_part&.body&.decoded : msg.body.decoded
-               text_body = msg.multipart? ? msg.text_part&.body&.decoded : ''
-
-               create!(
-                 to: dest,
-                 subject: msg.subject,
-                 body_html: html_body || '',
-                 body_text: text_body || '',
-                 reason: reason || action.to_s.humanize,
-                 recipient: user,
-                 mailer_action: action.to_s,
-                 mailer_args: extra_args
+               create_queued_mail_from_message(
+                 message,
+                 queued_mail_attrs(dest, reason || action.to_s.humanize, user, action.to_s, extra_args)
                )
              end
 
@@ -91,34 +76,19 @@ class QueuedMail < ApplicationRecord
 
     variables = MemberMailer.build_template_variables(template_recipient, extra_args)
 
+    return deliver_immediately(template, dest, variables) if template&.send_immediately?
+
     record = if template
-               rendered = template.render(variables)
-               create!(
-                 to: dest,
-                 subject: rendered[:subject],
-                 body_html: rendered[:body_html],
-                 body_text: rendered[:body_text] || '',
-                 reason: 'Application rejected',
-                 email_template: template,
-                 recipient: recipient_user,
-                 mailer_action: action,
-                 mailer_args: extra_args
+               create_queued_mail_from_template(
+                 template,
+                 variables,
+                 queued_mail_attrs(dest, 'Application rejected', recipient_user, action, extra_args)
                )
              else
                message = MemberMailer.application_rejected(template_recipient, **extra_args)
-               msg = message.message
-               html_body = msg.multipart? ? msg.html_part&.body&.decoded : msg.body.decoded
-               text_body = msg.multipart? ? msg.text_part&.body&.decoded : ''
-
-               create!(
-                 to: dest,
-                 subject: msg.subject,
-                 body_html: html_body || '',
-                 body_text: text_body || '',
-                 reason: 'Application rejected',
-                 recipient: recipient_user,
-                 mailer_action: action,
-                 mailer_args: extra_args
+               create_queued_mail_from_message(
+                 message,
+                 queued_mail_attrs(dest, 'Application rejected', recipient_user, action, extra_args)
                )
              end
 
@@ -141,6 +111,52 @@ class QueuedMail < ApplicationRecord
       display_name: name,
       email: application.email,
       username: 'Not set'
+    )
+  end
+
+  def self.deliver_immediately(template, dest, variables)
+    rendered = template.render(variables)
+    EmailTemplateMailer.send_rendered(
+      to: dest,
+      subject: rendered[:subject],
+      body_html: rendered[:body_html],
+      body_text: rendered[:body_text] || ''
+    ).deliver_now
+
+    ImmediateDelivery.new(to: dest, subject: rendered[:subject], email_template: template)
+  end
+
+  def self.queued_mail_attrs(dest, reason, recipient, action, args)
+    {
+      to: dest,
+      reason: reason,
+      recipient: recipient,
+      mailer_action: action,
+      mailer_args: args
+    }
+  end
+
+  def self.create_queued_mail_from_template(template, variables, attrs)
+    rendered = template.render(variables)
+    create!(
+      **attrs,
+      subject: rendered[:subject],
+      body_html: rendered[:body_html],
+      body_text: rendered[:body_text] || '',
+      email_template: template
+    )
+  end
+
+  def self.create_queued_mail_from_message(message, attrs)
+    msg = message.message
+    html_body = msg.multipart? ? msg.html_part&.body&.decoded : msg.body.decoded
+    text_body = msg.multipart? ? msg.text_part&.body&.decoded : ''
+
+    create!(
+      **attrs,
+      subject: msg.subject,
+      body_html: html_body || '',
+      body_text: text_body || ''
     )
   end
 

--- a/app/views/email_templates/edit.html.erb
+++ b/app/views/email_templates/edit.html.erb
@@ -117,6 +117,30 @@
             <div class="form-text">Disabled templates will not be sent.</div>
           </div>
 
+          <div class="mb-4 border rounded bg-body-tertiary p-3">
+            <h2 class="h6 mb-3">Delivery behavior</h2>
+            <div class="form-check">
+              <%= f.check_box :send_immediately,
+                              class: "form-check-input",
+                              disabled: @email_template.block_send_immediately? %>
+              <%= f.label :send_immediately, "Send immediately", class: "form-check-label" %>
+            </div>
+            <div class="form-text mb-3">
+              Sends this template immediately instead of placing it in the review queue.
+              <% if @email_template.block_send_immediately? %>
+                This is locked off by the safeguard below.
+              <% end %>
+            </div>
+
+            <div class="form-check">
+              <%= f.check_box :block_send_immediately, class: "form-check-input" %>
+              <%= f.label :block_send_immediately, "Block send immediately", class: "form-check-label" %>
+            </div>
+            <div class="form-text">
+              Forces send immediately off so this template cannot accidentally bypass review.
+            </div>
+          </div>
+
           <div class="d-flex gap-2">
             <%= f.submit "Save Template", class: "btn btn-primary" %>
             <%= link_to "Cancel", email_templates_path, class: "btn btn-outline-secondary" %>

--- a/app/views/email_templates/index.html.erb
+++ b/app/views/email_templates/index.html.erb
@@ -40,6 +40,7 @@
           <tr>
             <th>Template</th>
             <th>Subject</th>
+            <th>Delivery</th>
             <th>Status</th>
             <th class="text-end">Actions</th>
           </tr>
@@ -60,6 +61,16 @@
                 <span class="text-truncate d-inline-block" style="max-width: 300px;">
                   <%= template.subject %>
                 </span>
+              </td>
+              <td>
+                <% if template.send_immediately? %>
+                  <span class="badge text-bg-warning-subtle">Send immediately</span>
+                <% else %>
+                  <span class="text-muted small">Queued</span>
+                <% end %>
+                <% if template.block_send_immediately? %>
+                  <span class="badge text-bg-secondary-subtle">Immediate send blocked</span>
+                <% end %>
               </td>
               <td>
                 <% if template.enabled? %>

--- a/db/migrate/20260501160000_add_immediate_send_flags_to_email_templates.rb
+++ b/db/migrate/20260501160000_add_immediate_send_flags_to_email_templates.rb
@@ -1,0 +1,6 @@
+class AddImmediateSendFlagsToEmailTemplates < ActiveRecord::Migration[8.1]
+  def change
+    add_column :email_templates, :send_immediately, :boolean, default: false, null: false
+    add_column :email_templates, :block_send_immediately, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_01_140500) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_01_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -303,12 +303,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_140500) do
   create_table "email_templates", force: :cascade do |t|
     t.text "body_html", null: false
     t.text "body_text", null: false
+    t.boolean "block_send_immediately", default: false, null: false
     t.datetime "created_at", null: false
     t.string "description"
     t.boolean "enabled", default: true, null: false
     t.string "key", null: false
     t.string "name", null: false
     t.boolean "needs_review", default: true, null: false
+    t.boolean "send_immediately", default: false, null: false
     t.string "subject", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_email_templates_on_key", unique: true

--- a/test/controllers/email_templates_controller_test.rb
+++ b/test/controllers/email_templates_controller_test.rb
@@ -59,6 +59,43 @@ class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
     assert_select 'label[for=?]', 'email_template_sync_body_text', text: 'Keep in sync with HTML'
   end
 
+  test 'edit shows immediate send controls' do
+    get edit_email_template_path(@template)
+
+    assert_response :success
+    assert_select 'input[name=?]', 'email_template[send_immediately]'
+    assert_select 'input[name=?]', 'email_template[block_send_immediately]'
+  end
+
+  test 'index shows immediate send flags' do
+    @template.update!(send_immediately: true)
+
+    get email_templates_path
+
+    assert_response :success
+    assert_select 'span', text: 'Send immediately'
+  end
+
+  test 'update cannot enable send immediately while blocked' do
+    patch email_template_path(@template), params: {
+      email_template: {
+        name: @template.name,
+        description: @template.description,
+        subject: 'Updated Subject',
+        body_html: '<p>Replacement HTML</p>',
+        body_text: 'Replacement text',
+        enabled: '1',
+        send_immediately: '1',
+        block_send_immediately: '1'
+      }
+    }
+
+    assert_redirected_to email_templates_path
+    @template.reload
+    assert @template.block_send_immediately?
+    assert_not @template.send_immediately?
+  end
+
   test 'show wraps html body in high contrast preview container' do
     get email_template_path(@template)
 

--- a/test/models/email_template_test.rb
+++ b/test/models/email_template_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class EmailTemplateTest < ActiveSupport::TestCase
+  test 'block send immediately forces send immediately off' do
+    template = EmailTemplate.new(
+      key: 'blocked_immediate_test',
+      name: 'Blocked Immediate Test',
+      subject: 'Hello',
+      body_html: '<p>Hello</p>',
+      body_text: 'Hello',
+      send_immediately: true,
+      block_send_immediately: true
+    )
+
+    assert template.valid?
+    assert_not template.send_immediately?
+  end
+end

--- a/test/models/queued_mail_test.rb
+++ b/test/models/queued_mail_test.rb
@@ -111,6 +111,38 @@ class QueuedMailTest < ActiveSupport::TestCase
     assert_nil @pending.sent_at
   end
 
+  test 'enqueue sends immediate template without creating queued mail' do
+    ActionMailer::Base.deliveries.clear
+    EmailTemplate.where(key: 'application_received').delete_all
+    EmailTemplate.create!(
+      key: 'application_received',
+      name: 'Application Received Immediate',
+      subject: 'Immediate hello {{member_name}}',
+      body_html: '<p>Hello {{member_name}}</p>',
+      body_text: 'Hello {{member_name}}',
+      enabled: true,
+      send_immediately: true
+    )
+
+    result = nil
+    assert_no_enqueued_jobs only: QueuedMailDeliveryJob do
+      assert_no_difference 'QueuedMail.count' do
+        assert_difference 'MailLogEntry.count', 1 do
+          assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+            result = QueuedMail.enqueue(:application_received, users(:one), reason: 'Application received')
+          end
+        end
+      end
+    end
+
+    assert_instance_of QueuedMail::ImmediateDelivery, result
+    assert_equal users(:one).email, result.to
+    entry = MailLogEntry.order(:created_at).last
+    assert_nil entry.queued_mail_id
+    assert_equal result.to, entry.delivery_to
+    assert_equal result.subject, entry.delivery_subject
+  end
+
   # ─── Reject ──────────────────────────────────────────────────────
 
   test 'reject! sets status without sending mail' do


### PR DESCRIPTION
Allow selected templates to bypass the review queue while preserving a blocking safeguard for templates that must never be marked immediate.