### PR TITLE
Complete local Leaflet map styles

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -517,8 +517,12 @@
   overflow: hidden;
   position: relative;
   outline-style: none;
+  outline-offset: 1px;
   font-family: inherit;
+  font-size: 12px;
+  line-height: 1.5;
   background: var(--bs-tertiary-bg);
+  -webkit-tap-highlight-color: transparent;
 }
 
 .leaflet-pane,
@@ -540,7 +544,13 @@
 .leaflet-tile,
 .leaflet-marker-icon,
 .leaflet-marker-shadow {
+  -webkit-user-select: none;
+  -moz-user-select: none;
   user-select: none;
+}
+
+.leaflet-tile::selection {
+  background: transparent;
 }
 
 .leaflet-tile,
@@ -549,11 +559,41 @@
   -webkit-user-drag: none;
 }
 
+.leaflet-marker-icon,
+.leaflet-marker-shadow {
+  display: block;
+}
+
+.leaflet-container .leaflet-overlay-pane svg {
+  max-width: none !important;
+  max-height: none !important;
+}
+
+.leaflet-container .leaflet-marker-pane img,
+.leaflet-container .leaflet-shadow-pane img,
+.leaflet-container .leaflet-tile-pane img,
+.leaflet-container img.leaflet-image-layer,
+.leaflet-container .leaflet-tile {
+  max-width: none !important;
+  max-height: none !important;
+  width: auto;
+  padding: 0;
+}
+
 .leaflet-tile-container {
   pointer-events: none;
 }
 
-.leaflet-map-pane {
+.leaflet-tile {
+  filter: inherit;
+  visibility: hidden;
+}
+
+.leaflet-tile-loaded {
+  visibility: inherit;
+}
+
+.leaflet-pane {
   z-index: 400;
 }
 
@@ -581,10 +621,67 @@
   z-index: 700;
 }
 
+.leaflet-map-pane canvas {
+  z-index: 100;
+}
+
+.leaflet-map-pane svg {
+  z-index: 200;
+}
+
+.leaflet-zoom-animated {
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+}
+
+svg.leaflet-zoom-animated {
+  will-change: transform;
+}
+
+.leaflet-zoom-anim .leaflet-zoom-animated {
+  transition: transform 0.25s cubic-bezier(0, 0, 0.25, 1);
+}
+
+.leaflet-zoom-anim .leaflet-tile,
+.leaflet-pan-anim .leaflet-tile {
+  transition: none;
+}
+
+.leaflet-interactive {
+  cursor: pointer;
+}
+
+.leaflet-grab {
+  cursor: grab;
+}
+
+.leaflet-popup-pane,
+.leaflet-control {
+  cursor: auto;
+}
+
+.leaflet-marker-icon,
+.leaflet-marker-shadow,
+.leaflet-image-layer,
+.leaflet-pane > svg path,
+.leaflet-tile-container {
+  pointer-events: none;
+}
+
+.leaflet-marker-icon.leaflet-interactive,
+.leaflet-image-layer.leaflet-interactive,
+.leaflet-pane > svg path.leaflet-interactive,
+svg.leaflet-image-layer.leaflet-interactive path {
+  pointer-events: auto;
+}
+
 .leaflet-control {
   position: relative;
   z-index: 800;
   pointer-events: auto;
+  float: left;
+  clear: both;
 }
 
 .leaflet-top,
@@ -610,21 +707,35 @@
   right: 0;
 }
 
