### PR TITLE
Fix admin onboarding and payment display issues

### DIFF
--- a/app/controllers/cash_payments_controller.rb
+++ b/app/controllers/cash_payments_controller.rb
@@ -74,11 +74,13 @@ class CashPaymentsController < AdminController
   def update_user_dues_status(cash_payment)
     user = cash_payment.user
     old_dues_status = user.dues_status
+    current_dues_due_at = user.dues_due_at
 
     updates = user.apply_payment_updates(
       { time: cash_payment.paid_on.beginning_of_day, amount: cash_payment.amount },
       { payment_type: 'cash', last_payment_date: cash_payment.paid_on }
     )
+    keep_later_dues_due_at!(updates, current_dues_due_at)
 
     user.update!(updates) if updates.present?
 
@@ -92,5 +94,20 @@ class CashPaymentsController < AdminController
         'note' => "Cash payment of $#{format('%.2f', cash_payment.amount)} recorded"
       }
     )
+  end
+
+  def keep_later_dues_due_at!(updates, current_dues_due_at)
+    return unless updates.key?(:dues_due_at)
+
+    new_dues_due_at = updates[:dues_due_at]
+    if new_dues_due_at.blank?
+      updates.delete(:dues_due_at)
+      return
+    end
+
+    return if current_dues_due_at.blank?
+    return if new_dues_due_at > current_dues_due_at
+
+    updates.delete(:dues_due_at)
   end
 end

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -13,7 +13,7 @@ class OnboardingController < AdminController
     @user.dues_status = 'unknown'
     @user.active = false
 
-    if @user.save
+    if onboarding_email_present? && @user.save
       redirect_to onboard_payment_path(@user), status: :see_other
     else
       render :member_info, status: :unprocessable_content
@@ -188,5 +188,12 @@ class OnboardingController < AdminController
 
   def member_params
     params.expect(user: %i[full_name email username])
+  end
+
+  def onboarding_email_present?
+    return true if @user.email.present?
+
+    @user.errors.add(:email, :blank)
+    false
   end
 end

--- a/app/helpers/payments_helper.rb
+++ b/app/helpers/payments_helper.rb
@@ -70,6 +70,19 @@ module PaymentsHelper
     end
   end
 
+  def member_payment_event_details(event)
+    case event.source
+    when 'paypal'
+      'PayPal payment'
+    when 'recharge'
+      'Recharge payment'
+    when 'kofi'
+      'Ko-Fi Tip'
+    else
+      event.details || event.identifier
+    end
+  end
+
   def payment_type_badge_class(payment_type)
     case payment_type.to_s.downcase
     when 'donation'

--- a/app/views/member_maps/show.html.erb
+++ b/app/views/member_maps/show.html.erb
@@ -28,17 +28,6 @@
              data-markers="<%= @map_markers.to_json %>"></div>
       </div>
       <div class="col-lg-4">
-        <div class="status-panel status-clear mb-3">
-          <div class="fw-medium mb-1">Default view</div>
-          <div class="text-13 text-secondary">
-            Centered on the hackerspace at
-            <span class="text-body"><%= @map_center[:latitude] %>, <%= @map_center[:longitude] %></span>
-            with a
-            <span class="text-body"><%= number_with_precision(@map_radius_miles, precision: 1, strip_insignificant_zeros: true) %></span>
-            mile reference circle.
-          </div>
-        </div>
-
         <% if @map_markers.any? %>
           <div class="list-group list-compact">
             <% @map_markers.each do |marker| %>
