### PR TITLE
Fix Authentik application group membership propagation

### DIFF
--- a/app/controllers/training_topics_controller.rb
+++ b/app/controllers/training_topics_controller.rb
@@ -39,7 +39,7 @@ class TrainingTopicsController < AuthenticatedController
     user = User.find(params[:user_id])
 
     # Delete all trainings for this user and topic
-    deleted_count = @training_topic.trainings.where(trainee: user).delete_all
+    deleted_count = @training_topic.trainings.where(trainee: user).destroy_all.count
 
     if deleted_count.positive?
       redirect_to edit_training_topic_path(@training_topic), notice: "Training revoked for #{user.display_name}."

--- a/app/jobs/authentik/application_group_membership_sync_job.rb
+++ b/app/jobs/authentik/application_group_membership_sync_job.rb
@@ -10,7 +10,7 @@ module Authentik
         return
       end
 
-      groups = ApplicationGroup.with_authentik_group_id.with_member_sources(member_sources)
+      groups = groups_for_member_sources(member_sources)
       return if groups.empty?
 
       Rails.logger.info(
@@ -18,7 +18,7 @@ module Authentik
         "for sources: #{member_sources.join(', ')}"
       )
 
-      groups.find_each do |group|
+      groups.each do |group|
         sync = Authentik::GroupSync.new(group)
         result = sync.sync_members!
         Rails.logger.info("[ApplicationGroupMembershipSyncJob] Synced #{group.name}: #{result[:status]}")
@@ -31,6 +31,26 @@ module Authentik
 
     def api_configured?
       AuthentikConfig.settings.api_token.present? && AuthentikConfig.settings.api_base_url.present?
+    end
+
+    def groups_for_member_sources(member_sources)
+      source_groups = ApplicationGroup.with_member_sources(Array(member_sources).compact).to_a
+      groups_with_sync_dependents(source_groups).select { |group| group.authentik_group_id.present? }
+    end
+
+    def groups_with_sync_dependents(source_groups)
+      groups_by_id = source_groups.index_by(&:id)
+      frontier_ids = groups_by_id.keys
+
+      until frontier_ids.empty?
+        dependent_groups = ApplicationGroup.where(member_source: 'sync_group', sync_with_group_id: frontier_ids).to_a
+        new_groups = dependent_groups.reject { |group| groups_by_id.key?(group.id) }
+
+        new_groups.each { |group| groups_by_id[group.id] = group }
+        frontier_ids = new_groups.map(&:id)
+      end
+
+      groups_by_id.values
     end
   end
 end

--- a/app/models/application_group.rb
+++ b/app/models/application_group.rb
@@ -108,7 +108,6 @@ class ApplicationGroup < ApplicationRecord
 
   def queue_authentik_membership_sync(_user)
     return if Current.skip_authentik_sync
-    return if authentik_group_id.blank?
 
     Authentik::ApplicationGroupMembershipSyncJob.perform_later([member_source])
   end

--- a/app/models/trainer_capability.rb
+++ b/app/models/trainer_capability.rb
@@ -4,8 +4,8 @@ class TrainerCapability < ApplicationRecord
 
   validates :user_id, uniqueness: { scope: :training_topic_id }
 
-  after_create_commit :sync_can_train_group
-  after_destroy_commit :sync_can_train_group
+  after_create :sync_can_train_group
+  after_destroy :sync_can_train_group
 
   private
 

--- a/app/models/training.rb
+++ b/app/models/training.rb
@@ -7,8 +7,8 @@ class Training < ApplicationRecord
 
   scope :recent, -> { order(trained_at: :desc) }
 
-  after_create_commit :sync_trained_in_group
-  after_destroy_commit :sync_trained_in_group
+  after_create :sync_trained_in_group
+  after_destroy :sync_trained_in_group
 
   private
 

--- a/test/controllers/training_topics_controller_test.rb
+++ b/test/controllers/training_topics_controller_test.rb
@@ -109,6 +109,16 @@ class TrainingTopicsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_training_topic_path(@laser_topic)
   end
 
+  test 'admin training revocation queues trained-in Authentik group sync' do
+    sign_in_as_admin
+    user = users(:one)
+    Training.create!(trainee: user, training_topic: @laser_topic, trained_at: Time.current)
+
+    assert_enqueued_with(job: Authentik::ApplicationGroupMembershipSyncJob, args: [%w[trained_in]]) do
+      delete revoke_training_training_topic_path(@laser_topic, user_id: user.id)
+    end
+  end
+
   test 'admin can revoke trainer capability' do
     sign_in_as_admin
     user = users(:one)

