### PR TITLE
Fix Recharge link member search

### DIFF
--- a/app/controllers/recharge_payments_controller.rb
+++ b/app/controllers/recharge_payments_controller.rb
@@ -39,7 +39,7 @@ class RechargePaymentsController < AdminController
   def show
     @payment = RechargePayment.find(params[:id])
 
-    @customer_id = extract_customer_id(@payment)
+    @customer_id = @payment.customer_id || extract_customer_id(@payment)
     @user_by_customer_id = nil
     @user_by_customer_id = User.where(recharge_customer_id: @customer_id.to_s).first if @customer_id.present?
 

--- a/app/views/access_logs/index.html.erb
+++ b/app/views/access_logs/index.html.erb
@@ -253,7 +253,11 @@
             <label class="form-label">Select Member</label>
             <div id="link_user_list" class="border rounded" style="max-height: 300px; overflow-y: auto;">
               <% @all_users.each do |user| %>
-                <div class="link-user-item p-2 border-bottom" data-user-name="<%= user.display_name.downcase %>" style="cursor: pointer;">
+                <div class="link-user-item p-2 border-bottom"
+                     data-user-name="<%= user.display_name.downcase %>"
+                     data-user-email="<%= user.email.to_s.downcase %>"
+                     data-username="<%= user.username.to_s.downcase %>"
+                     style="cursor: pointer;">
                   <input type="radio" name="user_id" id="link_user_<%= user.id %>" value="<%= user.id %>" class="form-check-input me-2" required>
                   <label for="link_user_<%= user.id %>" class="form-check-label mb-0" style="cursor: pointer;">
                     <%= user.display_name %>
@@ -306,7 +310,10 @@
         const term = this.value.toLowerCase().trim();
         document.querySelectorAll('.link-user-item').forEach(function(item) {
           const name = item.getAttribute('data-user-name') || '';
-          item.style.display = name.includes(term) ? '' : 'none';
+          const email = item.getAttribute('data-user-email') || '';
+          const username = item.getAttribute('data-username') || '';
+          const haystack = name + ' ' + email + ' ' + username;
+          item.style.display = haystack.includes(term) ? '' : 'none';
         });
       });
     }

--- a/app/views/incident_reports/_form.html.erb
+++ b/app/views/incident_reports/_form.html.erb
@@ -62,6 +62,8 @@
         <div class="member-result p-2 border-bottom" 
              data-user-id="<%= user.id %>" 
              data-user-name="<%= user.display_name.downcase %>"
+             data-user-email="<%= user.email.to_s.downcase %>"
+             data-username="<%= user.username.to_s.downcase %>"
              data-user-display="<%= user.display_name %>"
              style="cursor: pointer;">
           <span class="member-name"><%= user.display_name %></span>
