### PR TITLE
Add member location map report

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -503,6 +503,10 @@
 
 .text-tertiary { color: var(--bs-secondary-color); opacity: 0.7; }
 
+.report-map {
+  min-height: 520px;
+}
+
 /* === Record training flow === */
 .form-section {
   background: rgba(255,255,255,0.02);

--- a/app/controllers/default_settings_controller.rb
+++ b/app/controllers/default_settings_controller.rb
@@ -40,7 +40,8 @@ class DefaultSettingsController < AdminController
                     active_members_group admins_group
                     unbanned_members_group all_members_group
                     trained_on_prefix can_train_prefix
-                    sync_inactive_members
+                    sync_inactive_members map_center_latitude
+                    map_center_longitude map_radius_miles
                   ])
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -2,6 +2,7 @@ class ReportsController < AdminController
   include Pagy::Method
 
   LIMIT = 20
+  EARTH_RADIUS_MILES = 3958.8
 
   def index
     @membership_status_unknown = User.where(membership_status: 'unknown',
@@ -93,6 +94,7 @@ class ReportsController < AdminController
 
     # Prepare chart data
     prepare_chart_data
+    prepare_map_data
   end
 
   def prepare_lapsed_with_access(limit: nil)
@@ -389,6 +391,65 @@ class ReportsController < AdminController
       @duration_median = 0
       @duration_avg = 0
     end
+  end
+
+  def prepare_map_data
+    settings = DefaultSetting.instance
+    @map_center = {
+      latitude: settings.map_center_latitude.to_f,
+      longitude: settings.map_center_longitude.to_f
+    }
+    @map_radius_miles = settings.map_radius_miles.to_f
+
+    scope = User.where(active: true)
+                .non_service_accounts
+                .non_legacy
+    mapped_users = scope.where.not(mailing_latitude: nil).where.not(mailing_longitude: nil)
+    @map_missing_coordinates_count = scope.where(mailing_latitude: nil).or(scope.where(mailing_longitude: nil)).count
+
+    markers = []
+    out_of_radius = 0
+
+    mapped_users.ordered_by_display_name.find_each do |user|
+      distance = distance_miles_between(
+        @map_center[:latitude],
+        @map_center[:longitude],
+        user.mailing_latitude.to_f,
+        user.mailing_longitude.to_f
+      )
+
+      if distance > @map_radius_miles
+        out_of_radius += 1
+        next
+      end
+
+      markers << {
+        name: user.display_name,
+        latitude: user.mailing_latitude.to_f,
+        longitude: user.mailing_longitude.to_f,
+        distance_miles: distance.round(2),
+        profile_path: user_path(user)
+      }
+    end
+
+    @map_markers = markers
+    @map_mapped_count = markers.size
+    @map_out_of_radius_count = out_of_radius
+  end
+
+  def distance_miles_between(from_latitude, from_longitude, to_latitude, to_longitude)
+    from_lat = degrees_to_radians(from_latitude)
+    to_lat = degrees_to_radians(to_latitude)
+    delta_lat = degrees_to_radians(to_latitude - from_latitude)
+    delta_lng = degrees_to_radians(to_longitude - from_longitude)
+
+    a = (Math.sin(delta_lat / 2)**2) +
+        (Math.cos(from_lat) * Math.cos(to_lat) * (Math.sin(delta_lng / 2)**2))
+    2 * EARTH_RADIUS_MILES * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  end
+
+  def degrees_to_radians(degrees)
+    degrees * Math::PI / 180
   end
 
   def view_all

--- a/app/models/default_setting.rb
+++ b/app/models/default_setting.rb
@@ -10,6 +10,9 @@ class DefaultSetting < ApplicationRecord
   validates :can_train_prefix, presence: true
   validates :sync_inactive_members, inclusion: { in: [true, false] }
   validates :rfid_facility_code, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :map_center_latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
+  validates :map_center_longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+  validates :map_radius_miles, numericality: { greater_than: 0, less_than_or_equal_to: 100 }
 
   def rfid_facility_prefix
     return '' if rfid_facility_code.blank?
@@ -29,6 +32,9 @@ class DefaultSetting < ApplicationRecord
       setting.all_members_group = 'ctrlh:org:members:all'
       setting.trained_on_prefix = 'ctrlh:org:members:trained-on'
       setting.can_train_prefix = 'ctrlh:org:members:can-train'
+      setting.map_center_latitude = 45.581678
+      setting.map_center_longitude = -122.682156
+      setting.map_radius_miles = 4.0
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,12 @@ class User < ApplicationRecord
   PROFILE_VISIBILITY_OPTIONS = %w[public members private].freeze
   validates :profile_visibility, inclusion: { in: PROFILE_VISIBILITY_OPTIONS }
   validates :dues_status, inclusion: { in: %w[current lapsed inactive unknown] }
+  validates :mailing_latitude,
+            numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 },
+            allow_nil: true
+  validates :mailing_longitude,
+            numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 },
+            allow_nil: true
   validate :extra_emails_format
 
   # Submitted with admin user form: if set for guest/sponsored, sets dues_due_at to now + N months

