### PR TITLE
Sync Authentik from all members group

### DIFF
--- a/app/services/authentik/group_synchronizer.rb
+++ b/app/services/authentik/group_synchronizer.rb
@@ -11,7 +11,7 @@ module Authentik
         return 0
       end
 
-      members = @client.group_members
+      members = @client.group_members(source_group_id)
       now = Time.current
 
       ActiveRecord::Base.transaction do
@@ -25,6 +25,14 @@ module Authentik
     end
 
     private
+
+    def source_group_id
+      all_members_group&.authentik_group_id.presence || AuthentikConfig.settings.group_id
+    end
+
+    def all_members_group
+      ApplicationGroup.with_member_sources('all_members').with_authentik_group_id.first
+    end
 
     def upsert_members(members, timestamp)
       members.each do |attrs|

--- a/test/services/authentik/group_synchronizer_test.rb
+++ b/test/services/authentik/group_synchronizer_test.rb
@@ -19,11 +19,15 @@ module Authentik
       other_user.update_columns(active: true)
 
       client = Class.new do
+        attr_reader :requested_group_ids
+
         def initialize(members)
           @members = members
+          @requested_group_ids = []
         end
 
-        def group_members
+        def group_members(group_id = nil)
+          @requested_group_ids << group_id
           @members
         end
       end.new(
@@ -57,6 +61,31 @@ module Authentik
       assert_not Rfid.exists?(user: user, rfid: 'RFID-FROM-AUTHENTIK')
 
       assert other_user.reload.active?
+    end
+
+    test 'uses all members Authentik group as source when configured' do
+      all_members_group = application_groups(:sample_group)
+      all_members_group.update!(
+        member_source: 'all_members',
+        authentik_group_id: 'all-members-authentik-group'
+      )
+
+      client = Class.new do
+        attr_reader :requested_group_ids
+
+        def initialize
+          @requested_group_ids = []
+        end
+
+        def group_members(group_id = nil)
+          @requested_group_ids << group_id
+          []
+        end
+      end.new
+
+      Authentik::GroupSynchronizer.new(client: client).call
+
+      assert_equal ['all-members-authentik-group'], client.requested_group_ids
     end
   end
 end


### PR DESCRIPTION
Prefer the configured all-members Authentik group for inbound sync so inactive members are included when the legacy source group points at active members.