### PR TITLE
Add member trainer dashboard action

### DIFF
--- a/app/controllers/training_topic_links_controller.rb
+++ b/app/controllers/training_topic_links_controller.rb
@@ -1,8 +1,8 @@
-# Manages resource links for training topics. Accessible to admins
-# and trainers who have capability for the associated topic.
+# Manages resource links for training topics. Topic setup is admin-only;
+# trainers use the Train a Member workflow without editing topic resources.
 class TrainingTopicLinksController < AuthenticatedController
+  before_action :require_admin!
   before_action :set_training_topic
-  before_action :require_trainer_or_admin_for_topic!
   before_action :set_link, only: %i[update destroy]
 
   def create
@@ -34,13 +34,6 @@ class TrainingTopicLinksController < AuthenticatedController
 
   def set_training_topic
     @training_topic = TrainingTopic.find(params[:training_topic_id])
-  end
-
-  def require_trainer_or_admin_for_topic!
-    return if current_user_admin?
-    return if current_user.training_topics.include?(@training_topic)
-
-    redirect_to root_path, alert: "You don't have permission to manage links for this training topic."
   end
 
   def set_link

--- a/app/controllers/training_topics_controller.rb
+++ b/app/controllers/training_topics_controller.rb
@@ -1,9 +1,8 @@
-# Manages training topics. Admins have full access; trainers can manage
-# topics they are authorized to train (edit links, documents, train members).
+# Manages training topics. Admins have full access; trainers use the
+# Train a Member workflow without editing topic setup.
 class TrainingTopicsController < AuthenticatedController
-  before_action :require_admin!, only: %i[index create destroy revoke_trainer_capability]
+  before_action :require_admin!, only: %i[index create edit update destroy revoke_training revoke_trainer_capability]
   before_action :set_training_topic, only: %i[edit update revoke_training revoke_trainer_capability]
-  before_action :require_trainer_or_admin_for_topic!, only: %i[edit update revoke_training]
 
   def index
     @training_topics = TrainingTopic.order(:name)
@@ -89,13 +88,6 @@ class TrainingTopicsController < AuthenticatedController
     @trainer_users = @training_topic.trainers.order(:full_name, :email)
     @users_for_search = User.ordered_by_display_name
     @topic_documents = @training_topic.documents.ordered
-  end
-
-  def require_trainer_or_admin_for_topic!
-    return if current_user_admin?
-    return if current_user.training_topics.include?(@training_topic)
-
-    redirect_to root_path, alert: "You don't have permission to manage this training topic."
   end
 
   def training_topic_params

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -75,7 +75,11 @@
                     <% @trainable_topics.each do |topic| %>
                       <% is_trained = trained_topic_ids.include?(topic.id) %>
                       <div class="d-inline-flex align-items-center border rounded px-3 py-2 <%= is_trained ? 'bg-success-subtle border-success' : 'bg-body-secondary' %>">
-                        <%= link_to topic.name, edit_training_topic_path(topic), class: "me-2 text-decoration-none" %>
+                        <% if current_user_admin? %>
+                          <%= link_to topic.name, edit_training_topic_path(topic), class: "me-2 text-decoration-none" %>
+                        <% else %>
+                          <span class="me-2"><%= topic.name %></span>
+                        <% end %>
                         <% if is_trained %>
                           <%= button_to remove_training_path(user_id: selected_user.id, topic_id: topic.id), 
                               method: :delete,
@@ -107,7 +111,11 @@
                     </div>
                     <div class="d-flex flex-wrap gap-2">
                       <% TrainingTopic.where(id: non_trainable_trained_ids).order(:name).each do |topic| %>
-                        <%= link_to topic.name, edit_training_topic_path(topic), class: "badge text-bg-primary fs-6 px-3 py-2 text-decoration-none" %>
+                        <% if current_user_admin? %>
+                          <%= link_to topic.name, edit_training_topic_path(topic), class: "badge text-bg-primary fs-6 px-3 py-2 text-decoration-none" %>
+                        <% else %>
+                          <span class="badge text-bg-primary fs-6 px-3 py-2"><%= topic.name %></span>
+                        <% end %>
                       <% end %>
                     </div>
                   <% end %>
@@ -166,7 +174,13 @@
                       <tbody>
                         <% trainings.each do |training| %>
                           <tr>
-                            <td><%= link_to training.training_topic.name, edit_training_topic_path(training.training_topic), class: "badge text-bg-primary text-decoration-none" %></td>
+                            <td>
+                              <% if current_user_admin? %>
+                                <%= link_to training.training_topic.name, edit_training_topic_path(training.training_topic), class: "badge text-bg-primary text-decoration-none" %>
+                              <% else %>
+                                <span class="badge text-bg-primary"><%= training.training_topic.name %></span>
+                              <% end %>
+                            </td>
                             <td>
                               <% if training.trainer %>
                                 <%= link_to training.trainer.display_name, user_path(training.trainer), class: "text-decoration-none" %>
