### PR TITLE
Add detailed AI Ollama health check logging

### DIFF
--- a/app/jobs/ai_ollama_health_check_job.rb
+++ b/app/jobs/ai_ollama_health_check_job.rb
@@ -2,33 +2,75 @@ class AiOllamaHealthCheckJob < ApplicationJob
   queue_as :default
 
   def perform
+    Rails.logger.info(
+      '[AiOllamaHealthCheckJob] Starting Ollama/OpenAI-compatible health checks (GET /v1/models per enabled profile)'
+    )
     AiOllamaProfile.ordered.each do |profile|
       check_profile(profile)
     end
+    Rails.logger.info('[AiOllamaHealthCheckJob] Finished health check pass')
   end
 
   private
 
   def check_profile(profile)
-    unless profile.enabled?
-      profile.update_columns(
-        last_health_check_at: Time.current,
-        updated_at: Time.current
-      )
-      return
-    end
+    ctx = profile_log_context(profile)
+    return mark_disabled(profile, ctx) unless profile.enabled?
 
     url = profile.effective_base_url
-    if url.blank?
-      profile.record_not_configured!
-      return
-    end
+    return mark_not_configured(profile, ctx) if url.blank?
 
-    result = Ollama::HealthCheck.call(base_url: url, api_key: profile.effective_api_key)
+    run_check(profile, ctx, url)
+  end
+
+  def mark_disabled(profile, ctx)
+    Rails.logger.info("[AiOllamaHealthCheckJob] Skip #{ctx}: disabled — last_health_check_at updated only")
+    profile.update_columns(
+      last_health_check_at: Time.current,
+      updated_at: Time.current
+    )
+  end
+
+  def mark_not_configured(profile, ctx)
+    Rails.logger.warn(
+      "[AiOllamaHealthCheckJob] Not configured #{ctx}: " \
+      "effective_base_url is blank after resolution — #{resolution_hint(profile)}"
+    )
+    profile.record_not_configured!
+  end
+
+  def run_check(profile, ctx, url)
+    Rails.logger.info("[AiOllamaHealthCheckJob] Checking #{ctx}")
+    result = Ollama::HealthCheck.call(
+      base_url: url,
+      api_key: profile.effective_api_key,
+      profile_id: profile.id,
+      profile_key: profile.key
+    )
     if result.ok
+      Rails.logger.info("[AiOllamaHealthCheckJob] Healthy #{ctx}")
       profile.record_health_success!
     else
+      Rails.logger.warn("[AiOllamaHealthCheckJob] Unhealthy #{ctx}: #{result.error}")
       profile.record_health_failure!(result.error)
+    end
+  end
+
+  def profile_log_context(profile)
+    "profile_id=#{profile.id} key=#{profile.key} name=#{profile.name.inspect}"
+  end
+
+  # Helps admins see what was configured when the resolved URL is still blank.
+  def resolution_hint(profile)
+    flags = []
+    flags << 'provider_url_override' if profile.provider_url_override.to_s.strip.present?
+    flags << 'ai_provider' if profile.ai_provider_id.present?
+    flags << 'base_url' if profile.base_url.to_s.strip.present?
+    flags << 'non_default_profile' if profile.key != 'default'
+    if flags.any?
+      "configured: #{flags.join(', ')} (effective_base_url still blank — check provider URL / Default profile)"
+    else
+      'configured: (none — set provider, override, or base URL)'
     end
   end
 end

--- a/app/services/ollama/health_check.rb
+++ b/app/services/ollama/health_check.rb
@@ -1,37 +1,144 @@
 module Ollama
   class HealthCheck
     TIMEOUT = 5
+    PATH = '/v1/models'.freeze
+    BODY_LOG_LIMIT = 400
 
-    def self.call(base_url:, api_key: nil)
-      new(base_url: base_url, api_key: api_key).call
+    def self.call(base_url:, api_key: nil, profile_id: nil, profile_key: nil)
+      new(
+        base_url: base_url,
+        api_key: api_key,
+        profile_id: profile_id,
+        profile_key: profile_key
+      ).call
     end
 
-    def initialize(base_url:, api_key: nil)
+    def initialize(base_url:, api_key: nil, profile_id: nil, profile_key: nil)
       @root = base_url.to_s.strip.chomp('/')
       @api_key = api_key.to_s.strip
+      @profile_id = profile_id
+      @profile_key = profile_key
     end
 
     def call
-      return Result.new(ok: false, error: 'Base URL is blank') if @root.blank?
+      return failure_blank_root if @root.blank?
 
