### PR TITLE
Fix mail health check for local relays

### DIFF
--- a/app/services/mailer_health_check.rb
+++ b/app/services/mailer_health_check.rb
@@ -2,7 +2,7 @@ require 'net/smtp'
 require 'openssl'
 
 class MailerHealthCheck
-  CACHE_KEY = 'mailer_health_check:v1'.freeze
+  CACHE_KEY = 'mailer_health_check:v2'.freeze
   CACHE_TTL = 5.minutes
   DEFAULT_TIMEOUT = 5
 
@@ -19,11 +19,11 @@ class MailerHealthCheck
   def call
     return unhealthy('Action Mailer is not configured to use SMTP') unless smtp_delivery_method?
     return unhealthy('SMTP is not configured') unless configured?
-    return unhealthy('SMTP username is missing') if settings[:user_name].blank?
-    return unhealthy('SMTP password is missing') if settings[:password].blank?
+    return unhealthy('SMTP password is missing') if settings[:user_name].present? && settings[:password].blank?
+    return unhealthy('SMTP username is missing') if settings[:password].present? && settings[:user_name].blank?
 
     check_smtp!
-    healthy("Connected and authenticated to #{settings[:address]}:#{settings[:port] || 25}")
+    healthy(success_message)
   rescue Net::SMTPAuthenticationError => e
     unhealthy("SMTP authentication failed: #{e.message}")
   rescue Net::OpenTimeout, Net::ReadTimeout
@@ -42,7 +42,7 @@ class MailerHealthCheck
     smtp.start(settings[:domain].presence || 'localhost',
                settings[:user_name],
                settings[:password],
-               authentication) { true }
+               authentication_for_start) { true }
   end
 
   def configure_tls(smtp)
@@ -67,6 +67,22 @@ class MailerHealthCheck
 
   def authentication
     (settings[:authentication].presence || :plain).to_sym
+  end
+
+  def authentication_for_start
+    return nil unless authenticated?
+
+    authentication
+  end
+
+  def authenticated?
+    settings[:user_name].present? && settings[:password].present?
+  end
+
+  def success_message
+    action = authenticated? ? 'Connected and authenticated' : 'Connected'
+
+    "#{action} to #{settings[:address]}:#{settings[:port] || 25}"
   end
 
   def timeout

--- a/test/services/mailer_health_check_test.rb
+++ b/test/services/mailer_health_check_test.rb
@@ -14,6 +14,14 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
       self.class.last = self
     end
 
+    def enable_tls
+      @tls = true
+    end
+
+    def enable_starttls
+      @starttls = true
+    end
+
     def enable_starttls_auto
       @starttls_auto = true
     end
@@ -28,7 +36,7 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
       yield if block_given?
     end
 
-    attr_reader :address, :port, :domain, :username, :password, :authentication, :starttls_auto
+    attr_reader :address, :port, :domain, :username, :password, :authentication, :tls, :starttls, :starttls_auto
   end
 
   setup do
@@ -71,6 +79,43 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
     assert_equal 'secret', FakeSmtp.last.password
     assert_equal :plain, FakeSmtp.last.authentication
     assert_equal true, FakeSmtp.last.starttls_auto
+  end
+
+  test 'healthy for unauthenticated local SMTP relay without TLS' do
+    Rails.configuration.action_mailer.delivery_method = :smtp
+    Rails.configuration.action_mailer.smtp_settings = {
+      address: 'localhost',
+      port: 25,
+      domain: 'members.example.test',
+      authentication: :plain,
+      enable_starttls_auto: false
+    }
+
+    result = MailerHealthCheck.call(force: true)
+
+    assert result.healthy?
+    assert_equal 'Connected to localhost:25', result.message
+    assert_equal 'localhost', FakeSmtp.last.address
+    assert_equal 25, FakeSmtp.last.port
+    assert_nil FakeSmtp.last.username
+    assert_nil FakeSmtp.last.password
+    assert_nil FakeSmtp.last.authentication
+    assert_nil FakeSmtp.last.tls
+    assert_nil FakeSmtp.last.starttls
+    assert_nil FakeSmtp.last.starttls_auto
+  end
+
+  test 'unhealthy when SMTP credentials are partially configured' do
+    Rails.configuration.action_mailer.delivery_method = :smtp
+    Rails.configuration.action_mailer.smtp_settings = {
+      address: 'smtp.example.test',
+      user_name: 'mailer'
+    }
+
+    result = MailerHealthCheck.call(force: true)
+
+    assert_not result.healthy?
+    assert_equal 'SMTP password is missing', result.message
   end
 
   test 'unhealthy when SMTP authentication fails' do


### PR DESCRIPTION
Allow the health check to mirror SMTP delivery for unauthenticated local relays while still reporting partial credential configuration clearly.