--- a/test/jobs/authentik_application_group_membership_sync_job_test.rb
+++ b/test/jobs/authentik_application_group_membership_sync_job_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class AuthentikApplicationGroupMembershipSyncJobTest < ActiveJob::TestCase
+  setup do
+    @settings = AuthentikConfig.settings
+    @original_api_token = @settings.api_token
+    @original_api_base_url = @settings.api_base_url
+    @settings.api_token = 'test-token'
+    @settings.api_base_url = 'https://authentik.example.test'
+  end
+
+  teardown do
+    @settings.api_token = @original_api_token
+    @settings.api_base_url = @original_api_base_url
+  end
+
+  test 'syncs Authentik groups that depend on changed source groups' do
+    source_group = application_groups(:sample_group)
+    source_group.update!(authentik_group_id: nil)
+
+    dependent_group = ApplicationGroup.create!(
+      application: applications(:sample_app),
+      name: 'Dependent Sync Group',
+      authentik_name: 'sample:dependent-sync-group',
+      authentik_group_id: 'dependent-authentik-group',
+      member_source: 'sync_group',
+      sync_with_group: source_group
+    )
+
+    nested_dependent_group = ApplicationGroup.create!(
+      application: applications(:sample_app),
+      name: 'Nested Dependent Sync Group',
+      authentik_name: 'sample:nested-dependent-sync-group',
+      authentik_group_id: 'nested-dependent-authentik-group',
+      member_source: 'sync_group',
+      sync_with_group: dependent_group
+    )
+
+    fake_client = Class.new do
+      class << self
+        attr_accessor :requested_group_ids
+      end
+      self.requested_group_ids = []
+
+      def get_group(group_id)
+        self.class.requested_group_ids << group_id
+        { 'users' => [] }
+      end
+
+      def set_group_users(_group_id, _user_ids); end
+    end
+
+    original_client = Authentik.send(:remove_const, :Client)
+    Authentik.const_set(:Client, fake_client)
+    begin
+      Authentik::ApplicationGroupMembershipSyncJob.perform_now(%w[manual])
+    ensure
+      Authentik.send(:remove_const, :Client)
+      Authentik.const_set(:Client, original_client)
+    end
+
+    assert_equal [dependent_group.authentik_group_id, nested_dependent_group.authentik_group_id],
+                 fake_client.requested_group_ids
+  end
+end

--- a/test/jobs/authentik_auto_sync_test.rb
+++ b/test/jobs/authentik_auto_sync_test.rb
@@ -28,6 +28,56 @@ class AuthentikAutoSyncTest < ActiveJob::TestCase
     end
   end
 
+  test 'source application group membership change queues sync for dependent groups' do
+    group = application_groups(:sample_group)
+    group.update_columns(authentik_group_id: nil)
+    ApplicationGroup.create!(
+      application: group.application,
+      name: 'Dependent Sync Group',
+      authentik_name: 'sample:dependent-sync-group',
+      authentik_group_id: 'dependent-authentik-group',
+      member_source: 'sync_group',
+      sync_with_group: group
+    )
+    user = users(:two)
+
+    assert_enqueued_with(job: Authentik::ApplicationGroupMembershipSyncJob) do
+      group.users << user unless group.users.include?(user)
+    end
+  end
+
+  test 'training changes queue trained-in application group membership sync' do
+    training = nil
+
+    assert_enqueued_with(job: Authentik::ApplicationGroupMembershipSyncJob, args: [%w[trained_in]]) do
+      training = Training.create!(
+        trainee: users(:one),
+        trainer: users(:two),
+        training_topic: training_topics(:laser_cutting),
+        trained_at: Time.current
+      )
+    end
+
+    assert_enqueued_with(job: Authentik::ApplicationGroupMembershipSyncJob, args: [%w[trained_in]]) do
+      training.destroy!
+    end
+  end
+
+  test 'trainer capability changes queue can-train application group membership sync' do
+    capability = nil
+
+    assert_enqueued_with(job: Authentik::ApplicationGroupMembershipSyncJob, args: [%w[can_train]]) do
+      capability = TrainerCapability.create!(
+        user: users(:one),
+        training_topic: training_topics(:laser_cutting)
+      )
+    end
+
+    assert_enqueued_with(job: Authentik::ApplicationGroupMembershipSyncJob, args: [%w[can_train]]) do
+      capability.destroy!
+    end
+  end
+
   test 'provisioning a user queues application group membership sync after authentik id is assigned' do
     user = users(:two)
     user.update_columns(authentik_id: nil, username: 'provision-membership-sync')


### PR DESCRIPTION
Ensure membership sync jobs include groups that depend on changed groups, and make training permission changes reliably queue Authentik membership updates.