@@ -211,21 +225,23 @@
     </div>
   <% end %>
 
-  <%# Manage Topics section - shows trainable topics with manage links %>
-  <div class="card shadow-sm border-0 mt-4">
-    <div class="card-header bg-body-tertiary">
-      <h5 class="mb-0"><i class="bi bi-gear me-2"></i>Manage Your Training Topics</h5>
-    </div>
-    <div class="card-body">
-      <p class="text-muted small mb-3">Edit links, documents, and trained users for topics you can train.</p>
-      <div class="d-flex flex-wrap gap-2">
-        <% @trainable_topics.each do |topic| %>
-          <%= link_to edit_training_topic_path(topic), class: "btn btn-outline-primary btn-sm" do %>
-            <i class="bi bi-pencil-square me-1"></i><%= topic.name %>
+  <% if current_user_admin? %>
+    <%# Manage Topics section - admin-only topic editing links %>
+    <div class="card shadow-sm border-0 mt-4">
+      <div class="card-header bg-body-tertiary">
+        <h5 class="mb-0"><i class="bi bi-gear me-2"></i>Manage Training Topics</h5>
+      </div>
+      <div class="card-body">
+        <p class="text-muted small mb-3">Edit links, documents, and trained users for training topics.</p>
+        <div class="d-flex flex-wrap gap-2">
+          <% @trainable_topics.each do |topic| %>
+            <%= link_to edit_training_topic_path(topic), class: "btn btn-outline-primary btn-sm" do %>
+              <i class="bi bi-pencil-square me-1"></i><%= topic.name %>
+            <% end %>
           <% end %>
-        <% end %>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
 </div>
 

--- a/app/views/users/_tab_dashboard_self.html.erb
+++ b/app/views/users/_tab_dashboard_self.html.erb
@@ -4,6 +4,7 @@
 <% unread_messages_count = @unread_messages_count.to_i %>
 <% messages_count = Message.visible_to(user).count %>
 <% messages_path_for_action = unread_messages_count.positive? ? messages_path(folder: :unread) : messages_path(folder: :all) %>
+<% can_train_members = user.training_topics.exists? %>
 
 <div class="row g-3">
   <div class="col-lg-8">
@@ -51,6 +52,14 @@
             </div>
           <% end %>
         </div>
+        <% if can_train_members %>
+          <div class="col-md-6">
+            <%= link_to train_member_path, class: "action-card" do %>
+              <div class="action-card-title"><i class="bi bi-person-check me-1"></i>Train a member</div>
+              <div class="action-card-desc">Mark members trained in topics you can teach</div>
+            <% end %>
+          </div>
+        <% end %>
         <div class="col-md-6">
           <%= link_to new_member_parking_permit_path, class: "action-card" do %>
             <div class="action-card-title"><i class="bi bi-p-circle me-1"></i>Project parking permit</div>

--- a/test/controllers/training_topic_links_controller_test.rb
+++ b/test/controllers/training_topic_links_controller_test.rb
@@ -85,14 +85,14 @@ class TrainingTopicLinksControllerTest < ActionDispatch::IntegrationTest
 
   # ─── Trainer access ───────────────────────────────────────────────────
 
-  test 'trainer can create a link for their topic' do
+  test 'trainer cannot create a link for their topic' do
     sign_in_as_trainer
-    assert_difference 'TrainingTopicLink.count', 1 do
+    assert_no_difference 'TrainingTopicLink.count' do
       post training_topic_links_path(@laser_topic), params: {
         training_topic_link: { title: 'Trainer Link', url: 'https://example.com/trainer' }
       }
     end
-    assert_redirected_to edit_training_topic_path(@laser_topic)
+    assert_response :redirect
   end
 
   test 'trainer cannot create a link for a topic they do not train' do
@@ -102,17 +102,18 @@ class TrainingTopicLinksControllerTest < ActionDispatch::IntegrationTest
         training_topic_link: { title: 'Unauthorized', url: 'https://example.com/nope' }
       }
     end
-    assert_redirected_to root_path
+    assert_response :redirect
   end
 
-  test 'trainer can update a link for their topic' do
+  test 'trainer cannot update a link for their topic' do
     sign_in_as_trainer
+    original_title = @laser_link.title
     patch training_topic_link_path(@laser_topic, @laser_link), params: {
       training_topic_link: { title: 'Trainer Updated Title' }
     }
