### PR TITLE
Disable STARTTLS default for port 25 mail relays

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -38,6 +38,7 @@ SMTP_DOMAIN=example.com
 SMTP_USERNAME=
 SMTP_PASSWORD=
 SMTP_AUTHENTICATION=plain
+# Set false for unauthenticated local port 25 relays.
 SMTP_ENABLE_STARTTLS=true
 
 # --- Omniauth / Authentik ---

--- a/app/services/mailer_health_check.rb
+++ b/app/services/mailer_health_check.rb
@@ -2,7 +2,7 @@ require 'net/smtp'
 require 'openssl'
 
 class MailerHealthCheck
-  CACHE_KEY = 'mailer_health_check:v2'.freeze
+  CACHE_KEY = 'mailer_health_check:v3'.freeze
   CACHE_TTL = 5.minutes
   DEFAULT_TIMEOUT = 5
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,14 +77,17 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.delivery_method = :smtp
 
+  smtp_port = ENV.fetch('SMTP_PORT', 587).to_i
+  smtp_enable_starttls = ENV.fetch('SMTP_ENABLE_STARTTLS') { smtp_port == 587 ? 'true' : 'false' } == 'true'
+
   config.action_mailer.smtp_settings = {
     address: ENV.fetch('SMTP_ADDRESS', 'smtp.example.com'),
-    port: ENV.fetch('SMTP_PORT', 587).to_i,
+    port: smtp_port,
     domain: ENV.fetch('SMTP_DOMAIN', 'example.com'),
     user_name: ENV['SMTP_USERNAME'],
     password: ENV['SMTP_PASSWORD'],
     authentication: ENV.fetch('SMTP_AUTHENTICATION', 'plain').to_sym,
-    enable_starttls_auto: ENV.fetch('SMTP_ENABLE_STARTTLS', 'true') == 'true'
+    enable_starttls_auto: smtp_enable_starttls
   }
 
   # Default URL options for mailer links

--- a/env.example
+++ b/env.example
@@ -72,4 +72,5 @@ SMTP_DOMAIN=example.com
 SMTP_USERNAME=your-smtp-username
 SMTP_PASSWORD=your-smtp-password
 SMTP_AUTHENTICATION=plain
+# Set false for unauthenticated local port 25 relays.
 SMTP_ENABLE_STARTTLS=true


### PR DESCRIPTION
Keep STARTTLS enabled by default for submission ports while avoiding TLS probes against unauthenticated local SMTP relays on port 25.