--- a/app/views/default_settings/edit.html.erb
+++ b/app/views/default_settings/edit.html.erb
@@ -75,7 +75,32 @@
         <div class="form-text">Automatically calculated as: <span id="can_train_prefix_preview"></span></div>
       </div>
 
-      <div class="d-flex gap-2">
+      <hr class="my-4">
+
+      <h2 class="h-section-label mb-3">Map report</h2>
+
+      <div class="row g-3">
+        <div class="col-md-4">
+          <%= f.label :map_center_latitude, "Center latitude", class: "form-label" %>
+          <%= f.number_field :map_center_latitude, class: "form-control", step: "0.000001", required: true %>
+          <div class="form-text">Default center for the member map.</div>
+        </div>
+        <div class="col-md-4">
+          <%= f.label :map_center_longitude, "Center longitude", class: "form-label" %>
+          <%= f.number_field :map_center_longitude, class: "form-control", step: "0.000001", required: true %>
+          <div class="form-text">Use a negative value for west longitude.</div>
+        </div>
+        <div class="col-md-4">
+          <%= f.label :map_radius_miles, "Radius", class: "form-label" %>
+          <div class="input-group">
+            <%= f.number_field :map_radius_miles, class: "form-control", step: "0.1", min: "0.1", max: "100", required: true %>
+            <span class="input-group-text">miles</span>
+          </div>
+          <div class="form-text">Default report radius around the center.</div>
+        </div>
+      </div>
+
+      <div class="d-flex gap-2 mt-4">
         <%= f.submit "Update Settings", class: "btn btn-primary" %>
         <%= link_to "Cancel", default_settings_path, class: "btn btn-outline-secondary" %>
       </div>

--- a/app/views/default_settings/show.html.erb
+++ b/app/views/default_settings/show.html.erb
@@ -37,6 +37,17 @@
 
       <dt class="col-sm-4 text-secondary">Can Train Prefix</dt>
       <dd class="col-sm-8"><code><%= @default_setting.can_train_prefix %></code></dd>
+
+      <dt class="col-sm-4 text-secondary">Map Center</dt>
+      <dd class="col-sm-8">
+        <code><%= @default_setting.map_center_latitude %>, <%= @default_setting.map_center_longitude %></code>
+      </dd>
+
+      <dt class="col-sm-4 text-secondary">Map Radius</dt>
+      <dd class="col-sm-8">
+        <%= number_with_precision(@default_setting.map_radius_miles, precision: 1, strip_insignificant_zeros: true) %>
+        miles
+      </dd>
     </dl>
   </div>
 </div>

