### PR TITLE
Adjust member map privacy behavior

### DIFF
--- a/app/controllers/member_maps_controller.rb
+++ b/app/controllers/member_maps_controller.rb
@@ -1,5 +1,6 @@
 class MemberMapsController < AdminController
   EARTH_RADIUS_MILES = 3958.8
+  INITIAL_VIEW_HALF_SPAN_MILES = 2.5
 
   def show
     prepare_map_data
@@ -19,16 +20,15 @@ class MemberMapsController < AdminController
       longitude: settings.map_center_longitude.to_f
     }
     @map_radius_miles = settings.map_radius_miles.to_f
+    @map_initial_bounds = initial_bounds
   end
 
   def apply_member_marker_data
     scope = map_member_scope
     @map_missing_coordinates_count = scope.where(mailing_latitude: nil).or(scope.where(mailing_longitude: nil)).count
 
-    marker_data = build_marker_data(scope)
-    @map_markers = marker_data.fetch(:markers)
+    @map_markers = build_markers(scope)
     @map_mapped_count = @map_markers.size
-    @map_out_of_radius_count = marker_data.fetch(:out_of_radius_count)
   end
 
   def map_member_scope
@@ -37,20 +37,11 @@ class MemberMapsController < AdminController
         .non_legacy
   end
 
-  def build_marker_data(scope)
-    markers = []
-    out_of_radius_count = 0
-
-    users_with_coordinates(scope).find_each do |user|
-      distance = distance_from_map_center(user)
-      if distance > @map_radius_miles
-        out_of_radius_count += 1
-      else
-        markers << marker_for(user, distance)
-      end
+  def build_markers(scope)
+    markers = users_with_coordinates(scope).map do |user|
+      marker_for(user, distance_from_map_center(user))
     end
-
-    { markers: markers, out_of_radius_count: out_of_radius_count }
+    markers.sort_by { |marker| marker.fetch(:distance_miles) }
   end
 
   def users_with_coordinates(scope)
@@ -76,6 +67,20 @@ class MemberMapsController < AdminController
       distance_miles: distance.round(2),
       profile_path: user_path(user)
     }
+  end
+
+  def initial_bounds
+    latitude_delta = INITIAL_VIEW_HALF_SPAN_MILES / miles_per_degree_latitude
+    {
+      south: @map_center[:latitude] - latitude_delta,
+      north: @map_center[:latitude] + latitude_delta,
+      west: @map_center[:longitude],
+      east: @map_center[:longitude]
+    }
+  end
+
+  def miles_per_degree_latitude
+    (Math::PI / 180) * EARTH_RADIUS_MILES
   end
 
   def distance_miles_between(from_latitude, from_longitude, to_latitude, to_longitude)

--- a/app/views/member_maps/show.html.erb
+++ b/app/views/member_maps/show.html.erb
@@ -8,12 +8,10 @@
   <div>
     <h1 class="h-page-title mb-0">Member Map</h1>
     <div class="text-13 text-secondary mt-1">
-      <span class="text-body"><%= @map_mapped_count %></span> mapped within
-      <span class="text-body"><%= number_with_precision(@map_radius_miles, precision: 1, strip_insignificant_zeros: true) %></span> miles ·
+      <span class="text-body"><%= @map_mapped_count %></span> mapped ·
       <span class="<%= @map_missing_coordinates_count.positive? ? 'text-warning' : 'text-secondary' %>">
         <%= @map_missing_coordinates_count %>
-      </span> missing coordinates ·
-      <span class="text-secondary"><%= @map_out_of_radius_count %></span> outside radius
+      </span> missing coordinates
     </div>
   </div>
   <%= link_to "Map settings", edit_default_settings_path, class: "btn btn-outline-secondary btn-sm" %>
@@ -26,6 +24,7 @@
         <div id="member-map" class="member-map rounded border"
              data-center="<%= @map_center.to_json %>"
              data-radius-miles="<%= @map_radius_miles %>"
+             data-initial-bounds="<%= @map_initial_bounds.to_json %>"
              data-markers="<%= @map_markers.to_json %>"></div>
       </div>
       <div class="col-lg-4">
@@ -34,32 +33,28 @@
           <div class="text-13 text-secondary">
             Centered on the hackerspace at
             <span class="text-body"><%= @map_center[:latitude] %>, <%= @map_center[:longitude] %></span>
-            and limited to
+            with a
             <span class="text-body"><%= number_with_precision(@map_radius_miles, precision: 1, strip_insignificant_zeros: true) %></span>
-            miles.
+            mile reference circle.
           </div>
         </div>
 
         <% if @map_markers.any? %>
           <div class="list-group list-compact">
-            <% @map_markers.first(20).each do |marker| %>
-              <%= link_to marker[:profile_path], class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" do %>
+            <% @map_markers.each do |marker| %>
+              <div class="list-group-item d-flex justify-content-between align-items-start">
                 <span>
