### PR TITLE
Keep live search results in place

### DIFF
--- a/app/javascript/controllers/live_filter_controller.js
+++ b/app/javascript/controllers/live_filter_controller.js
@@ -84,7 +84,7 @@ export default class extends Controller {
     this.inputTarget.value = ""
     if (this.serverValue) {
       this._updateClearButton("")
-      this._navigateWithSearch("")
+      this._submitServerSearch()
       this.inputTarget.focus()
       return
     }
@@ -113,29 +113,13 @@ export default class extends Controller {
 
   _scheduleServerSearch(term) {
     clearTimeout(this.searchTimeout)
-    this.searchTimeout = setTimeout(() => this._navigateWithSearch(term), this.delayValue)
+    this.searchTimeout = setTimeout(() => this._submitServerSearch(), this.delayValue)
   }
 
-  _navigateWithSearch(term) {
-    const url = new URL(window.location.href)
-    const paramName = this.inputTarget.name || "q"
+  _submitServerSearch() {
+    const form = this.inputTarget.form || this.element.closest("form")
+    if (!form) return
 
-    if (term === "") {
-      url.searchParams.delete(paramName)
-    } else {
-      url.searchParams.set(paramName, term)
-    }
-
-    // A new search should start at the first page of the filtered result set.
-    url.searchParams.delete("page")
-
-    const nextUrl = `${url.pathname}${url.search}${url.hash}`
-    if (nextUrl === `${window.location.pathname}${window.location.search}${window.location.hash}`) return
-
-    if (window.Turbo) {
-      window.Turbo.visit(nextUrl)
-    } else {
-      window.location.assign(nextUrl)
-    }
+    form.requestSubmit()
   }
 }

--- a/app/views/paypal_payments/index.html.erb
+++ b/app/views/paypal_payments/index.html.erb
@@ -95,7 +95,7 @@
 </div>
 
 <%= form_with url: paypal_payments_path, method: :get, local: true,
-              data: { controller: "live-filter", live_filter_server_value: true } do |form| %>
+              data: { controller: "live-filter", live_filter_server_value: true, turbo_frame: "paypal_payments_results" } do |form| %>
   <% request.query_parameters.except('q', 'page').each do |key, value| %>
     <%= hidden_field_tag key, value %>
   <% end %>
@@ -113,9 +113,10 @@
   </div>
 <% end %>
 
-<div class="card shadow-sm border-0">
-  <div class="table-responsive">
-    <table class="table mb-0 align-middle">
+<%= turbo_frame_tag "paypal_payments_results" do %>
+  <div class="card shadow-sm border-0">
+    <div class="table-responsive">
+      <table class="table mb-0 align-middle">
       <thead class="bg-body-tertiary">
         <tr>
           <th scope="col">Transaction</th>
@@ -163,13 +164,14 @@
       </tbody>
     </table>
   </div>
-</div>
-<% if @pagy.pages > 1 %>
-  <div class="mt-3">
-    <%== @pagy.series_nav(:bootstrap) %>
-    <div class="text-center text-muted small mt-2">
-      Showing <%= @pagy.from %>-<%= @pagy.to %> of <%= @pagy.count %>
-    </div>
   </div>
+  <% if @pagy.pages > 1 %>
+    <div class="mt-3">
+      <%== @pagy.series_nav(:bootstrap) %>
+      <div class="text-center text-muted small mt-2">
+        Showing <%= @pagy.from %>-<%= @pagy.to %> of <%= @pagy.count %>
+      </div>
+    </div>
+  <% end %>
 <% end %>
 

--- a/app/views/recharge_payments/index.html.erb
+++ b/app/views/recharge_payments/index.html.erb
@@ -89,7 +89,7 @@
 </div>
 
 <%= form_with url: recharge_payments_path, method: :get, local: true,
-              data: { controller: "live-filter", live_filter_server_value: true } do |form| %>
+              data: { controller: "live-filter", live_filter_server_value: true, turbo_frame: "recharge_payments_results" } do |form| %>
   <% request.query_parameters.except('q', 'page').each do |key, value| %>
     <%= hidden_field_tag key, value %>
   <% end %>
@@ -107,9 +107,10 @@
   </div>
 <% end %>
 
-<div class="card shadow-sm border-0">
-  <div class="table-responsive">
-    <table class="table table-compact mb-0 align-middle">
+<%= turbo_frame_tag "recharge_payments_results" do %>
+  <div class="card shadow-sm border-0">
+    <div class="table-responsive">
+      <table class="table table-compact mb-0 align-middle">
       <thead>
         <tr>
           <th scope="col">Charge</th>
@@ -182,11 +183,12 @@
       </tbody>
     </table>
   </div>
-</div>
-<% if @pagy.pages > 1 %>
-  <div class="mt-3 d-flex justify-content-between align-items-center">
-    <div class="text-secondary text-12">Showing <%= @pagy.from %>-<%= @pagy.to %> of <%= @pagy.count %></div>
-    <%== @pagy.series_nav(:bootstrap) %>
   </div>
+  <% if @pagy.pages > 1 %>
+    <div class="mt-3 d-flex justify-content-between align-items-center">
+      <div class="text-secondary text-12">Showing <%= @pagy.from %>-<%= @pagy.to %> of <%= @pagy.count %></div>
+      <%== @pagy.series_nav(:bootstrap) %>
+    </div>
+  <% end %>
 <% end %>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -186,7 +186,7 @@
 </div>
 
 <%= form_with url: users_path, method: :get, local: true,
-              data: { controller: "live-filter", live_filter_server_value: true } do |form| %>
+              data: { controller: "live-filter", live_filter_server_value: true, turbo_frame: "users_results" } do |form| %>
   <% request.query_parameters.except('q', 'page').each do |key, value| %>
     <%= hidden_field_tag key, value %>
   <% end %>
@@ -204,55 +204,56 @@
   </div>
 <% end %>
 
-<% if @recent_members.any? && !@filter_active && !@include_legacy %>
-  <div class="card shadow-sm border-0 mb-4">
-    <div class="card-header bg-body-tertiary">
-      <h6 class="mb-0"><i class="bi bi-person-plus me-1"></i>New Members This Week (<%= @recent_members.size %>)</h6>
-    </div>
-    <div class="table-responsive">
-        <table class="table table-compact mb-0 align-middle">
-        <thead>
-          <tr>
-            <th scope="col" style="width: 48px;"></th>
-            <th scope="col">Username</th>
-            <th scope="col">Name</th>
-            <th scope="col">Email</th>
-            <th scope="col">Status</th>
-            <th scope="col">Joined</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @recent_members.each do |user| %>
+<%= turbo_frame_tag "users_results" do %>
+  <% if @recent_members.any? && !@filter_active && !@include_legacy %>
+    <div class="card shadow-sm border-0 mb-4">
+      <div class="card-header bg-body-tertiary">
+        <h6 class="mb-0"><i class="bi bi-person-plus me-1"></i>New Members This Week (<%= @recent_members.size %>)</h6>
+      </div>
+      <div class="table-responsive">
+          <table class="table table-compact mb-0 align-middle">
+          <thead>
             <tr>
-              <td>
-                <%= link_to user_path(user, @list_params) do %>
-                  <%= render 'shared/user_avatar', user: user %>
-                <% end %>
-              </td>
-              <td class="small text-monospace text-secondary fw-semibold"><%= link_to user.username, user_path(user, @list_params), class: "text-decoration-none text-secondary" %></td>
-              <td class="fw-semibold"><%= link_to user.display_name, user_path(user, @list_params), class: "text-decoration-none" %></td>
-              <td>
-                <% if user.email.present? %>
-                  <%= mail_to user.email %>
-                <% else %>
-                  <span class="text-muted fst-italic">Not provided</span>
-                <% end %>
-              </td>
-              <td>
-                <span class="badge <%= membership_status_badge_subtle_class(user.membership_status) %>"><%= user.membership_status&.humanize %></span>
-              </td>
-              <td class="text-muted small"><%= time_ago_in_words(user.created_at) %> ago</td>
+              <th scope="col" style="width: 48px;"></th>
+              <th scope="col">Username</th>
+              <th scope="col">Name</th>
+              <th scope="col">Email</th>
+              <th scope="col">Status</th>
+              <th scope="col">Joined</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <% @recent_members.each do |user| %>
+              <tr>
+                <td>
+                  <%= link_to user_path(user, @list_params) do %>
+                    <%= render 'shared/user_avatar', user: user %>
+                  <% end %>
+                </td>
+                <td class="small text-monospace text-secondary fw-semibold"><%= link_to user.username, user_path(user, @list_params), class: "text-decoration-none text-secondary" %></td>
+                <td class="fw-semibold"><%= link_to user.display_name, user_path(user, @list_params), class: "text-decoration-none" %></td>
+                <td>
+                  <% if user.email.present? %>
+                    <%= mail_to user.email %>
+                  <% else %>
+                    <span class="text-muted fst-italic">Not provided</span>
+                  <% end %>
+                </td>
+                <td>
+                  <span class="badge <%= membership_status_badge_subtle_class(user.membership_status) %>"><%= user.membership_status&.humanize %></span>
+                </td>
+                <td class="text-muted small"><%= time_ago_in_words(user.created_at) %> ago</td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
 
-<div class="card shadow-sm border-0">
-  <div class="table-responsive">
-    <table class="table table-compact mb-0 align-middle">
+  <div class="card shadow-sm border-0">
+    <div class="table-responsive">
+      <table class="table table-compact mb-0 align-middle">
       <thead>
         <tr>
           <th scope="col" style="width: 48px;"></th>
@@ -325,13 +326,14 @@
       </tbody>
     </table>
   </div>
-</div>
-<% if @pagy.pages > 1 %>
-  <div class="mt-3">
-    <%== @pagy.series_nav(:bootstrap) %>
-    <div class="text-center text-muted small mt-2">
-      Showing <%= @pagy.from %>-<%= @pagy.to %> of <%= @pagy.count %>
-    </div>
   </div>
+  <% if @pagy.pages > 1 %>
+    <div class="mt-3">
+      <%== @pagy.series_nav(:bootstrap) %>
+      <div class="text-center text-muted small mt-2">
+        Showing <%= @pagy.from %>-<%= @pagy.to %> of <%= @pagy.count %>
+      </div>
+    </div>
+  <% end %>
 <% end %>
 

--- a/test/controllers/paypal_payments_controller_test.rb
+++ b/test/controllers/paypal_payments_controller_test.rb
@@ -39,10 +39,11 @@ class PaypalPaymentsControllerTest < ActionDispatch::IntegrationTest
     get paypal_payments_path(page: 2, q: 'pagination target')
 
     assert_response :success
-    assert_select 'form[action=?][method=get]', paypal_payments_path do
+    assert_select 'form[action=?][method=get][data-turbo-frame=?]', paypal_payments_path, 'paypal_payments_results' do
       assert_select 'input[name=q][value=?]', 'pagination target'
       assert_select 'input[name=page]', count: 0
     end
+    assert_select 'turbo-frame[id=?]', 'paypal_payments_results'
   end
 
   test 'payment search paginates the filtered result set' do

--- a/test/controllers/recharge_payments_controller_test.rb
+++ b/test/controllers/recharge_payments_controller_test.rb
@@ -39,10 +39,12 @@ class RechargePaymentsControllerTest < ActionDispatch::IntegrationTest
     get recharge_payments_path(page: 2, q: 'pagination target')
 
     assert_response :success
-    assert_select 'form[action=?][method=get]', recharge_payments_path do
+    assert_select 'form[action=?][method=get][data-turbo-frame=?]',
+                  recharge_payments_path, 'recharge_payments_results' do
       assert_select 'input[name=q][value=?]', 'pagination target'
       assert_select 'input[name=page]', count: 0
     end
+    assert_select 'turbo-frame[id=?]', 'recharge_payments_results'
   end
 
   test 'payment search paginates the filtered result set' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -151,10 +151,11 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get users_path(page: 2, q: 'pagination target')
 
     assert_response :success
-    assert_select 'form[action=?][method=get]', users_path do
+    assert_select 'form[action=?][method=get][data-turbo-frame=?]', users_path, 'users_results' do
       assert_select 'input[name=q][value=?]', 'pagination target'
       assert_select 'input[name=page]', count: 0
     end
+    assert_select 'turbo-frame[id=?]', 'users_results'
   end
 
   test 'member search paginates the filtered result set' do


### PR DESCRIPTION
Paginated live searches now submit into Turbo Frames so the search field keeps focus while results and pagination refresh.