@@ -64,65 +53,106 @@
 
 <script>
   (function() {
-    var map;
+    var leafletUrl = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
+
+    function loadLeaflet() {
+      if (typeof L !== 'undefined') return Promise.resolve();
+      if (window.memberMapLeafletPromise) return window.memberMapLeafletPromise;
+
+      window.memberMapLeafletPromise = new Promise(function(resolve, reject) {
+        var existingScript = document.querySelector('script[src="' + leafletUrl + '"]');
+        if (existingScript) {
+          existingScript.addEventListener('load', resolve, { once: true });
+          existingScript.addEventListener('error', reject, { once: true });
+          return;
+        }
+
+        var script = document.createElement('script');
+        script.src = leafletUrl;
+        script.integrity = 'sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=';
+        script.crossOrigin = '';
+        script.addEventListener('load', resolve, { once: true });
+        script.addEventListener('error', reject, { once: true });
+        document.head.appendChild(script);
+      });
+
+      return window.memberMapLeafletPromise;
+    }
 
     function initializeMemberMap() {
       var mapElement = document.getElementById('member-map');
-      if (!mapElement || typeof L === 'undefined' || map) return;
+      if (!mapElement || mapElement._memberMap) return;
 
-      var center = JSON.parse(mapElement.dataset.center || '{}');
-      var markers = JSON.parse(mapElement.dataset.markers || '[]');
-      var initialBounds = JSON.parse(mapElement.dataset.initialBounds || '{}');
-      var radiusMiles = Number(mapElement.dataset.radiusMiles || 4);
+      loadLeaflet().then(function() {
+        if (!document.body.contains(mapElement) || mapElement._memberMap) return;
 
-      map = L.map(mapElement);
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        maxZoom: 19,
-        attribution: '&copy; OpenStreetMap contributors'
-      }).addTo(map);
+        var center = JSON.parse(mapElement.dataset.center || '{}');
+        var markers = JSON.parse(mapElement.dataset.markers || '[]');
+        var initialBounds = JSON.parse(mapElement.dataset.initialBounds || '{}');
+        var radiusMiles = Number(mapElement.dataset.radiusMiles || 4);
 
-      if (initialBounds.south !== undefined && initialBounds.north !== undefined) {
-        map.fitBounds(
-          [
-            [initialBounds.south, initialBounds.west],
-            [initialBounds.north, initialBounds.east]
-          ],
-          { padding: [10, 10] }
-        );
-      } else {
-        map.setView([center.latitude, center.longitude], 12);
-      }
-
-      L.circle([center.latitude, center.longitude], {
-        radius: radiusMiles * 1609.344,
-        color: '#0d6efd',
-        weight: 1,
-        fillColor: '#0d6efd',
-        fillOpacity: 0.06
-      }).addTo(map);
-
-      L.circleMarker([center.latitude, center.longitude], {
-        radius: 7,
-        color: '#0d6efd',
-        weight: 2,
-        fillColor: '#0d6efd',
-        fillOpacity: 0.95
-      }).addTo(map).bindPopup('Hackerspace');
-
-      markers.forEach(function(marker) {
-        L.circleMarker([marker.latitude, marker.longitude], {
-          radius: 6,
-          color: '#198754',
-          weight: 1,
-          fillColor: '#198754',
-          fillOpacity: 0.75
+        var map = L.map(mapElement);
+        mapElement._memberMap = map;
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 19,
+          attribution: '&copy; OpenStreetMap contributors'
         }).addTo(map);
-      });
 
-      setTimeout(function() { map.invalidateSize(); }, 100);
+        if (initialBounds.south !== undefined && initialBounds.north !== undefined) {
+          map.fitBounds(
+            [
+              [initialBounds.south, initialBounds.west],
+              [initialBounds.north, initialBounds.east]
+            ],
+            { padding: [10, 10] }
+          );
+        } else {
+          map.setView([center.latitude, center.longitude], 12);
+        }
+
+        L.circle([center.latitude, center.longitude], {
+          radius: radiusMiles * 1609.344,
+          color: '#0d6efd',
+          weight: 1,
+          fillColor: '#0d6efd',
+          fillOpacity: 0.06
+        }).addTo(map);
+
+        L.circleMarker([center.latitude, center.longitude], {
+          radius: 7,
+          color: '#0d6efd',
+          weight: 2,
+          fillColor: '#0d6efd',
+          fillOpacity: 0.95
+        }).addTo(map).bindPopup('Hackerspace');
+
+        markers.forEach(function(marker) {
+          L.circleMarker([marker.latitude, marker.longitude], {
+            radius: 6,
+            color: '#198754',
+            weight: 1,
+            fillColor: '#198754',
+            fillOpacity: 0.75
+          }).addTo(map);
+        });
+
+        requestAnimationFrame(function() {
+          map.invalidateSize();
+          setTimeout(function() { map.invalidateSize(); }, 100);
+        });
+      });
+    }
+
+    function teardownMemberMap() {
+      var mapElement = document.getElementById('member-map');
+      if (mapElement && mapElement._memberMap) {
+        mapElement._memberMap.remove();
+        delete mapElement._memberMap;
+      }
     }
 
     document.addEventListener('DOMContentLoaded', initializeMemberMap);
     document.addEventListener('turbo:load', initializeMemberMap);
+    document.addEventListener('turbo:before-cache', teardownMemberMap);
   })();
 </script>

--- a/app/views/onboarding/member_info.html.erb
+++ b/app/views/onboarding/member_info.html.erb
@@ -43,7 +43,7 @@
             <div>
               <%= f.label :email, "Email Address", class: "form-label" %>
               <%= f.email_field :email, value: @user.email, class: "form-control form-control-lg",
-                  autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
+                  autocorrect: "off", autocapitalize: "off", spellcheck: "false", required: true %>
             </div>
 
             <div>