-                  <div class="item-title"><%= marker[:name] %></div>
+                  <div class="item-title">
+                    <%= link_to marker[:name], marker[:profile_path], class: "link-body-emphasis" %>
+                  </div>
                   <div class="item-desc"><%= marker[:distance_miles] %> miles from the hackerspace</div>
                 </span>
-                <span class="chevron"></span>
-              <% end %>
+              </div>
             <% end %>
           </div>
-          <% if @map_markers.size > 20 %>
-            <div class="text-12 text-secondary mt-2">
-              Showing the first 20 mapped members in the list. All <%= @map_markers.size %> appear on the map.
-            </div>
-          <% end %>
         <% else %>
           <p class="text-secondary mb-0">
-            No active members have coordinates inside the configured radius yet.
+            No active members have coordinates yet.
           </p>
         <% end %>
       </div>
@@ -71,31 +66,32 @@
   (function() {
     var map;
 
-    function escapeHtml(value) {
-      return String(value).replace(/[&<>"']/g, function(character) {
-        return {
-          '&': '&amp;',
-          '<': '&lt;',
-          '>': '&gt;',
-          '"': '&quot;',
-          "'": '&#39;'
-        }[character];
-      });
-    }
-
     function initializeMemberMap() {
       var mapElement = document.getElementById('member-map');
       if (!mapElement || typeof L === 'undefined' || map) return;
 
       var center = JSON.parse(mapElement.dataset.center || '{}');
       var markers = JSON.parse(mapElement.dataset.markers || '[]');
+      var initialBounds = JSON.parse(mapElement.dataset.initialBounds || '{}');
       var radiusMiles = Number(mapElement.dataset.radiusMiles || 4);
 
-      map = L.map(mapElement).setView([center.latitude, center.longitude], 12);
+      map = L.map(mapElement);
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
         attribution: '&copy; OpenStreetMap contributors'
       }).addTo(map);
+
+      if (initialBounds.south !== undefined && initialBounds.north !== undefined) {
+        map.fitBounds(
+          [
+            [initialBounds.south, initialBounds.west],
+            [initialBounds.north, initialBounds.east]
+          ],
+          { padding: [10, 10] }
+        );
+      } else {
+        map.setView([center.latitude, center.longitude], 12);
+      }
 
       L.circle([center.latitude, center.longitude], {
         radius: radiusMiles * 1609.344,
@@ -114,17 +110,13 @@
       }).addTo(map).bindPopup('Hackerspace');
 
       markers.forEach(function(marker) {
-        var popup = '<strong>' + escapeHtml(marker.name) + '</strong><br>' +
-          escapeHtml(marker.distance_miles) + ' miles from the hackerspace<br>' +
-          '<a href="' + encodeURI(marker.profile_path) + '">View profile</a>';
-
         L.circleMarker([marker.latitude, marker.longitude], {
           radius: 6,
           color: '#198754',
           weight: 1,
           fillColor: '#198754',
           fillOpacity: 0.75
-        }).addTo(map).bindPopup(popup);
+        }).addTo(map);
       });
 
       setTimeout(function() { map.invalidateSize(); }, 100);

--- a/test/controllers/member_maps_controller_test.rb
+++ b/test/controllers/member_maps_controller_test.rb
@@ -33,6 +33,51 @@ class MemberMapsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, 'Example User One'
   end
 
+  test 'shows all mapped members ordered by distance' do
+    near_member = users(:one)
+    far_member = users(:two)
+    near_member.update_columns(
+      active: true,
+      mailing_latitude: 45.582,
+      mailing_longitude: -122.682,
+      mailing_geocoded_at: Time.current
+    )
+    far_member.update_columns(
+      active: true,
+      mailing_latitude: 46.2,
+      mailing_longitude: -122.682,
+      mailing_geocoded_at: Time.current
+    )
+
+    get member_map_url
+
+    assert_response :success
+    markers = JSON.parse(css_select('#member-map').first['data-markers'])
+    marker_names = markers.map { |marker| marker.fetch('name') }
+    assert_includes marker_names, near_member.display_name
+    assert_includes marker_names, far_member.display_name
+    assert_operator marker_names.index(near_member.display_name), :<, marker_names.index(far_member.display_name)
+
+    near_position = response.body.index(near_member.display_name)
+    far_position = response.body.index(far_member.display_name)
+    assert_operator near_position, :<, far_position
+  end
+
+  test 'member list uses name links without row chevrons' do
+    users(:one).update_columns(
+      active: true,
+      mailing_latitude: 45.582,
+      mailing_longitude: -122.682,
+      mailing_geocoded_at: Time.current
+    )
+
+    get member_map_url
+
+    assert_response :success
+    assert_select '.list-group-item .item-title a', text: 'Example User One'
+    assert_select '.list-group-item .chevron', false
+  end
+
   private
 
   def sign_in_as_admin


### PR DESCRIPTION
Shows all mapped members without labeling map dots while keeping the side list distance-ordered with explicit profile links.