-      connection = Faraday.new(url: @root) do |f|
+      log_request_start
+      response = faraday_get_models
+      return failure_http(response) unless response.success?
+
+      success_after_json_parse(response)
+    rescue JSON::ParserError => e
+      failure_json_parse(e, response)
+    rescue Faraday::Error => e
+      failure_faraday(e)
+    rescue StandardError => e
+      log_unexpected_error(e)
+      raise
+    end
+
+    Result = Struct.new(:ok, :error)
+
+    private
+
+    def failure_blank_root
+      log_failure('blank_base_url', 'Base URL is blank after normalization')
+      Result.new(ok: false, error: 'Base URL is blank')
+    end
+
+    def log_request_start
+      Rails.logger.info(
+        "#{log_tag} GET #{PATH} endpoint=#{safe_endpoint_label} " \
+        "auth=#{auth_mode} timeout_open=#{TIMEOUT}s timeout_read=#{TIMEOUT}s"
+      )
+    end
+
+    def faraday_get_models
+      conn = Faraday.new(url: @root) do |f|
         f.options.timeout = TIMEOUT
         f.options.open_timeout = TIMEOUT
         f.adapter Faraday.default_adapter
       end
-      response = connection.get('/v1/models') do |req|
+      conn.get(PATH) do |req|
         req.headers['Authorization'] = "Bearer #{@api_key}" if @api_key.present?
       end
-      return Result.new(ok: false, error: "HTTP #{response.status}") unless response.success?
-
-      JSON.parse(response.body)
-      Result.new(ok: true, error: nil)
-    rescue JSON::ParserError => e
-      Result.new(ok: false, error: "Invalid response: #{e.message}")
-    rescue Faraday::Error => e
-      Result.new(ok: false, error: e.message.presence || e.class.name)
     end
 
-    Result = Struct.new(:ok, :error)
+    def failure_http(response)
+      preview = body_preview_for_log(response.body)
+      ct = response.headers['Content-Type'].to_s.presence || '(none)'
+      msg = "HTTP #{response.status}"
+      log_failure(
+        'http_error',
+        "#{msg} content_type=#{ct} body_preview=#{preview}",
+        http_status: response.status
+      )
+      Result.new(ok: false, error: msg)
+    end
+
+    def success_after_json_parse(response)
+      JSON.parse(response.body)
+      Rails.logger.info("#{log_tag} #{PATH} succeeded (JSON parsed)")
+      Result.new(ok: true, error: nil)
+    end
+
+    def failure_json_parse(error, response)
+      preview = body_preview_for_log(response&.body)
+      log_failure('json_parse_error', "#{error.class}: #{error.message} body_preview=#{preview}")
+      Result.new(ok: false, error: "Invalid response: #{error.message}")
+    end
+
+    def failure_faraday(error)
+      log_failure(
+        'faraday_error',
+        "#{error.class.name}: #{error.message.presence || '(no message)'}",
+        faraday_class: error.class.name
+      )
+      Result.new(ok: false, error: error.message.presence || error.class.name)
+    end
+
+    def log_unexpected_error(error)
+      Rails.logger.error(
+        "#{log_tag} unexpected #{error.class.name}: #{error.message} — " \
+        "#{Array(error.backtrace).first(5).join(' | ')}"
+      )
+    end
+
+    def log_tag
+      parts = ['[Ollama::HealthCheck]']
+      parts << "profile_id=#{@profile_id}" if @profile_id.present?
+      parts << "profile_key=#{@profile_key}" if @profile_key.present?
+      parts.join(' ')
+    end
+
+    def auth_mode
+      @api_key.present? ? 'bearer' : 'none'
+    end
+
+    def safe_endpoint_label
+      uri = URI.parse(@root)
+      return @root.truncate(120) unless uri.host
+
+      hostpart = +uri.host
+      hostpart << ":#{uri.port}" if uri.port && [80, 443].exclude?(uri.port.to_i)
+
+      uri.scheme.present? ? "#{uri.scheme}://#{hostpart}" : hostpart
+    rescue URI::InvalidURIError
+      @root.truncate(120)
+    end
+
+    def body_preview_for_log(body)
+      raw = body.to_s.gsub(/\s+/, ' ').strip
+      return '(empty)' if raw.blank?
+
+      raw.length > BODY_LOG_LIMIT ? "#{raw[0, BODY_LOG_LIMIT]}…(truncated)" : raw
+    end
+
+    def log_failure(reason, detail, **extra)
+      suffix = extra.compact_blank.map { |k, v| "#{k}=#{v}" }.join(' ')
+      msg = "#{log_tag} FAILED reason=#{reason} #{detail}"
+      msg = "#{msg} #{suffix}" if suffix.present?
+      Rails.logger.warn(msg)
+    end
   end
 end


### PR DESCRIPTION
Log each profile decision (disabled, unconfigured, healthy, unhealthy) in AiOllamaHealthCheckJob with id/key/name context. Ollama::HealthCheck logs GET /v1/models attempts with safe endpoint labels, auth mode, timeouts, and structured failure reasons with HTTP details or body previews. Refactor for RuboCop (metrics and style).