--- a/app/views/paypal_payments/index.html.erb
+++ b/app/views/paypal_payments/index.html.erb
@@ -123,7 +123,6 @@
           <th scope="col">Status</th>
           <th scope="col">Amount</th>
           <th scope="col">Payer</th>
-          <th scope="col">Linked Member</th>
           <th scope="col">Time</th>
         </tr>
       </thead>
@@ -143,19 +142,13 @@
             <td class="fw-semibold"><%= link_to payment.paypal_id, paypal_payment_path(payment), data: { turbo_frame: "_top" } %></td>
             <td><span class="badge text-bg-secondary"><%= payment.status.presence || "Unknown" %></span></td>
             <td><%= payment.amount_with_currency || "—" %></td>
-            <td>
-              <% if payment.payer_name.present? %>
-                <div><strong><%= payment.payer_name %></strong></div>
-              <% end %>
-              <% if payment.payer_email.present? %>
-                <div class="text-muted small"><%= mail_to payment.payer_email %></div>
-              <% end %>
-            </td>
-            <td>
+            <td class="paypal-payment-payer">
               <% if payment.user.present? %>
                 <%= link_to payment.user.display_name, user_path(payment.user), class: "text-decoration-none", data: { turbo_frame: "_top" } %>
+              <% elsif payment.payer_email.present? %>
+                <%= mail_to payment.payer_email %>
               <% else %>
-                <span class="text-muted fst-italic">Not linked</span>
+                <span class="text-muted fst-italic">No payer email</span>
               <% end %>
             </td>
             <td><%= payment.transaction_time ? l(payment.transaction_time, format: :long) : "n/a" %></td>

--- a/app/views/users/_tab_payments.html.erb
+++ b/app/views/users/_tab_payments.html.erb
@@ -48,8 +48,10 @@
                   <% linked = event.linked_payment %>
                   <% if local_assigns[:show_payment_links] && linked %>
                     <%= link_to event.details || event.identifier, payment_show_path(linked), class: "text-decoration-none" %>
-                  <% else %>
+                  <% elsif local_assigns[:show_payment_links] %>
                     <span class="text-muted"><%= event.details || event.identifier %></span>
+                  <% else %>
+                    <span class="text-muted"><%= member_payment_event_details(event) %></span>
                   <% end %>
                 </td>
                 <td><%= event.amount_with_currency || "—" %></td>

--- a/test/controllers/cash_payments_controller_test.rb
+++ b/test/controllers/cash_payments_controller_test.rb
@@ -58,6 +58,37 @@ class CashPaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal Date.current + 1.month, @user.dues_due_at.to_date
   end
 
+  test 'create sets payment due date when none is recorded' do
+    @user.update_columns(dues_due_at: nil, last_payment_date: nil)
+
+    post_cash_payment
+
+    assert_redirected_to cash_payment_path(CashPayment.last)
+    @user.reload
+    assert_equal Date.current + 1.month, @user.dues_due_at.to_date
+  end
+
+  test 'create advances payment due date when calculated date is later' do
+    @user.update_columns(dues_due_at: 1.week.from_now, last_payment_date: nil)
+
+    post_cash_payment
+
+    assert_redirected_to cash_payment_path(CashPayment.last)
+    @user.reload
+    assert_equal Date.current + 1.month, @user.dues_due_at.to_date
+  end
+
+  test 'create does not move payment due date earlier' do
+    existing_due_at = 2.months.from_now.beginning_of_day
+    @user.update_columns(dues_due_at: existing_due_at, last_payment_date: nil)
+
+    post_cash_payment
+
+    assert_redirected_to cash_payment_path(CashPayment.last)
+    @user.reload
+    assert_equal existing_due_at.to_date, @user.dues_due_at.to_date
+  end
+
   test 'create rejects invalid data' do
     assert_no_difference('CashPayment.count') do
       post cash_payments_path, params: {
@@ -121,6 +152,18 @@ class CashPaymentsControllerTest < ActionDispatch::IntegrationTest
       session: {
         email: account.email,
         password: 'localpassword123'
+      }
+    }
+  end
+
+  def post_cash_payment(paid_on: Date.current)
+    post cash_payments_path, params: {
+      cash_payment: {
+        user_id: @user.id,
+        membership_plan_id: @plan.id,
+        amount: 100.00,
+        paid_on: paid_on,
+        notes: 'Test payment'
       }
     }
   end

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -43,6 +43,36 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Request training/i, response.body)
   end
 