-    assert_redirected_to edit_training_topic_path(@laser_topic)
+    assert_response :redirect
     @laser_link.reload
-    assert_equal 'Trainer Updated Title', @laser_link.title
+    assert_equal original_title, @laser_link.title
   end
 
   test 'trainer cannot update a link for a topic they do not train' do
@@ -121,17 +122,17 @@ class TrainingTopicLinksControllerTest < ActionDispatch::IntegrationTest
     patch training_topic_link_path(@woodworking_topic, @woodworking_link), params: {
       training_topic_link: { title: 'Hacked Title' }
     }
-    assert_redirected_to root_path
+    assert_response :redirect
     @woodworking_link.reload
     assert_equal original_title, @woodworking_link.title
   end
 
-  test 'trainer can delete a link for their topic' do
+  test 'trainer cannot delete a link for their topic' do
     sign_in_as_trainer
-    assert_difference 'TrainingTopicLink.count', -1 do
+    assert_no_difference 'TrainingTopicLink.count' do
       delete training_topic_link_path(@laser_topic, @laser_link)
     end
-    assert_redirected_to edit_training_topic_path(@laser_topic)
+    assert_response :redirect
   end
 
   test 'trainer cannot delete a link for a topic they do not train' do
@@ -139,7 +140,7 @@ class TrainingTopicLinksControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference 'TrainingTopicLink.count' do
       delete training_topic_link_path(@woodworking_topic, @woodworking_link)
     end
-    assert_redirected_to root_path
+    assert_response :redirect
   end
 
   # ─── Regular member access ────────────────────────────────────────────

--- a/test/controllers/training_topics_controller_test.rb
+++ b/test/controllers/training_topics_controller_test.rb
@@ -122,16 +122,16 @@ class TrainingTopicsControllerTest < ActionDispatch::IntegrationTest
 
   # ─── Trainer access ───────────────────────────────────────────────────
 
-  test 'trainer can access edit for their topic' do
+  test 'trainer cannot access edit for their topic' do
     sign_in_as_trainer
     get edit_training_topic_path(@laser_topic)
-    assert_response :success
+    assert_response :redirect
   end
 
   test 'trainer cannot access edit for a topic they do not train' do
     sign_in_as_trainer
     get edit_training_topic_path(@woodworking_topic)
-    assert_redirected_to root_path
+    assert_response :redirect
   end
 
   test 'trainer cannot access training topics index' do
@@ -160,6 +160,7 @@ class TrainingTopicsControllerTest < ActionDispatch::IntegrationTest
       training_topic: { name: 'Hacked Name' }
     }
     @laser_topic.reload
+    assert_response :redirect
     assert_equal original_name, @laser_topic.name
   end
 
@@ -182,15 +183,15 @@ class TrainingTopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
-  test 'trainer can revoke training for their topic' do
+  test 'trainer cannot revoke training through training topic edit workflow' do
     trainer_user = sign_in_as_trainer
     trainee = users(:one)
     Training.create!(trainee: trainee, trainer: trainer_user, training_topic: @laser_topic, trained_at: Time.current)
 
-    assert_difference 'Training.count', -1 do
+    assert_no_difference 'Training.count' do
       delete revoke_training_training_topic_path(@laser_topic, user_id: trainee.id)
     end
-    assert_redirected_to edit_training_topic_path(@laser_topic)
+    assert_response :redirect
   end
 
   test 'trainer cannot revoke training for a topic they do not train' do
@@ -201,58 +202,7 @@ class TrainingTopicsControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference 'Training.count' do
       delete revoke_training_training_topic_path(@woodworking_topic, user_id: trainee.id)
     end
-    assert_redirected_to root_path
-  end
-
-  test 'trainer edit page does not show topic rename form' do
-    sign_in_as_trainer
-    get edit_training_topic_path(@laser_topic)
-    assert_response :success
-    assert_no_match 'Topic Name', response.body
-    assert_no_match 'Update Topic', response.body
-  end
-
-  test 'trainer edit page does not show trainers list' do
-    sign_in_as_trainer
-    get edit_training_topic_path(@laser_topic)
-    assert_response :success
-    assert_no_match 'Users Who Can Train This Topic', response.body
-  end
-
-  test 'trainer edit page does not show delete button' do
-    sign_in_as_trainer
-    get edit_training_topic_path(@laser_topic)
-    assert_response :success
-    assert_no_match 'Danger Zone', response.body
-    assert_no_match 'Delete Topic', response.body
-  end
-
-  test 'trainer edit page shows links section' do
-    sign_in_as_trainer
-    get edit_training_topic_path(@laser_topic)
-    assert_response :success
-    assert_match 'Links', response.body
-  end
-
-  test 'trainer edit page shows documents section' do
-    sign_in_as_trainer
-    get edit_training_topic_path(@laser_topic)
-    assert_response :success
-    assert_match 'Documents', response.body
-  end
-
-  test 'trainer edit page shows trained users section' do
-    sign_in_as_trainer
-    get edit_training_topic_path(@laser_topic)
-    assert_response :success
-    assert_match 'Users Trained in This Topic', response.body
-  end
-
-  test 'trainer edit page shows train a member section' do
-    sign_in_as_trainer
-    get edit_training_topic_path(@laser_topic)
-    assert_response :success
-    assert_match 'Train a Member', response.body
+    assert_response :redirect
   end
 
   # ─── Regular member access ────────────────────────────────────────────