--- a/app/views/reports/_map.html.erb
+++ b/app/views/reports/_map.html.erb
@@ -1,0 +1,140 @@
+<div class="tab-pane fade <%= 'show active' if active_tab == 'map' %>"
+     id="map-pane"
+     role="tabpanel"
+     aria-labelledby="map-tab">
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-body-tertiary d-flex justify-content-between align-items-center">
+      <div>
+        <h2 class="h5 mb-0">Member Map</h2>
+        <div class="text-13 text-secondary mt-1">
+          <span class="text-body"><%= @map_mapped_count %></span> mapped within
+          <span class="text-body"><%= number_with_precision(@map_radius_miles, precision: 1, strip_insignificant_zeros: true) %></span> miles ·
+          <span class="<%= @map_missing_coordinates_count.positive? ? 'text-warning' : 'text-secondary' %>">
+            <%= @map_missing_coordinates_count %>
+          </span> missing coordinates ·
+          <span class="text-secondary"><%= @map_out_of_radius_count %></span> outside radius
+        </div>
+      </div>
+      <%= link_to "Map settings", edit_default_settings_path, class: "btn btn-outline-secondary btn-sm" %>
+    </div>
+    <div class="card-body">
+      <div class="row g-3">
+        <div class="col-lg-8">
+          <div id="member-map" class="report-map rounded border"
+               data-center="<%= @map_center.to_json %>"
+               data-radius-miles="<%= @map_radius_miles %>"
+               data-markers="<%= @map_markers.to_json %>"></div>
+        </div>
+        <div class="col-lg-4">
+          <div class="status-panel status-clear mb-3">
+            <div class="fw-medium mb-1">Default view</div>
+            <div class="text-13 text-secondary">
+              Centered on the hackerspace at
+              <span class="text-body"><%= @map_center[:latitude] %>, <%= @map_center[:longitude] %></span>
+              and limited to
+              <span class="text-body"><%= number_with_precision(@map_radius_miles, precision: 1, strip_insignificant_zeros: true) %></span>
+              miles.
+            </div>
+          </div>
+
+          <% if @map_markers.any? %>
+            <div class="list-group list-compact">
+              <% @map_markers.first(20).each do |marker| %>
+                <%= link_to marker[:profile_path], class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" do %>
+                  <span>
+                    <div class="item-title"><%= marker[:name] %></div>
+                    <div class="item-desc"><%= marker[:distance_miles] %> miles from the hackerspace</div>
+                  </span>
+                  <span class="chevron"></span>
+                <% end %>
+              <% end %>
+            </div>
+            <% if @map_markers.size > 20 %>
+              <div class="text-12 text-secondary mt-2">
+                Showing the first 20 mapped members in the list. All <%= @map_markers.size %> appear on the map.
+              </div>
+            <% end %>
+          <% else %>
+            <p class="text-secondary mb-0">
+              No active members have coordinates inside the configured radius yet.
+            </p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIINfQ8dbybeAI8or+Hi4m0YbXv3wC6lQ7A="
+      crossorigin="">
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+        crossorigin=""></script>
+<script>
+  (function() {
+    var map;
+
+    function escapeHtml(value) {
+      return String(value).replace(/[&<>"']/g, function(character) {
+        return {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;'
+        }[character];
+      });
+    }
+
+    function initializeMemberMap() {
+      var mapElement = document.getElementById('member-map');
+      if (!mapElement || typeof L === 'undefined' || map) return;
+
+      var center = JSON.parse(mapElement.dataset.center || '{}');
+      var markers = JSON.parse(mapElement.dataset.markers || '[]');
+      var radiusMiles = Number(mapElement.dataset.radiusMiles || 4);
+
+      map = L.map(mapElement).setView([center.latitude, center.longitude], 12);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; OpenStreetMap contributors'
+      }).addTo(map);
+
+      L.circle([center.latitude, center.longitude], {
+        radius: radiusMiles * 1609.344,
+        color: '#0d6efd',
+        weight: 1,
+        fillColor: '#0d6efd',
+        fillOpacity: 0.06
+      }).addTo(map);
+
+      L.marker([center.latitude, center.longitude]).addTo(map).bindPopup('Hackerspace');
+
+      markers.forEach(function(marker) {
+        var popup = '<strong>' + escapeHtml(marker.name) + '</strong><br>' +
+          escapeHtml(marker.distance_miles) + ' miles from the hackerspace<br>' +
+          '<a href="' + encodeURI(marker.profile_path) + '">View profile</a>';
+
+        L.circleMarker([marker.latitude, marker.longitude], {
+          radius: 6,
+          color: '#198754',
+          weight: 1,
+          fillColor: '#198754',
+          fillOpacity: 0.75
+        }).addTo(map).bindPopup(popup);
+      });
+
+      setTimeout(function() { map.invalidateSize(); }, 100);
+    }
+
+    document.addEventListener('DOMContentLoaded', initializeMemberMap);
+    document.addEventListener('turbo:load', initializeMemberMap);
+    document.addEventListener('shown.bs.tab', function(event) {
+      if (event.target && event.target.id === 'map-tab') {
+        initializeMemberMap();
+        if (map) setTimeout(function() { map.invalidateSize(); }, 100);
+      }
+    });
+  })();
+</script>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -7,6 +7,7 @@
   active_tab = params[:tab] || 'charts'
   tabs = [
     { id: 'charts', name: 'Charts', count: nil },
+    { id: 'map', name: 'Map', count: @map_mapped_count },
     { id: 'membership-status-unknown', name: 'Membership', count: @membership_status_unknown_count },
     { id: 'payment-type-unknown', name: 'Payment', count: @payment_type_unknown_count },
     { id: 'dues-status-unknown', name: 'Dues', count: @dues_status_unknown_count },
@@ -141,6 +142,8 @@
       </div>
     </div>
   </div>
+
+  <%= render 'map', active_tab: active_tab %>
 
   <!-- Membership Status Unknown -->
   <div class="tab-pane fade <%= 'show active' if active_tab == 'membership-status-unknown' %>" 

--- a/app/views/settings/_index_refresh.html.erb
+++ b/app/views/settings/_index_refresh.html.erb
@@ -19,6 +19,7 @@
   { category: "Communications", title: "Documents", desc: "Member documents and training-topic attachments.", path: documents_path },
   { category: "Communications", title: "Text fragments", desc: "Reusable HTML snippets for help text and system messages.", path: text_fragments_path },
   { category: "Member profiles", title: "Interests", desc: "Profile interests, suggested terms, renames, and merges.", path: interests_path, attention_count: @settings_attention_counts[:interests] },
+  { category: "Member profiles", title: "Map defaults", desc: "Default center and radius for the member location report.", path: default_settings_path },
   { category: "AI & integrations", title: "AI services", desc: "Service prompts, model selections, and health checks.", path: ai_ollama_profiles_path, attention_count: @settings_attention_counts[:ai_services] },
   { category: "AI & integrations", title: "AI providers", desc: "Reusable AI provider URLs and optional API keys.", path: ai_providers_path },
   { category: "AI & integrations", title: "Member sources", desc: "Authentik, Sheets, and Slack reconciliation sources.", path: member_sources_path },

--- a/db/migrate/20260513173500_add_map_location_fields.rb
+++ b/db/migrate/20260513173500_add_map_location_fields.rb
@@ -1,0 +1,15 @@
+class AddMapLocationFields < ActiveRecord::Migration[8.1]
+  def change
+    change_table :default_settings, bulk: true do |t|
+      t.decimal :map_center_latitude, precision: 10, scale: 6, null: false, default: 45.581678
+      t.decimal :map_center_longitude, precision: 10, scale: 6, null: false, default: -122.682156
+      t.decimal :map_radius_miles, precision: 5, scale: 2, null: false, default: 4.0
+    end
+
+    change_table :users, bulk: true do |t|
+      t.decimal :mailing_latitude, precision: 10, scale: 6
+      t.decimal :mailing_longitude, precision: 10, scale: 6
+      t.datetime :mailing_geocoded_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_13_164500) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_13_173500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -277,6 +277,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_164500) do
     t.string "can_train_prefix", null: false
     t.datetime "created_at", null: false
     t.string "members_prefix", null: false