+  test 'member home payments details use source labels without payer emails' do
+    admin_user = User.find_by!(email: local_accounts(:active_admin).email)
+    [
+      ['paypal', 'PAY-HOME-PRIVACY', 'PayPal payment from private-paypal@example.com'],
+      ['recharge', 'RECHARGE-HOME-PRIVACY', 'Recharge payment from private-recharge@example.com'],
+      ['kofi', 'KOFI-HOME-PRIVACY', 'Ko-Fi Tip from private-kofi@example.com']
+    ].each do |source, external_id, details|
+      PaymentEvent.create!(
+        user: admin_user,
+        source: source,
+        external_id: external_id,
+        event_type: 'payment',
+        details: details,
+        amount: 10,
+        currency: 'USD',
+        occurred_at: Time.current
+      )
+    end
+
+    get root_path(tab: :payments)
+
+    assert_response :success
+    assert_select 'td', text: 'PayPal payment'
+    assert_select 'td', text: 'Recharge payment'
+    assert_select 'td', text: 'Ko-Fi Tip'
+    assert_no_match(/private-paypal@example\.com/, response.body)
+    assert_no_match(/private-recharge@example\.com/, response.body)
+    assert_no_match(/private-kofi@example\.com/, response.body)
+  end
+
   test 'home messages nav badge only shows unread count' do
     admin_user = User.find_by!(email: local_accounts(:active_admin).email)
     Message.where(recipient: admin_user).destroy_all

--- a/test/controllers/member_maps_controller_test.rb
+++ b/test/controllers/member_maps_controller_test.rb
@@ -17,6 +17,7 @@ class MemberMapsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select '#member-map[data-markers]'
     assert_select 'link[href*="leaflet.css"]', false
+    assert_select '.status-panel', text: /Default view/, count: 0
   end
 
   test 'should show mapped members' do

--- a/test/controllers/onboarding_controller_test.rb
+++ b/test/controllers/onboarding_controller_test.rb
@@ -29,6 +29,36 @@ class OnboardingControllerTest < ActionDispatch::IntegrationTest
     assert_select 'input[name=?][value=?]', 'rfid_code', '127,'
   end
 
+  test 'create member requires an email address' do
+    assert_no_difference 'User.count' do
+      post onboard_create_path, params: {
+        user: {
+          full_name: 'Missing Email',
+          username: 'missingemail',
+          email: ''
+        }
+      }
+    end
+
+    assert_response :unprocessable_content
+    assert_select '.alert-danger', text: /Email can't be blank/
+  end
+
+  test 'create member validates email format' do
+    assert_no_difference 'User.count' do
+      post onboard_create_path, params: {
+        user: {
+          full_name: 'Invalid Email',
+          username: 'invalidemail',
+          email: 'not-an-email'
+        }
+      }
+    end
+
+    assert_response :unprocessable_content
+    assert_select '.alert-danger', text: /Email is invalid/
+  end
+
   private
 
   def sign_in_as_admin

--- a/test/controllers/paypal_payments_controller_test.rb
+++ b/test/controllers/paypal_payments_controller_test.rb
@@ -77,6 +77,37 @@ class PaypalPaymentsControllerTest < ActionDispatch::IntegrationTest
                   paypal_payment_path(payment), '_top'
   end
 
+  test 'index shows linked member in payer column without separate linked member column' do
+    get paypal_payments_path(q: @payment.paypal_id)
+
+    assert_response :success
+    assert_select 'th', text: 'Linked Member', count: 0
+    assert_select 'td.paypal-payment-payer a[href=?][data-turbo-frame=?]',
+                  user_path(@payment.user), '_top',
+                  text: @payment.user.display_name
+  end
+
+  test 'index falls back to payer email when payment is unlinked' do
+    payment = PaypalPayment.create!(
+      paypal_id: 'PAY-UNLINKED-PAYER',
+      status: 'COMPLETED',
+      amount: 42.50,
+      currency: 'USD',
+      transaction_time: Time.current,
+      transaction_type: 'T0001',
+      payer_email: 'unlinked-payer@example.com',
+      payer_name: 'Unlinked Payer',
+      payer_id: 'PAYER-UNLINKED-PAYER',
+      matches_plan: true
+    )
+
+    get paypal_payments_path(q: payment.paypal_id)
+
+    assert_response :success
+    assert_select 'td.paypal-payment-payer a[href=?]', 'mailto:unlinked-payer@example.com',
+                  text: 'unlinked-payer@example.com'
+  end
+
   test 'payment search paginates the filtered result set' do
     105.times do |index|
       PaypalPayment.create!(


### PR DESCRIPTION
Require emails during admin onboarding, simplify payment privacy displays, stabilize map loading, and avoid moving cash payment due dates backwards.