-.leaflet-control-container .leaflet-top.leaflet-left {
-  left: 10px;
-  top: 10px;
+.leaflet-right .leaflet-control {
+  float: right;
 }
 
-.leaflet-control-container .leaflet-bottom.leaflet-right {
-  right: 10px;
-  bottom: 10px;
+.leaflet-top .leaflet-control {
+  margin-top: 10px;
+}
+
+.leaflet-bottom .leaflet-control {
+  margin-bottom: 10px;
+}
+
+.leaflet-left .leaflet-control {
+  margin-left: 10px;
+}
+
+.leaflet-right .leaflet-control {
+  margin-right: 10px;
+}
+
+.leaflet-bar {
+  border-radius: 4px;
 }
 
 .leaflet-control-zoom a {
   display: block;
-  width: 28px;
-  height: 28px;
-  line-height: 28px;
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
   text-align: center;
   text-decoration: none;
   background: var(--bs-body-bg);
@@ -632,10 +743,84 @@
   color: var(--bs-body-color);
 }
 
+.leaflet-control-zoom a:first-child {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.leaflet-control-zoom a:last-child {
+  border-bottom: none;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.leaflet-control-zoom-in,
+.leaflet-control-zoom-out {
+  font: bold 18px "Lucida Console", Monaco, monospace;
+}
+
 .leaflet-control-attribution {
   padding: 0 5px;
   font-size: 11px;
+  line-height: 1.4;
   background: rgba(var(--bs-body-bg-rgb), 0.8);
+}
+
+.leaflet-popup {
+  position: absolute;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.leaflet-popup-content-wrapper {
+  padding: 1px;
+  text-align: left;
+  border-radius: 12px;
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.4);
+}
+
+.leaflet-popup-content {
+  margin: 13px 24px 13px 20px;
+  line-height: 1.3;
+  font-size: 13px;
+  min-height: 1px;
+}
+
+.leaflet-popup-tip-container {
+  width: 40px;
+  height: 20px;
+  position: absolute;
+  left: 50%;
+  margin-top: -1px;
+  margin-left: -20px;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.leaflet-popup-tip {
+  width: 17px;
+  height: 17px;
+  padding: 1px;
+  margin: -10px auto 0;
+  transform: rotate(45deg);
+  background: var(--bs-body-bg);
+  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.4);
+}
+
+.leaflet-container a.leaflet-popup-close-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  border: none;
+  text-align: center;
+  width: 24px;
+  height: 24px;
+  font: 16px/24px Tahoma, Verdana, sans-serif;
+  color: var(--bs-secondary-color);
+  text-decoration: none;
+  background: transparent;
 }
 
 @media (max-width: 767.98px) {

--- a/app/views/member_maps/show.html.erb
+++ b/app/views/member_maps/show.html.erb
@@ -105,7 +105,13 @@
         fillOpacity: 0.06
       }).addTo(map);
 
-      L.marker([center.latitude, center.longitude]).addTo(map).bindPopup('Hackerspace');
+      L.circleMarker([center.latitude, center.longitude], {
+        radius: 7,
+        color: '#0d6efd',
+        weight: 2,
+        fillColor: '#0d6efd',
+        fillOpacity: 0.95
+      }).addTo(map).bindPopup('Hackerspace');
 
       markers.forEach(function(marker) {
         var popup = '<strong>' + escapeHtml(marker.name) + '</strong><br>' +

--- a/test/assets/member_map_leaflet_css_test.rb
+++ b/test/assets/member_map_leaflet_css_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class MemberMapLeafletCssTest < ActiveSupport::TestCase
+  test 'local stylesheet includes required Leaflet tile layout rules' do
+    stylesheet = Rails.root.join('app/assets/stylesheets/application.bootstrap.scss').read
+
+    assert_includes stylesheet, '.leaflet-container .leaflet-tile'
+    assert_includes stylesheet, 'max-width: none !important'
+    assert_includes stylesheet, '.leaflet-tile-loaded'
+    assert_includes stylesheet, 'visibility: inherit'
+    assert_includes stylesheet, '.leaflet-pane'
+    assert_includes stylesheet, 'z-index: 400'
+    assert_includes stylesheet, '.leaflet-zoom-animated'
+    assert_includes stylesheet, 'transform-origin: 0 0'
+  end
+end


### PR DESCRIPTION
Adds the missing Leaflet tile and pane layout rules locally so the admin map renders tiles inside the map container.