### PR TITLE
fix(rfid): normalize stored codes (whitespace, comma suffix zeros)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -261,7 +261,7 @@ class SessionsController < ApplicationController
   end
 
   def find_user_by_rfid(value)
-    normalized = value.to_s.strip.downcase
+    normalized = RfidNormalizer.call(value)&.downcase
     return if normalized.blank?
 
     # Search in the rfids table

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -291,8 +291,10 @@ class WebhooksController < ApplicationController
       return
     end
 
-    RfidWebhookService.store(rfid_code.to_s.strip, pin_code.to_s.strip, reader.id, reader.name)
-    Rails.logger.info("RFID webhook received from #{reader.name}: RFID=#{rfid_code}, PIN=#{pin_code[0..1]}**")
+    RfidWebhookService.store(rfid_code, pin_code.to_s.strip, reader.id, reader.name)
+    Rails.logger.info(
+      "RFID webhook received from #{reader.name}: RFID=#{RfidNormalizer.call(rfid_code)}, PIN=#{pin_code[0..1]}**"
+    )
 
     head :ok
   end

--- a/app/models/rfid.rb
+++ b/app/models/rfid.rb
@@ -3,6 +3,10 @@ class Rfid < ApplicationRecord
 
   validates :rfid, presence: true, uniqueness: { scope: :user_id }
 
+  def rfid=(value)
+    super(RfidNormalizer.call(value))
+  end
+
   after_create_commit :journal_key_fob_added!
   after_destroy_commit :journal_key_fob_removed!
 

--- a/app/models/sheet_entry.rb
+++ b/app/models/sheet_entry.rb
@@ -24,6 +24,10 @@ class SheetEntry < ApplicationRecord
 
   validates :name, presence: true
 
+  def rfid=(value)
+    super(RfidNormalizer.call(value))
+  end
+
   scope :with_email, -> { where.not(email: nil) }
 
   def access_permissions

--- a/app/services/rfid_normalizer.rb
+++ b/app/services/rfid_normalizer.rb
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 John Romkey
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Canonical form for stored RFID strings: no whitespace; if there is a comma,
+# the suffix is stripped of leading zeros when it is purely decimal digits.
+class RfidNormalizer
+  def self.call(raw)
+    new(raw).call
+  end
+
+  def initialize(raw)
+    @raw = raw
+  end
+
+  def call
+    return nil if @raw.nil?
+
+    s = @raw.to_s.gsub(/\s+/, '')
+    return nil if s.blank?
+
+    comma_at = s.index(',')
+    if comma_at
+      left = s[0...comma_at]
+      right = s[(comma_at + 1)..] || ''
+      "#{left},#{normalize_numeric_suffix(right)}"
+    else
+      s
+    end
+  end
+
+  private
+
+  def normalize_numeric_suffix(segment)
+    return segment if segment.blank?
+    return segment unless segment.match?(/\A0*\d+\z/)
+
+    segment.to_i.to_s
+  end
+end

--- a/app/services/rfid_webhook_service.rb
+++ b/app/services/rfid_webhook_service.rb
@@ -7,6 +7,9 @@ class RfidWebhookService
   EXPIRATION_TIME = 5.minutes
 
   def self.store(rfid_code, pin_code, reader_id = nil, reader_name = nil)
+    rfid_code = RfidNormalizer.call(rfid_code)
+    return nil if rfid_code.blank?
+
     key = redis_key(rfid_code)
     data = {
       rfid: rfid_code,
@@ -93,7 +96,7 @@ class RfidWebhookService
   end
 
   def self.redis_key(rfid_code)
-    "#{REDIS_KEY_PREFIX}#{rfid_code.to_s.downcase.strip}"
+    "#{REDIS_KEY_PREFIX}#{RfidNormalizer.call(rfid_code).to_s.downcase}"
   end
 
   def self.redis

--- a/test/models/rfid_test.rb
+++ b/test/models/rfid_test.rb
@@ -22,6 +22,15 @@ class RfidTest < ActiveSupport::TestCase
     assert_equal 'Front door fob', journal.changes_json.dig('key_fob', 'notes')
   end
 
+  test 'normalizes RFID on assign: strips whitespace and comma spacing regression' do
+    user = users(:one)
+    Current.user = users(:two)
+
+    rfid = Rfid.create!(user: user, rfid: '7001, 00456842')
+    rfid.reload
+    assert_equal '7001,456842', rfid.rfid
+  end
+
   test 'destroying a key fob creates a highlighted journal entry' do
     actor = users(:two)
     rfid = rfids(:one)

--- a/test/services/rfid_normalizer_test.rb
+++ b/test/services/rfid_normalizer_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class RfidNormalizerTest < ActiveSupport::TestCase
+  test 'returns nil for nil or blank' do
+    assert_nil RfidNormalizer.call(nil)
+    assert_nil RfidNormalizer.call('')
+    assert_nil RfidNormalizer.call("  \t\n")
+  end
+
+  test 'removes all whitespace including after comma without adding spaces' do
+    assert_equal '123,4567', RfidNormalizer.call('123,4567')
+    assert_equal '123,4567', RfidNormalizer.call('123, 4567')
+    assert_equal '123,4567', RfidNormalizer.call('123 ,4567')
+    assert_equal '123,4567', RfidNormalizer.call("123 ,\t 4567")
+    assert_equal 'AB,CD', RfidNormalizer.call('AB , CD')
+  end
+
+  test 'strips leading zeros from numeric suffix after comma' do
+    assert_equal '123,456', RfidNormalizer.call('123,0456')
+    assert_equal '123,456', RfidNormalizer.call('123, 00456')
+    assert_equal 'fac,7', RfidNormalizer.call('fac,007')
+    assert_equal '1,0', RfidNormalizer.call('1,000')
+  end
+
+  test 'does not alter non-numeric suffix after comma' do
+    assert_equal '12,0AB', RfidNormalizer.call('12,0AB')
+    assert_equal '12,00AB', RfidNormalizer.call('12,00AB')
+  end
+
+  test 'leaves values without comma unchanged aside from whitespace removal' do
+    assert_equal 'RFID001', RfidNormalizer.call(' RFID001 ')
+    assert_equal 'deadbeef', RfidNormalizer.call('dead beef')
+  end
+
+  test 'idempotent' do
+    once = RfidNormalizer.call('123, 0456')
+    assert_equal once, RfidNormalizer.call(once)
+  end
+end


### PR DESCRIPTION
Introduce RfidNormalizer used when assigning Rfid and SheetEntry rfid, in RFID webhook Redis keys/storage, and when resolving login by fob.

Removes all whitespace (not only strip) so values like fac,card stay compact without injected spaces after commas. Numeric suffix after the first comma drops leading zeros via integer coercion.

Adds unit and model regression tests; full suite passes under Docker.