### PR TITLE
Fix message badges and template redirects

### DIFF
--- a/app/controllers/email_templates_controller.rb
+++ b/app/controllers/email_templates_controller.rb
@@ -25,7 +25,8 @@ class EmailTemplatesController < AdminController
 
   def update
     if @email_template.update(email_template_update_params)
-      redirect_to email_templates_path, notice: "Email template '#{@email_template.name}' was successfully updated."
+      redirect_to email_template_path(@email_template),
+                  notice: "Email template '#{@email_template.name}' was successfully updated."
     else
       render :edit, status: :unprocessable_content
     end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -36,8 +36,6 @@
         <i class="bi bi-chat-dots me-1"></i> Messages
         <% if @home_unread_messages_count.to_i > 0 %>
           <span class="badge bg-danger ms-1"><%= @home_unread_messages_count %></span>
-        <% elsif @home_messages_count.to_i > 0 %>
-          <span class="badge bg-secondary ms-1"><%= @home_messages_count %></span>
         <% end %>
       <% end %>
     </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -286,8 +286,6 @@
         <i class="bi bi-chat-dots me-1"></i> Messages
         <% if @unread_messages_count.to_i > 0 %>
           <span class="badge bg-danger ms-1"><%= @unread_messages_count %></span>
-        <% elsif @messages_count.to_i > 0 %>
-          <span class="badge bg-secondary ms-1"><%= @messages_count %></span>
         <% end %>
       <% end %>
     </li>

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -43,6 +43,25 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Request training/i, response.body)
   end
 
+  test 'home messages nav badge only shows unread count' do
+    admin_user = User.find_by!(email: local_accounts(:active_admin).email)
+    Message.where(recipient: admin_user).destroy_all
+    Message.create!(
+      sender: users(:one),
+      recipient: admin_user,
+      subject: 'Read home message',
+      body: 'Already read',
+      read_at: Time.current
+    )
+
+    get root_path
+
+    assert_response :success
+    assert_select 'a.nav-link[href=?]', messages_path(folder: :unread) do
+      assert_select '.badge', count: 0
+    end
+  end
+
   test 'admin dashboard urgent items come from shared urgent snapshot' do
     snapshot = AdminDashboard::UrgentItems::Snapshot.new(
       [],

--- a/test/controllers/email_templates_controller_test.rb
+++ b/test/controllers/email_templates_controller_test.rb
@@ -94,10 +94,34 @@ class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_redirected_to email_templates_path
+    assert_redirected_to email_template_path(@template)
     @template.reload
     assert @template.block_send_immediately?
     assert_not @template.send_immediately?
+  end
+
+  test 'update redirects back to template view' do
+    patch email_template_path(@template), params: {
+      email_template: {
+        name: @template.name,
+        description: @template.description,
+        subject: 'Updated Subject',
+        body_html: '<p>Replacement HTML</p>',
+        body_text: 'Replacement text',
+        enabled: '1'
+      }
+    }
+
+    assert_redirected_to email_template_path(@template)
+  end
+
+  test 'mark reviewed redirects back to template view' do
+    @template.update!(needs_review: true)
+
+    post mark_reviewed_email_template_path(@template)
+
+    assert_redirected_to email_template_path(@template)
+    assert_not @template.reload.needs_review?
   end
 
   test 'show wraps html body in high contrast preview container' do
@@ -120,7 +144,7 @@ class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_redirected_to email_templates_path
+    assert_redirected_to email_template_path(@template)
     @template.reload
     assert_equal '<h1>Welcome</h1><p>Hello <strong>{{member_name}}</strong><br>Line two</p>', @template.body_html
     assert_equal "Welcome\nHello {{member_name}}\nLine two", @template.body_text
@@ -145,7 +169,7 @@ class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_redirected_to email_templates_path
+    assert_redirected_to email_template_path(@template)
     @template.reload
     assert_equal <<~TEXT.strip, @template.body_text
       Visit the getting started guide and your application.
@@ -169,7 +193,7 @@ class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_redirected_to email_templates_path
+    assert_redirected_to email_template_path(@template)
     @template.reload
     assert_equal '<p>Replacement HTML</p>', @template.body_html
     assert_equal 'Custom plain text', @template.body_text

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -79,6 +79,25 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a.nav-link', text: /Messages\s*1/, count: 0
   end
 
+  test 'admin user messages tab badge only shows unread count' do
+    member = users(:member_with_local_account)
+    Message.where(recipient: member).destroy_all
+    Message.create!(
+      sender: users(:one),
+      recipient: member,
+      subject: 'Read admin-visible message',
+      body: 'Already read',
+      read_at: Time.current
+    )
+
+    get user_path(member, tab: :profile)
+
+    assert_response :success
+    assert_select 'a.nav-link[href=?]', user_path(member, tab: :messages) do
+      assert_select '.badge', count: 0
+    end
+  end
+
   test 'self messages tab badge shows unread count' do
     member = users(:member_with_local_account)
     Message.where(recipient: member).destroy_all


### PR DESCRIPTION
Keep message badges tied to unread messages only and return admins to the template detail after edit/review actions.