--- a/test/controllers/trainings_controller_test.rb
+++ b/test/controllers/trainings_controller_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+class TrainingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+    @laser_topic = training_topics(:laser_cutting)
+    @woodworking_topic = training_topics(:woodworking)
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+  end
+
+  test 'trainer sees only topics they can train and no topic edit links' do
+    trainer = sign_in_as_trainer
+    TrainerCapability.create!(user: trainer, training_topic: @laser_topic)
+
+    get train_member_path
+
+    assert_response :success
+    assert_match 'Laser Cutting', response.body
+    assert_no_match 'Woodworking', response.body
+    assert_select 'a[href=?]', edit_training_topic_path(@laser_topic), count: 0
+    assert_no_match 'Manage Training Topics', response.body
+  end
+
+  test 'trainer can add training for a topic they can train' do
+    trainer = sign_in_as_trainer
+    trainee = users(:no_email)
+    TrainerCapability.create!(user: trainer, training_topic: @laser_topic)
+
+    assert_difference 'Training.count', 1 do
+      post add_training_path(user_id: trainee.id, topic_id: @laser_topic.id)
+    end
+
+    assert_redirected_to train_member_path(user_id: trainee.id)
+    assert Training.exists?(trainee: trainee, trainer: trainer, training_topic: @laser_topic)
+  end
+
+  test 'trainer cannot add training for a topic they cannot train' do
+    trainer = sign_in_as_trainer
+    trainee = users(:no_email)
+    TrainerCapability.create!(user: trainer, training_topic: @laser_topic)
+
+    assert_no_difference 'Training.count' do
+      post add_training_path(user_id: trainee.id, topic_id: @woodworking_topic.id)
+    end
+
+    assert_redirected_to train_member_path
+  end
+
+  test 'regular member cannot access train a member' do
+    sign_in_as_regular_member
+
+    get train_member_path
+
+    assert_redirected_to root_path
+  end
+
+  private
+
+  def sign_in_as_trainer
+    account = local_accounts(:trainer_account)
+    post local_login_path, params: {
+      session: {
+        email: account.email,
+        password: 'trainerpassword123'
+      }
+    }
+    User.find_by!(authentik_id: "local:#{account.id}")
+  end
+
+  def sign_in_as_regular_member
+    account = local_accounts(:regular_member)
+    post local_login_path, params: {
+      session: {
+        email: account.email,
+        password: 'memberpassword123'
+      }
+    }
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -166,6 +166,29 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', profile_setup_path, text: /Update your profile/
   end
 
+  test 'member dashboard shows train a member action for trainers' do
+    delete logout_path
+    trainer = sign_in_as_trainer
+    TrainerCapability.create!(user: trainer, training_topic: training_topics(:laser_cutting))
+
+    get user_path(trainer, tab: :dashboard)
+
+    assert_response :success
+    assert_select 'a[href=?]', train_member_path, text: /Train a member/
+  end
+
+  test 'member dashboard hides train a member action for non-trainers' do
+    member = users(:member_with_local_account)
+
+    delete logout_path
+    sign_in_as_regular_member
+
+    get user_path(member, tab: :dashboard)
+
+    assert_response :success
+    assert_select 'a[href=?]', train_member_path, count: 0
+  end
+
   test 'self profile hides inline edit actions and sessions field' do
     member = users(:member_with_local_account)
 
@@ -308,5 +331,16 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         password: 'memberpassword123'
       }
     }
+  end
+
+  def sign_in_as_trainer
+    account = local_accounts(:trainer_account)
+    post local_login_path, params: {
+      session: {
+        email: account.email,
+        password: 'trainerpassword123'
+      }
+    }
+    User.find_by!(authentik_id: "local:#{account.id}")
   end
 end


### PR DESCRIPTION
Let trainer-capable members reach the Train a Member workflow while keeping topic setup and resource editing admin-only.