+    t.decimal "map_center_latitude", precision: 10, scale: 6, default: "45.581678", null: false
+    t.decimal "map_center_longitude", precision: 10, scale: 6, default: "-122.682156", null: false
+    t.decimal "map_radius_miles", precision: 5, scale: 2, default: "4.0", null: false
     t.string "site_prefix", default: "ctrlh", null: false
     t.boolean "sync_inactive_members", default: false, null: false
     t.string "trained_on_prefix", null: false
@@ -997,7 +1000,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_164500) do
     t.boolean "legacy", default: false, null: false
     t.string "login_token"
     t.datetime "login_token_expires_at"
+    t.datetime "mailing_geocoded_at"
     t.text "mailing_address"
+    t.decimal "mailing_latitude", precision: 10, scale: 6
+    t.decimal "mailing_longitude", precision: 10, scale: 6
     t.date "membership_ended_date"
     t.bigint "membership_plan_id"
     t.date "membership_start_date"

--- a/test/controllers/default_settings_controller_test.rb
+++ b/test/controllers/default_settings_controller_test.rb
@@ -28,6 +28,22 @@ class DefaultSettingsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to default_settings_url
   end
 
+  test 'should update map defaults' do
+    patch default_settings_url, params: {
+      default_setting: {
+        map_center_latitude: '45.500000',
+        map_center_longitude: '-122.600000',
+        map_radius_miles: '6.5'
+      }
+    }
+
+    assert_redirected_to default_settings_url
+    setting = DefaultSetting.instance
+    assert_equal 45.5, setting.map_center_latitude.to_f
+    assert_equal(-122.6, setting.map_center_longitude.to_f)
+    assert_equal 6.5, setting.map_radius_miles.to_f
+  end
+
   private
 
   def sign_in_as_admin

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -16,6 +16,20 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should show mapped members on map report' do
+    users(:one).update!(
+      mailing_latitude: 45.582,
+      mailing_longitude: -122.682,
+      mailing_geocoded_at: Time.current
+    )
+
+    get reports_url(tab: 'map')
+
+    assert_response :success
+    assert_select '#member-map[data-markers]'
+    assert_includes response.body, 'Example User One'
+  end
+
   private
 
   def sign_in_as_admin

--- a/test/fixtures/default_settings.yml
+++ b/test/fixtures/default_settings.yml
@@ -11,3 +11,6 @@ one:
   trained_on_prefix: trained-on
   can_train_prefix: can-train
   rfid_facility_code:
+  map_center_latitude: 45.581678
+  map_center_longitude: -122.682156
+  map_radius_miles: 4.0

--- a/test/models/default_setting_test.rb
+++ b/test/models/default_setting_test.rb
@@ -14,4 +14,16 @@ class DefaultSettingTest < ActiveSupport::TestCase
 
     assert_equal '', setting.rfid_facility_prefix
   end
+
+  test 'map defaults require plausible coordinates and radius' do
+    setting = default_settings(:one)
+    setting.map_center_latitude = 91
+    setting.map_center_longitude = -181
+    setting.map_radius_miles = 0
+
+    assert_not setting.valid?
+    assert_includes setting.errors[:map_center_latitude], 'must be less than or equal to 90'
+    assert_includes setting.errors[:map_center_longitude], 'must be greater than or equal to -180'
+    assert_includes setting.errors[:map_radius_miles], 'must be greater than 0'
+  end
 end


### PR DESCRIPTION
Adds a configurable admin map report so staff can see active member locations around the hackerspace when coordinates are available.