### PR TITLE
Keep Leaflet map layout CSS local

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -512,6 +512,132 @@
   width: 100%;
 }
 
+/* Leaflet's layout CSS is required for tile positioning; keep it local so map tiles cannot scatter if CDN CSS is blocked. */
+.leaflet-container {
+  overflow: hidden;
+  position: relative;
+  outline-style: none;
+  font-family: inherit;
+  background: var(--bs-tertiary-bg);
+}
+
+.leaflet-pane,
+.leaflet-tile,
+.leaflet-marker-icon,
+.leaflet-marker-shadow,
+.leaflet-tile-container,
+.leaflet-pane > svg,
+.leaflet-pane > canvas,
+.leaflet-zoom-box,
+.leaflet-image-layer,
+.leaflet-layer {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.leaflet-container,
+.leaflet-tile,
+.leaflet-marker-icon,
+.leaflet-marker-shadow {
+  user-select: none;
+}
+
+.leaflet-tile,
+.leaflet-marker-icon,
+.leaflet-marker-shadow {
+  -webkit-user-drag: none;
+}
+
+.leaflet-tile-container {
+  pointer-events: none;
+}
+
+.leaflet-map-pane {
+  z-index: 400;
+}
+
+.leaflet-tile-pane {
+  z-index: 200;
+}
+
+.leaflet-overlay-pane {
+  z-index: 400;
+}
+
+.leaflet-shadow-pane {
+  z-index: 500;
+}
+
+.leaflet-marker-pane {
+  z-index: 600;
+}
+
+.leaflet-tooltip-pane {
+  z-index: 650;
+}
+
+.leaflet-popup-pane {
+  z-index: 700;
+}
+
+.leaflet-control {
+  position: relative;
+  z-index: 800;
+  pointer-events: auto;
+}
+
+.leaflet-top,
+.leaflet-bottom {
+  position: absolute;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.leaflet-top {
+  top: 0;
+}
+
+.leaflet-bottom {
+  bottom: 0;
+}
+
+.leaflet-left {
+  left: 0;
+}
+
+.leaflet-right {
+  right: 0;
+}
+
+.leaflet-control-container .leaflet-top.leaflet-left {
+  left: 10px;
+  top: 10px;
+}
+
+.leaflet-control-container .leaflet-bottom.leaflet-right {
+  right: 10px;
+  bottom: 10px;
+}
+
+.leaflet-control-zoom a {
+  display: block;
+  width: 28px;
+  height: 28px;
+  line-height: 28px;
+  text-align: center;
+  text-decoration: none;
+  background: var(--bs-body-bg);
+  border-bottom: 1px solid var(--bs-border-color);
+  color: var(--bs-body-color);
+}
+
+.leaflet-control-attribution {
+  padding: 0 5px;
+  font-size: 11px;
+  background: rgba(var(--bs-body-bg-rgb), 0.8);
+}
+
 @media (max-width: 767.98px) {
   .member-map {
     height: 320px;

--- a/app/views/member_maps/show.html.erb
+++ b/app/views/member_maps/show.html.erb
@@ -1,7 +1,4 @@
 <% content_for :head do %>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-        integrity="sha256-p4NxAoJBhIINfQ8dbybeAI8or+Hi4m0YbXv3wC6lQ7A="
-        crossorigin="">
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
           integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
           crossorigin=""></script>

--- a/test/controllers/member_maps_controller_test.rb
+++ b/test/controllers/member_maps_controller_test.rb
@@ -16,7 +16,7 @@ class MemberMapsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '#member-map[data-markers]'
-    assert_select 'link[href*="leaflet.css"]'
+    assert_select 'link[href*="leaflet.css"]', false
   end
 
   test 'should show mapped members' do


### PR DESCRIPTION
Adds the required Leaflet positioning rules to the app stylesheet so map tiles stay contained even when external CSS is unavailable.