@@ -215,11 +217,14 @@
       }
 
       results.forEach(function(result) {
-        const name = result.getAttribute('data-user-name');
+        const name = result.getAttribute('data-user-name') || '';
+        const email = result.getAttribute('data-user-email') || '';
+        const username = result.getAttribute('data-username') || '';
+        const haystack = name + ' ' + email + ' ' + username;
         const userId = result.getAttribute('data-user-id');
         const isSelected = selectedIds.has(userId);
         
-        if (!isSelected && name && name.includes(searchTerm)) {
+        if (!isSelected && haystack.includes(searchTerm)) {
           result.style.display = '';
           visibleCount++;
         } else {

--- a/app/views/parking_notices/_form.html.erb
+++ b/app/views/parking_notices/_form.html.erb
@@ -45,6 +45,7 @@
                    data-user-id="<%= user.id %>"
                    data-user-name="<%= user.display_name.downcase %>"
                    data-user-email="<%= user.email.to_s.downcase %>"
+                   data-username="<%= user.username.to_s.downcase %>"
                    data-user-display="<%= user.display_name %>"
                    role="button" style="cursor: pointer;">
                 <%= user.display_name %>
@@ -200,7 +201,9 @@
           items.forEach(function(item) {
             var name = item.getAttribute('data-user-name') || '';
             var email = item.getAttribute('data-user-email') || '';
-            if (name.includes(term) || email.includes(term)) {
+            var username = item.getAttribute('data-username') || '';
+            var haystack = name + ' ' + email + ' ' + username;
+            if (haystack.includes(term)) {
               item.style.display = '';
               visibleCount++;
             } else {

--- a/app/views/paypal_payments/index.html.erb
+++ b/app/views/paypal_payments/index.html.erb
@@ -140,7 +140,7 @@
                 payment.user&.display_name,
                 payment.user_id.present? ? "linked" : "unlinked"
               ].compact.join(' ').downcase %>">
-            <td class="fw-semibold"><%= link_to payment.paypal_id, paypal_payment_path(payment) %></td>
+            <td class="fw-semibold"><%= link_to payment.paypal_id, paypal_payment_path(payment), data: { turbo_frame: "_top" } %></td>
             <td><span class="badge text-bg-secondary"><%= payment.status.presence || "Unknown" %></span></td>
             <td><%= payment.amount_with_currency || "—" %></td>
             <td>
@@ -153,7 +153,7 @@
             </td>
             <td>
               <% if payment.user.present? %>
-                <%= link_to payment.user.display_name, user_path(payment.user), class: "text-decoration-none" %>
+                <%= link_to payment.user.display_name, user_path(payment.user), class: "text-decoration-none", data: { turbo_frame: "_top" } %>
               <% else %>
                 <span class="text-muted fst-italic">Not linked</span>
               <% end %>

--- a/app/views/recharge_payments/index.html.erb
+++ b/app/views/recharge_payments/index.html.erb
@@ -135,7 +135,7 @@
                 payment.user&.display_name,
                 payment.user_id.present? ? "linked" : "unlinked"
               ].compact.join(' ').downcase %>">
-            <td class="font-monospace text-12"><%= link_to payment.recharge_id, recharge_payment_path(payment), class: "text-info text-decoration-none" %></td>
+            <td class="font-monospace text-12"><%= link_to payment.recharge_id, recharge_payment_path(payment), class: "text-info text-decoration-none", data: { turbo_frame: "_top" } %></td>
             <td>
               <% if payment.status.to_s.casecmp("success").zero? %>
                 <span class="status-dot status-success" title="Success"></span>
@@ -164,9 +164,9 @@
             </td>
             <td>
               <% if payment.user.present? %>
-                <%= link_to payment.user.display_name, user_path(payment.user), class: "text-decoration-none" %>
+                <%= link_to payment.user.display_name, user_path(payment.user), class: "text-decoration-none", data: { turbo_frame: "_top" } %>
               <% elsif unlinked %>
-                <%= link_to "Link member...", recharge_payment_path(payment), class: "btn btn-sm btn-warning" %>
+                <%= link_to "Link member...", recharge_payment_path(payment), class: "btn btn-sm btn-warning", data: { turbo_frame: "_top" } %>
               <% else %>
                 <span class="text-muted fst-italic">Not linked</span>
               <% end %>

--- a/app/views/shared/_link_user_modal.html.erb
+++ b/app/views/shared/_link_user_modal.html.erb
@@ -24,7 +24,12 @@
             <label class="form-label">Select Member</label>
             <div id="user_list" class="border rounded" style="max-height: 300px; overflow-y: auto;">
               <% users.each do |user| %>
-                <div class="user-item p-2 border-bottom" data-user-id="<%= user.id %>" data-user-name="<%= user.display_name.downcase %>" role="button">
+                <div class="user-item p-2 border-bottom"
+                     data-user-id="<%= user.id %>"
+                     data-user-name="<%= user.display_name.downcase %>"
+                     data-user-email="<%= user.email.to_s.downcase %>"
+                     data-username="<%= user.username.to_s.downcase %>"
+                     role="button">
                   <input type="radio" name="user_id" id="user_<%= user.id %>" value="<%= user.id %>" class="form-check-input me-2" required>
                   <label for="user_<%= user.id %>" class="form-check-label mb-0" role="button">
                     <%= user.display_name %>
@@ -67,8 +72,11 @@
       let visibleCount = 0;
 
       userItems.forEach(function(item) {
-        const userName = item.getAttribute('data-user-name');
-        if (userName && userName.includes(searchTerm)) {
+        const name = item.getAttribute('data-user-name') || '';
+        const email = item.getAttribute('data-user-email') || '';
+        const username = item.getAttribute('data-username') || '';
+        const haystack = name + ' ' + email + ' ' + username;
+        if (haystack.includes(searchTerm)) {
           item.style.display = '';
           visibleCount++;
         } else {

--- a/app/views/slack_users/index.html.erb
+++ b/app/views/slack_users/index.html.erb
@@ -300,7 +300,12 @@
             <label class="form-label">Select Member</label>
             <div id="slack_user_list" class="border rounded" style="max-height: 300px; overflow-y: auto;">
               <% @all_users.each do |user| %>
-                <div class="slack-link-user-item p-2 border-bottom" data-user-id="<%= user.id %>" data-user-name="<%= user.display_name.downcase %>" style="cursor: pointer;">
+                <div class="slack-link-user-item p-2 border-bottom"
+                     data-user-id="<%= user.id %>"
+                     data-user-name="<%= user.display_name.downcase %>"
+                     data-user-email="<%= user.email.to_s.downcase %>"
+                     data-username="<%= user.username.to_s.downcase %>"
+                     style="cursor: pointer;">
                   <input type="radio" name="user_id" id="slack_link_user_<%= user.id %>" value="<%= user.id %>" class="form-check-input me-2" required>
                   <label for="slack_link_user_<%= user.id %>" class="form-check-label mb-0" style="cursor: pointer;">
                     <%= user.display_name %>
@@ -406,8 +411,11 @@
           let visible = 0;
 
           items.forEach(function(item) {
-            const name = item.getAttribute('data-user-name');
-            if (name && name.includes(term)) {
+            const name = item.getAttribute('data-user-name') || '';
+            const email = item.getAttribute('data-user-email') || '';
+            const username = item.getAttribute('data-username') || '';
+            const haystack = name + ' ' + email + ' ' + username;
+            if (haystack.includes(term)) {
               item.style.display = '';
               visible++;
             } else {

--- a/test/controllers/access_logs_controller_test.rb
+++ b/test/controllers/access_logs_controller_test.rb
@@ -36,6 +36,15 @@ class AccessLogsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'link modal can search members by email and username' do
+    user = users(:one)
+
+    get access_logs_path
+    assert_response :success
+
+    assert_select '.link-user-item[data-user-email=?][data-username=?]', user.email, user.username
+  end
+
   # ─── Link User ─────────────────────────────────────────────────────
 
   test 'link_user links access log to a member' do

--- a/test/controllers/parking_notices_controller_test.rb
+++ b/test/controllers/parking_notices_controller_test.rb
@@ -46,6 +46,16 @@ class ParkingNoticesControllerTest < ActionDispatch::IntegrationTest
     assert_select 'input[name="parking_notice[notice_type]"][value="permit"]'
   end
 
+  test 'member search includes email and username fields' do
+    user = users(:one)
+
+    get new_parking_notice_url(type: 'permit')
+    assert_response :success
+
+    assert_select '.pn-member-item[data-user-id=?][data-user-email=?][data-username=?]',
+                  user.id.to_s, user.email, user.username
+  end
+
   test 'new renders ticket form' do
     get new_parking_notice_url(type: 'ticket')
     assert_response :success

--- a/test/controllers/paypal_payments_controller_test.rb
+++ b/test/controllers/paypal_payments_controller_test.rb
@@ -46,6 +46,27 @@ class PaypalPaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'turbo-frame[id=?]', 'paypal_payments_results'
   end
 
+  test 'payment result links navigate outside turbo search frame' do
+    payment = PaypalPayment.create!(
+      paypal_id: 'PAY-FRAME-TARGET',
+      status: 'COMPLETED',
+      amount: 42.50,
+      currency: 'USD',
+      transaction_time: Time.current,
+      transaction_type: 'T0001',
+      payer_email: 'paypal-frame@example.com',
+      payer_name: 'PayPal Frame Target',
+      payer_id: 'PAYER-FRAME-TARGET',
+      matches_plan: true
+    )
+
+    get paypal_payments_path(q: 'PAY-FRAME-TARGET')
+    assert_response :success
+
+    assert_select 'turbo-frame#paypal_payments_results a[href=?][data-turbo-frame=?]',
+                  paypal_payment_path(payment), '_top'
+  end
+
   test 'payment search paginates the filtered result set' do
     105.times do |index|
       PaypalPayment.create!(

--- a/test/controllers/recharge_payments_controller_test.rb
+++ b/test/controllers/recharge_payments_controller_test.rb
@@ -47,6 +47,46 @@ class RechargePaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'turbo-frame[id=?]', 'recharge_payments_results'
   end
 
+  test 'payment result links navigate outside turbo search frame' do
+    unlinked = RechargePayment.create!(
+      recharge_id: 'RC-UNLINKED-FRAME',
+      status: 'success',
+      amount: 30.00,
+      currency: 'USD',
+      processed_at: Time.current,
+      customer_id: 'recharge-frame-customer',
+      customer_email: 'frame@example.com',
+      customer_name: 'Frame Customer'
+    )
+
+    get recharge_payments_path(q: 'RC-UNLINKED-FRAME')
+    assert_response :success
+
+    assert_select 'turbo-frame#recharge_payments_results a[href=?][data-turbo-frame=?]',
+                  recharge_payment_path(unlinked), '_top'
+  end
+
+  test 'link member modal can search by member email and username' do
+    unlinked = RechargePayment.create!(
+      recharge_id: 'RC-LINK-MODAL-SEARCH',
+      status: 'success',
+      amount: 30.00,
+      currency: 'USD',
+      processed_at: Time.current,
+      customer_id: 'recharge-link-modal-customer',
+      customer_email: 'modal@example.com',
+      customer_name: 'Modal Customer'
+    )
+    user = users(:one)
+
+    get recharge_payment_path(unlinked)
+    assert_response :success
+
+    assert_select '.user-item[data-user-id=?]', user.id.to_s
+    assert_match %(data-user-email="#{user.email}"), response.body
+    assert_match %(data-username="#{user.username}"), response.body
+  end
+
   test 'payment search paginates the filtered result set' do
     105.times do |index|
       RechargePayment.create!(

--- a/test/controllers/slack_users_controller_test.rb
+++ b/test/controllers/slack_users_controller_test.rb
@@ -25,6 +25,16 @@ class SlackUsersControllerTest < ActionDispatch::IntegrationTest
     assert_match 'Unlinked', response.body
   end
 
+  test 'index link modal can search members by email and username' do
+    user = users(:one)
+
+    get slack_users_path
+    assert_response :success
+
+    assert_select '.slack-link-user-item[data-user-id=?][data-user-email=?][data-username=?]',
+                  user.id.to_s, user.email, user.username
+  end
+
   test 'index status filters split active inactive and deactivated accounts' do
     recent = SlackUser.create!(slack_id: 'URECENTFILTER', display_name: 'Recent Slack', last_active_at: 1.month.ago)
     inactive = SlackUser.create!(slack_id: 'UINACTIVEFILTER', display_name: 'Dormant Slack', last_active_at: nil)


### PR DESCRIPTION
Ensure payment live-search results navigate outside Turbo frames and member link searches include email and username so admins can reliably link unmatched payments.