### PR TITLE
Fix member dashboard and Authentik cleanup

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -335,6 +335,15 @@
   text-decoration: none;
   color: inherit;
 }
+.action-card.disabled {
+  background: rgba(255,255,255,0.01);
+  border-color: rgba(255,255,255,0.05);
+  cursor: not-allowed;
+}
+.action-card.disabled:hover {
+  background: rgba(255,255,255,0.01);
+  border-color: rgba(255,255,255,0.05);
+}
 .action-card-title {
   font-size: 14px;
   font-weight: 500;

--- a/app/javascript/controllers/email_template_rewrite_controller.js
+++ b/app/javascript/controllers/email_template_rewrite_controller.js
@@ -9,13 +9,16 @@ export default class extends Controller {
     "rewriteButton",
     "undoButton",
     "spinner",
-    "status"
+    "status",
+    "sendImmediately",
+    "blockSendImmediately"
   ]
   static values = { url: String }
 
   connect() {
     this.previousState = null
     this.loading = false
+    this.syncImmediateSendControls()
   }
 
   async rewrite(event) {
@@ -91,6 +94,17 @@ export default class extends Controller {
 
   syncBodyTextBeforeSubmit() {
     this.syncBodyTextFromHtml()
+  }
+
+  syncImmediateSendControls() {
+    if (!this.hasSendImmediatelyTarget || !this.hasBlockSendImmediatelyTarget) return
+
+    if (this.blockSendImmediatelyTarget.checked) {
+      this.sendImmediatelyTarget.checked = false
+      this.sendImmediatelyTarget.disabled = true
+    } else {
+      this.sendImmediatelyTarget.disabled = false
+    }
   }
 
   setLoading(isLoading) {

--- a/app/services/authentik/group_synchronizer.rb
+++ b/app/services/authentik/group_synchronizer.rb
@@ -16,6 +16,7 @@ module Authentik
 
       ActiveRecord::Base.transaction do
         upsert_members(members, now)
+        prune_removed_authentik_users(members)
       end
 
       # Record sync in member source
@@ -42,6 +43,27 @@ module Authentik
       rescue ActiveRecord::RecordInvalid => e
         @logger.error("Failed to sync Authentik user #{attrs.inspect}: #{e.message}")
       end
+    end
+
+    def prune_removed_authentik_users(members)
+      synced_ids = members.filter_map { |attrs| attrs[:authentik_id].to_s.presence }
+      removed_records = AuthentikUser.where.not(authentik_id: synced_ids)
+      removed_count = removed_records.count
+      return if removed_count.zero?
+
+      removed_records.find_each do |authentik_user|
+        unlink_member_from_removed_authentik_user!(authentik_user)
+        authentik_user.destroy!
+      end
+
+      @logger.info("Deleted #{removed_count} local Authentik user(s) no longer present in Authentik.")
+    end
+
+    def unlink_member_from_removed_authentik_user!(authentik_user)
+      user = authentik_user.user
+      return unless user&.authentik_id == authentik_user.authentik_id
+
+      user.update_columns(authentik_id: nil, authentik_dirty: false, updated_at: Time.current)
     end
 
     def find_matching_user(attrs)

--- a/app/views/email_templates/edit.html.erb
+++ b/app/views/email_templates/edit.html.erb
@@ -122,7 +122,8 @@
             <div class="form-check">
               <%= f.check_box :send_immediately,
                               class: "form-check-input",
-                              disabled: @email_template.block_send_immediately? %>
+                              disabled: @email_template.block_send_immediately?,
+                              data: { email_template_rewrite_target: "sendImmediately" } %>
               <%= f.label :send_immediately, "Send immediately", class: "form-check-label" %>
             </div>
             <div class="form-text mb-3">
@@ -133,7 +134,12 @@
             </div>
 
             <div class="form-check">
-              <%= f.check_box :block_send_immediately, class: "form-check-input" %>
+              <%= f.check_box :block_send_immediately,
+                              class: "form-check-input",
+                              data: {
+                                email_template_rewrite_target: "blockSendImmediately",
+                                action: "change->email-template-rewrite#syncImmediateSendControls"
+                              } %>
               <%= f.label :block_send_immediately, "Block send immediately", class: "form-check-label" %>
             </div>
             <div class="form-text">

--- a/app/views/users/_tab_dashboard_self.html.erb
+++ b/app/views/users/_tab_dashboard_self.html.erb
@@ -1,6 +1,9 @@
 <% attention_items = @member_dashboard_attention_items || [] %>
 <% training_request_count = (@trainer_training_requests_by_topic || {}).values.sum(&:size) %>
 <% requestable_training = @member_requestable_topics&.any? %>
+<% unread_messages_count = @unread_messages_count.to_i %>
+<% messages_count = Message.visible_to(user).count %>
+<% messages_path_for_action = unread_messages_count.positive? ? messages_path(folder: :unread) : messages_path(folder: :all) %>
 
 <div class="row g-3">
   <div class="col-lg-8">
@@ -55,13 +58,20 @@
           <% end %>
         </div>
         <div class="col-md-6">
-          <%= link_to messages_path, class: "action-card" do %>
-            <div class="action-card-title"><i class="bi bi-chat-dots me-1"></i>View messages</div>
-            <div class="action-card-desc">Read messages from admins or the board</div>
+          <% if messages_count.positive? %>
+            <%= link_to messages_path_for_action, class: "action-card" do %>
+              <div class="action-card-title"><i class="bi bi-chat-dots me-1"></i>View messages</div>
+              <div class="action-card-desc">Read messages from admins or the board</div>
+            <% end %>
+          <% else %>
+            <div class="action-card disabled text-secondary" aria-disabled="true">
+              <div class="action-card-title text-secondary"><i class="bi bi-chat-dots me-1"></i>View messages</div>
+              <div class="action-card-desc">You do not have any messages yet</div>
+            </div>
           <% end %>
         </div>
         <div class="col-md-6">
-          <%= link_to user_path(user, tab: :profile, view_as: params[:view_as]), class: "action-card" do %>
+          <%= link_to profile_setup_path, class: "action-card" do %>
             <div class="action-card-title"><i class="bi bi-person me-1"></i>Update your profile</div>
             <div class="action-card-desc">Add links, interests, and contact details</div>
           <% end %>

--- a/app/views/users/_tab_profile_self.html.erb
+++ b/app/views/users/_tab_profile_self.html.erb
@@ -1,4 +1,3 @@
-<% edit_profile_path = edit_user_path(user) %>
 <% visibility_label = { 'public' => 'Public', 'members' => 'Other members', 'private' => 'Private' }[user.profile_visibility] || user.profile_visibility.humanize %>
 <% user_interests = user.interests.order(:name) %>
 
@@ -14,10 +13,8 @@
           <span class="profile-field-label">Display name</span>
           <% if user.greeting_name.present? %>
             <span class="profile-field-value"><%= user.greeting_name %></span>
-            <%= link_to "Edit", edit_profile_path, class: "profile-field-edit" %>
           <% else %>
             <span class="profile-field-value empty">Choose how members should greet you</span>
-            <%= link_to "Add", edit_profile_path, class: "profile-field-edit" %>
           <% end %>
         </div>
 
@@ -25,10 +22,8 @@
           <span class="profile-field-label">About</span>
           <% if user.bio.present? %>
             <span class="profile-field-value"><%= sanitize(user.bio, tags: %w[p br strong b em i u s ul ol li a h1 h2 h3 h4 h5 h6 span div], attributes: %w[href target style]) %></span>
-            <%= link_to "Edit", edit_profile_path, class: "profile-field-edit" %>
           <% else %>
             <span class="profile-field-value empty">Tell others a bit about yourself</span>
-            <%= link_to "Add", edit_profile_path, class: "profile-field-edit" %>
           <% end %>
         </div>
 
@@ -42,10 +37,8 @@
                 <% end %>
               <% end %>
             </span>
-            <%= link_to "Edit", edit_profile_path, class: "profile-field-edit" %>
           <% else %>
             <span class="profile-field-value empty">Website, social, portfolio...</span>
-            <%= link_to "Add", edit_profile_path, class: "profile-field-edit" %>
           <% end %>
         </div>
 
@@ -57,17 +50,14 @@
                 <span class="cert-pill me-1"><%= interest.name %></span>
               <% end %>
             </span>
-            <%= link_to "Edit", edit_profile_path, class: "profile-field-edit" %>
           <% else %>
             <span class="profile-field-value empty">Help others find common ground</span>
-            <%= link_to "Add", edit_profile_path, class: "profile-field-edit" %>
           <% end %>
         </div>
 
         <div class="profile-field-row">
           <span class="profile-field-label">Profile visibility</span>
           <span class="profile-field-value"><%= visibility_label %></span>
-          <%= link_to "Edit", edit_profile_path, class: "profile-field-edit" %>
         </div>
       </div>
     </div>
@@ -82,10 +72,8 @@
           <span class="profile-field-label">Email</span>
           <% if user.email.present? %>
             <span class="profile-field-value"><%= mail_to user.email %></span>
-            <%= link_to "Edit", edit_profile_path, class: "profile-field-edit" %>
           <% else %>
             <span class="profile-field-value empty">Add an email address</span>
-            <%= link_to "Add", edit_profile_path, class: "profile-field-edit" %>
           <% end %>
         </div>
 
@@ -129,11 +117,6 @@
           <span></span>
         </div>
 
-        <div class="profile-field-row">
-          <span class="profile-field-label">Sessions</span>
-          <span class="profile-field-value">Current session active</span>
-          <span></span>
-        </div>
       </div>
     </div>
   </div>
@@ -141,5 +124,6 @@
   <div class="col-lg-4">
     <%= render 'users/member_membership_card', user: user %>
     <%= render 'users/member_training_card', user: user %>
+    <%= render 'users/member_resources_card', user: user %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -372,8 +372,6 @@
         Messages
         <% if @unread_messages_count.to_i > 0 %>
           <span class="text-warning small ms-1"><%= @unread_messages_count %></span>
-        <% elsif @messages_count.to_i > 0 %>
-          <span class="text-secondary small ms-1"><%= @messages_count %></span>
         <% end %>
       <% end %>
     </li>

--- a/test/controllers/email_templates_controller_test.rb
+++ b/test/controllers/email_templates_controller_test.rb
@@ -63,8 +63,12 @@ class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
     get edit_email_template_path(@template)
 
     assert_response :success
-    assert_select 'input[name=?]', 'email_template[send_immediately]'
-    assert_select 'input[name=?]', 'email_template[block_send_immediately]'
+    assert_select 'input[name=?][data-email-template-rewrite-target=?]',
+                  'email_template[send_immediately]', 'sendImmediately'
+    assert_select 'input[name=?][data-email-template-rewrite-target=?][data-action=?]',
+                  'email_template[block_send_immediately]',
+                  'blockSendImmediately',
+                  'change->email-template-rewrite#syncImmediateSendControls'
   end
 
   test 'index shows immediate send flags' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -59,6 +59,128 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', membership_application_path(app), count: 0
   end
 
+  test 'self messages tab badge only shows unread count' do
+    member = users(:member_with_local_account)
+    Message.where(recipient: member).destroy_all
+    Message.create!(
+      sender: users(:one),
+      recipient: member,
+      subject: 'Read message',
+      body: 'Already read',
+      read_at: Time.current
+    )
+
+    delete logout_path
+    sign_in_as_regular_member
+
+    get user_path(member, tab: :dashboard)
+
+    assert_response :success
+    assert_select 'a.nav-link', text: /Messages\s*1/, count: 0
+  end
+
+  test 'self messages tab badge shows unread count' do
+    member = users(:member_with_local_account)
+    Message.where(recipient: member).destroy_all
+    Message.create!(
+      sender: users(:one),
+      recipient: member,
+      subject: 'Unread message',
+      body: 'Please read',
+      read_at: nil
+    )
+
+    delete logout_path
+    sign_in_as_regular_member
+
+    get user_path(member, tab: :dashboard)
+
+    assert_response :success
+    assert_select 'a.nav-link', text: /Messages\s*1/
+  end
+
+  test 'member dashboard disables view messages action when there are no messages' do
+    member = users(:member_with_local_account)
+    Message.where(recipient: member).destroy_all
+    Message.where(sender: member).destroy_all
+
+    delete logout_path
+    sign_in_as_regular_member
+
+    get user_path(member, tab: :dashboard)
+
+    assert_response :success
+    assert_select 'a[href=?]', messages_path, count: 0
+    assert_select '.action-card.disabled', text: /View messages/
+  end
+
+  test 'member dashboard enables view messages action for sent messages' do
+    member = users(:member_with_local_account)
+    Message.where(recipient: member).destroy_all
+    Message.where(sender: member).destroy_all
+    Message.create!(
+      sender: member,
+      recipient: users(:one),
+      subject: 'Sent message',
+      body: 'Already sent'
+    )
+
+    delete logout_path
+    sign_in_as_regular_member
+
+    get user_path(member, tab: :dashboard)
+
+    assert_response :success
+    assert_select 'a[href=?]', messages_path(folder: :all), text: /View messages/
+    assert_select '.action-card.disabled', count: 0
+  end
+
+  test 'member dashboard profile action opens setup wizard' do
+    member = users(:member_with_local_account)
+
+    delete logout_path
+    sign_in_as_regular_member
+
+    get user_path(member, tab: :dashboard)
+
+    assert_response :success
+    assert_select 'a[href=?]', profile_setup_path, text: /Update your profile/
+  end
+
+  test 'self profile hides inline edit actions and sessions field' do
+    member = users(:member_with_local_account)
+
+    delete logout_path
+    sign_in_as_regular_member
+
+    get user_path(member, tab: :profile)
+
+    assert_response :success
+    assert_select '.profile-field-edit', count: 0
+    assert_no_match(/Sessions/, response.body)
+  end
+
+  test 'self profile shows the same member resources as dashboard' do
+    member = users(:member_with_local_account)
+    topic = training_topics(:laser_cutting)
+    Training.create!(trainee: member, trainer: users(:one), training_topic: topic, trained_at: Time.current)
+
+    delete logout_path
+    sign_in_as_regular_member
+
+    get user_path(member, tab: :dashboard)
+
+    assert_response :success
+    assert_select '.sidebar-card', text: /Resources for you/
+    assert_select 'a.resource-link[href=?]', 'https://example.com/laser-safety', text: /Laser Safety Guide/
+
+    get user_path(member, tab: :profile)
+
+    assert_response :success
+    assert_select '.sidebar-card', text: /Resources for you/
+    assert_select 'a.resource-link[href=?]', 'https://example.com/laser-safety', text: /Laser Safety Guide/
+  end
+
   # ─── Disabled Source Guards ──────────────────────────────────────
 
   test 'sync from authentik redirects with alert when authentik source is disabled' do

--- a/test/services/authentik/group_synchronizer_test.rb
+++ b/test/services/authentik/group_synchronizer_test.rb
@@ -87,5 +87,47 @@ module Authentik
 
       assert_equal ['all-members-authentik-group'], client.requested_group_ids
     end
+
+    test 'deletes local authentik users missing from authentik sync results' do
+      linked_user = users(:one)
+      stale_authentik_user = AuthentikUser.create!(
+        authentik_id: 'stale-authentik-id',
+        username: 'stale',
+        email: 'stale@example.com',
+        full_name: 'Stale Authentik User',
+        user: linked_user
+      )
+      linked_user.update_columns(authentik_id: stale_authentik_user.authentik_id, authentik_dirty: true)
+
+      current_authentik_user = AuthentikUser.create!(
+        authentik_id: 'current-authentik-id',
+        username: 'current',
+        email: 'current@example.com',
+        full_name: 'Current Authentik User'
+      )
+
+      client = Class.new do
+        def group_members(_group_id = nil)
+          [
+            {
+              authentik_id: 'current-authentik-id',
+              email: 'current@example.com',
+              full_name: 'Current Authentik User',
+              username: 'current',
+              active: true,
+              attributes: {}
+            }
+          ]
+        end
+      end.new
+
+      Authentik::GroupSynchronizer.new(client: client).call
+
+      assert_nil AuthentikUser.find_by(authentik_id: stale_authentik_user.authentik_id)
+      assert AuthentikUser.exists?(id: current_authentik_user.id)
+      linked_user.reload
+      assert_nil linked_user.authentik_id
+      assert_not linked_user.authentik_dirty?
+    end
   end
 end


### PR DESCRIPTION
Keep member-facing profile and messaging actions consistent while pruning stale Authentik mirror records during sync.