### PR TITLE
Add map defaults and geocoding locality fallback

### DIFF
--- a/app/controllers/default_settings_controller.rb
+++ b/app/controllers/default_settings_controller.rb
@@ -7,6 +7,14 @@ class DefaultSettingsController < AdminController
     @default_setting = DefaultSetting.instance
   end
 
+  def map
+    @default_setting = DefaultSetting.instance
+  end
+
+  def edit_map
+    @default_setting = DefaultSetting.instance
+  end
+
   def provision_core_groups
     provisioner = Authentik::CoreGroupProvisioner.new
     results = provisioner.provision_and_sync!
@@ -32,6 +40,17 @@ class DefaultSettingsController < AdminController
     end
   end
 
+  def update_map
+    @default_setting = DefaultSetting.instance
+
+    if @default_setting.update(map_default_setting_params)
+      redirect_to map_default_settings_path, notice: 'Map defaults updated successfully.'
+    else
+      flash.now[:alert] = 'Unable to update map defaults.'
+      render :edit_map, status: :unprocessable_content
+    end
+  end
+
   private
 
   def default_setting_params
@@ -40,8 +59,14 @@ class DefaultSettingsController < AdminController
                     active_members_group admins_group
                     unbanned_members_group all_members_group
                     trained_on_prefix can_train_prefix
-                    sync_inactive_members map_center_latitude
-                    map_center_longitude map_radius_miles
+                    sync_inactive_members
+                  ])
+  end
+
+  def map_default_setting_params
+    params.expect(default_setting: %i[
+                    map_center_latitude map_center_longitude
+                    map_radius_miles map_default_city map_default_state
                   ])
   end
 end

--- a/app/jobs/member_geocoding_job.rb
+++ b/app/jobs/member_geocoding_job.rb
@@ -1,6 +1,59 @@
 class MemberGeocodingJob < ApplicationJob
   queue_as :default
 
+  STATE_ABBREVIATIONS = {
+    'alabama' => 'al',
+    'alaska' => 'ak',
+    'arizona' => 'az',
+    'arkansas' => 'ar',
+    'california' => 'ca',
+    'colorado' => 'co',
+    'connecticut' => 'ct',
+    'delaware' => 'de',
+    'florida' => 'fl',
+    'georgia' => 'ga',
+    'hawaii' => 'hi',
+    'idaho' => 'id',
+    'illinois' => 'il',
+    'indiana' => 'in',
+    'iowa' => 'ia',
+    'kansas' => 'ks',
+    'kentucky' => 'ky',
+    'louisiana' => 'la',
+    'maine' => 'me',
+    'maryland' => 'md',
+    'massachusetts' => 'ma',
+    'michigan' => 'mi',
+    'minnesota' => 'mn',
+    'mississippi' => 'ms',
+    'missouri' => 'mo',
+    'montana' => 'mt',
+    'nebraska' => 'ne',
+    'nevada' => 'nv',
+    'new hampshire' => 'nh',
+    'new jersey' => 'nj',
+    'new mexico' => 'nm',
+    'new york' => 'ny',
+    'north carolina' => 'nc',
+    'north dakota' => 'nd',
+    'ohio' => 'oh',
+    'oklahoma' => 'ok',
+    'oregon' => 'or',
+    'pennsylvania' => 'pa',
+    'rhode island' => 'ri',
+    'south carolina' => 'sc',
+    'south dakota' => 'sd',
+    'tennessee' => 'tn',
+    'texas' => 'tx',
+    'utah' => 'ut',
+    'vermont' => 'vt',
+    'virginia' => 'va',
+    'washington' => 'wa',
+    'west virginia' => 'wv',
+    'wisconsin' => 'wi',
+    'wyoming' => 'wy'
+  }.freeze
+
   def perform(user_id = nil)
     geocoder = Geocoding::NominatimClient.new
     return geocode_one(User.find_by(id: user_id), geocoder) if user_id.present?
@@ -22,7 +75,7 @@ class MemberGeocodingJob < ApplicationJob
   def geocode_one(user, geocoder)
     return if user.blank? || user.mailing_address.blank?
 
-    result = geocoder.geocode(user.mailing_address)
+    result = geocoder.geocode(geocoding_address(user.mailing_address))
     updates = { mailing_geocoded_at: Time.current, updated_at: Time.current }
     if result.present?
       fuzzed_result = Geocoding::CoordinateFuzzer.call(
@@ -34,6 +87,41 @@ class MemberGeocodingJob < ApplicationJob
     end
 
     user.update_columns(updates)
+  end
+
+  def geocoding_address(address)
+    settings = DefaultSetting.instance
+    address = address.to_s.strip
+    city = settings.map_default_city.to_s.strip
+    state = settings.map_default_state.to_s.strip
+    return address if address.blank? || city.blank? || state.blank?
+
+    normalized_address = address.downcase
+    city_present = normalized_address.match?(/\b#{Regexp.escape(city.downcase)}\b/)
+    state_present = state_tokens(state).any? do |token|
+      normalized_address.match?(/\b#{Regexp.escape(token)}\b/)
+    end
+    return address if city_present && state_present
+
+    locality = if city_present
+                 state
+               else
+                 "#{city}, #{state}"
+               end
+    "#{address}, #{locality}"
+  end
+
+  def state_tokens(state)
+    normalized = state.downcase
+    tokens = [normalized]
+    if normalized.length == 2
+      full_state = STATE_ABBREVIATIONS.key(normalized)
+      tokens << full_state if full_state.present?
+    else
+      abbreviation = STATE_ABBREVIATIONS[normalized]
+      tokens << abbreviation if abbreviation.present?
+    end
+    tokens
   end
 
   def throttle_seconds

--- a/app/models/default_setting.rb
+++ b/app/models/default_setting.rb
@@ -15,6 +15,8 @@ class DefaultSetting < ApplicationRecord
                                  numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :map_center_latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
   validates :map_center_longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+  validates :map_default_city, presence: true
+  validates :map_default_state, presence: true
   validates :map_radius_miles, numericality: { greater_than: 0, less_than_or_equal_to: 100 }
 
   def rfid_facility_prefix
@@ -36,6 +38,8 @@ class DefaultSetting < ApplicationRecord
       setting.rfid_facility_code = DEFAULT_RFID_FACILITY_CODE
       setting.map_center_latitude = 45.581678
       setting.map_center_longitude = -122.682156
+      setting.map_default_city = 'Portland'
+      setting.map_default_state = 'Oregon'
       setting.map_radius_miles = 4.0
     end
   end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -156,12 +156,6 @@
             <div class="col-md-4">
               <div class="h-section-label mb-2">Members</div>
               <div class="d-flex flex-wrap gap-2">
-                <%= link_to onboard_path, class: "btn btn-primary btn-sm" do %>
-                  <i class="bi bi-person-badge me-1"></i>New member
-                <% end %>
-                <%= link_to new_invitation_path, class: "btn btn-outline-secondary btn-sm" do %>
-                  <i class="bi bi-envelope-plus me-1"></i>Invitation
-                <% end %>
                 <%= link_to new_rfid_path, class: "btn btn-outline-secondary btn-sm" do %>
                   <i class="bi bi-key me-1"></i>Key
                 <% end %>
@@ -169,6 +163,12 @@
                   <%= link_to record_training_path, class: "btn btn-outline-secondary btn-sm" do %>
                     <i class="bi bi-mortarboard me-1"></i>Record training
                   <% end %>
+                <% end %>
+                <%= link_to onboard_path, class: "btn btn-outline-secondary btn-sm" do %>
+                  <i class="bi bi-person-badge me-1"></i>New member
+                <% end %>
+                <%= link_to new_invitation_path, class: "btn btn-outline-secondary btn-sm" do %>
+                  <i class="bi bi-envelope-plus me-1"></i>Invitation
                 <% end %>
               </div>
             </div>

--- a/app/views/default_settings/edit.html.erb
+++ b/app/views/default_settings/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
   <div>
-    <h1 class="h3 mb-1">Edit Default Settings</h1>
-    <p class="text-muted mb-0">Configure default prefixes and group names used throughout the application.</p>
+    <h1 class="h3 mb-1">Edit Application Group Defaults</h1>
+    <p class="text-muted mb-0">Configure default prefixes and group names used for applications and core member groups.</p>
   </div>
   <div>
     <%= link_to "&larr; Back to Defaults".html_safe, default_settings_path, class: "text-decoration-none" %>
@@ -73,31 +73,6 @@
         <%= f.label :can_train_prefix, "Can Train Prefix", class: "form-label" %>
         <%= f.text_field :can_train_prefix, class: "form-control", required: true, id: "default_setting_can_train_prefix", readonly: true %>
         <div class="form-text">Automatically calculated as: <span id="can_train_prefix_preview"></span></div>
-      </div>
-
-      <hr class="my-4">
-
-      <h2 class="h-section-label mb-3">Map report</h2>
-
-      <div class="row g-3">
-        <div class="col-md-4">
-          <%= f.label :map_center_latitude, "Center latitude", class: "form-label" %>
-          <%= f.number_field :map_center_latitude, class: "form-control", step: "0.000001", required: true %>
-          <div class="form-text">Default center for the member map.</div>
-        </div>
-        <div class="col-md-4">
-          <%= f.label :map_center_longitude, "Center longitude", class: "form-label" %>
-          <%= f.number_field :map_center_longitude, class: "form-control", step: "0.000001", required: true %>
-          <div class="form-text">Use a negative value for west longitude.</div>
-        </div>
-        <div class="col-md-4">
-          <%= f.label :map_radius_miles, "Radius", class: "form-label" %>
-          <div class="input-group">
-            <%= f.number_field :map_radius_miles, class: "form-control", step: "0.1", min: "0.1", max: "100", required: true %>
-            <span class="input-group-text">miles</span>
-          </div>
-          <div class="form-text">Default report radius around the center.</div>
-        </div>
       </div>
 
       <div class="d-flex gap-2 mt-4">

--- a/app/views/default_settings/edit_map.html.erb
+++ b/app/views/default_settings/edit_map.html.erb
@@ -1,0 +1,66 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <div>
+    <h1 class="h3 mb-1">Edit Map Defaults</h1>
+    <p class="text-muted mb-0">Set the hackerspace location and fallback locality for incomplete mailing addresses.</p>
+  </div>
+  <div>
+    <%= link_to "&larr; Back to Map Defaults".html_safe, map_default_settings_path, class: "text-decoration-none" %>
+  </div>
+</div>
+
+<div class="card shadow-sm border-0">
+  <div class="card-body">
+    <%= form_with model: @default_setting, url: update_map_default_settings_path, method: :patch, local: true do |f| %>
+      <% if @default_setting.errors.any? %>
+        <div class="alert alert-danger">
+          <ul class="mb-0">
+            <% @default_setting.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <h2 class="h-section-label mb-3">Hackerspace location</h2>
+      <div class="row g-3 mb-4">
+        <div class="col-md-4">
+          <%= f.label :map_center_latitude, "Latitude", class: "form-label" %>
+          <%= f.number_field :map_center_latitude, class: "form-control", step: "0.000001", required: true %>
+          <div class="form-text">Default center for the member map.</div>
+        </div>
+        <div class="col-md-4">
+          <%= f.label :map_center_longitude, "Longitude", class: "form-label" %>
+          <%= f.number_field :map_center_longitude, class: "form-control", step: "0.000001", required: true %>
+          <div class="form-text">Use a negative value for west longitude.</div>
+        </div>
+        <div class="col-md-4">
+          <%= f.label :map_radius_miles, "Reference radius", class: "form-label" %>
+          <div class="input-group">
+            <%= f.number_field :map_radius_miles, class: "form-control", step: "0.1", min: "0.1", max: "100", required: true %>
+            <span class="input-group-text">miles</span>
+          </div>
+          <div class="form-text">Default report radius around the center.</div>
+        </div>
+      </div>
+
+      <h2 class="h-section-label mb-3">Address geocoding fallback</h2>
+      <div class="row g-3">
+        <div class="col-md-6">
+          <%= f.label :map_default_city, "Default city", class: "form-label" %>
+          <%= f.text_field :map_default_city, class: "form-control", required: true %>
+          <div class="form-text">Used when a member mailing address looks like it only has a street address.</div>
+        </div>
+        <div class="col-md-6">
+          <%= f.label :map_default_state, "Default state", class: "form-label" %>
+          <%= f.text_field :map_default_state, class: "form-control", required: true %>
+          <div class="form-text">Examples: Oregon, OR.</div>
+        </div>
+      </div>
+
+      <div class="d-flex gap-2 mt-4">
+        <%= f.submit "Update Map Defaults", class: "btn btn-primary" %>
+        <%= link_to "Cancel", map_default_settings_path, class: "btn btn-outline-secondary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/default_settings/map.html.erb
+++ b/app/views/default_settings/map.html.erb
@@ -1,0 +1,39 @@
+<div class="d-flex align-items-end justify-content-between mb-3">
+  <div>
+    <h1 class="h-page-title mb-0">Map Defaults</h1>
+    <div class="text-13 text-secondary mt-1">
+      Hackerspace location and fallback locality for member address geocoding
+    </div>
+  </div>
+  <%= link_to "Edit", edit_map_default_settings_path, class: "btn btn-primary btn-sm" %>
+</div>
+
+<div class="card shadow-sm border-0 mb-4">
+  <div class="card-body">
+    <h2 class="h-section-label mb-3">Hackerspace location</h2>
+    <dl class="row mb-4">
+      <dt class="col-sm-4 text-secondary">Latitude</dt>
+      <dd class="col-sm-8"><code><%= @default_setting.map_center_latitude %></code></dd>
+
+      <dt class="col-sm-4 text-secondary">Longitude</dt>
+      <dd class="col-sm-8"><code><%= @default_setting.map_center_longitude %></code></dd>
+
+      <dt class="col-sm-4 text-secondary">Reference radius</dt>
+      <dd class="col-sm-8">
+        <%= number_with_precision(@default_setting.map_radius_miles, precision: 1, strip_insignificant_zeros: true) %>
+        miles
+      </dd>
+    </dl>
+
+    <h2 class="h-section-label mb-3">Address geocoding fallback</h2>
+    <dl class="row mb-0">
+      <dt class="col-sm-4 text-secondary">Default city</dt>
+      <dd class="col-sm-8"><%= @default_setting.map_default_city %></dd>
+
+      <dt class="col-sm-4 text-secondary">Default state</dt>
+      <dd class="col-sm-8"><%= @default_setting.map_default_state %></dd>
+    </dl>
+  </div>
+</div>
+
+<%= link_to "Back to Settings", settings_path, class: "btn btn-outline-secondary btn-sm" %>

--- a/app/views/default_settings/show.html.erb
+++ b/app/views/default_settings/show.html.erb
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
   <div>
-    <h1 class="h3 mb-1">Manage Defaults</h1>
-    <p class="text-muted mb-0">Configure default prefixes and group names used throughout the application.</p>
+    <h1 class="h3 mb-1">Application Group Defaults</h1>
+    <p class="text-muted mb-0">Configure default prefixes and group names used for applications and core member groups.</p>
   </div>
   <div>
     <%= link_to "&larr; Back to Settings".html_safe, settings_path, class: "text-decoration-none" %>
@@ -38,16 +38,6 @@
       <dt class="col-sm-4 text-secondary">Can Train Prefix</dt>
       <dd class="col-sm-8"><code><%= @default_setting.can_train_prefix %></code></dd>
 
-      <dt class="col-sm-4 text-secondary">Map Center</dt>
-      <dd class="col-sm-8">
-        <code><%= @default_setting.map_center_latitude %>, <%= @default_setting.map_center_longitude %></code>
-      </dd>
-
-      <dt class="col-sm-4 text-secondary">Map Radius</dt>
-      <dd class="col-sm-8">
-        <%= number_with_precision(@default_setting.map_radius_miles, precision: 1, strip_insignificant_zeros: true) %>
-        miles
-      </dd>
     </dl>
   </div>
 </div>

--- a/app/views/member_maps/show.html.erb
+++ b/app/views/member_maps/show.html.erb
@@ -14,7 +14,7 @@
       </span> missing coordinates
     </div>
   </div>
-  <%= link_to "Map settings", edit_default_settings_path, class: "btn btn-outline-secondary btn-sm" %>
+  <%= link_to "Map settings", edit_map_default_settings_path, class: "btn btn-outline-secondary btn-sm" %>
 </div>
 
 <div class="card shadow-sm border-0 member-map-card mx-auto">

--- a/app/views/settings/_index_refresh.html.erb
+++ b/app/views/settings/_index_refresh.html.erb
@@ -19,7 +19,7 @@
   { category: "Communications", title: "Documents", desc: "Member documents and training-topic attachments.", path: documents_path },
   { category: "Communications", title: "Text fragments", desc: "Reusable HTML snippets for help text and system messages.", path: text_fragments_path },
   { category: "Member profiles", title: "Interests", desc: "Profile interests, suggested terms, renames, and merges.", path: interests_path, attention_count: @settings_attention_counts[:interests] },
-  { category: "Member profiles", title: "Map defaults", desc: "Default center and radius for the member location report.", path: default_settings_path },
+  { category: "Member profiles", title: "Map defaults", desc: "Hackerspace location and fallback city/state for member geocoding.", path: map_default_settings_path },
   { category: "AI & integrations", title: "AI services", desc: "Service prompts, model selections, and health checks.", path: ai_ollama_profiles_path, attention_count: @settings_attention_counts[:ai_services] },
   { category: "AI & integrations", title: "AI providers", desc: "Reusable AI provider URLs and optional API keys.", path: ai_providers_path },
   { category: "AI & integrations", title: "Member sources", desc: "Authentik, Sheets, and Slack reconciliation sources.", path: member_sources_path },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,6 +282,9 @@ Rails.application.routes.draw do
   end
 
   resource :default_settings, only: [:show, :edit, :update], path: "settings/defaults" do
+    get :map, on: :member
+    get :edit_map, on: :member
+    patch :update_map, on: :member
     post :provision_core_groups, on: :member
   end
   resource :membership_settings, only: [:show, :edit, :update], path: "settings/membership"

--- a/db/migrate/20260515075600_add_default_locality_to_default_settings.rb
+++ b/db/migrate/20260515075600_add_default_locality_to_default_settings.rb
@@ -1,0 +1,6 @@
+class AddDefaultLocalityToDefaultSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :default_settings, :map_default_city, :string, null: false, default: 'Portland'
+    add_column :default_settings, :map_default_state, :string, null: false, default: 'Oregon'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_14_033000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_15_075600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -279,6 +279,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_033000) do
     t.string "members_prefix", null: false
     t.decimal "map_center_latitude", precision: 10, scale: 6, default: "45.581678", null: false
     t.decimal "map_center_longitude", precision: 10, scale: 6, default: "-122.682156", null: false
+    t.string "map_default_city", default: "Portland", null: false
+    t.string "map_default_state", default: "Oregon", null: false
     t.decimal "map_radius_miles", precision: 5, scale: 2, default: "4.0", null: false
     t.string "site_prefix", default: "ctrlh", null: false
     t.boolean "sync_inactive_members", default: false, null: false

--- a/test/controllers/default_settings_controller_test.rb
+++ b/test/controllers/default_settings_controller_test.rb
@@ -21,6 +21,22 @@ class DefaultSettingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should get map defaults' do
+    get map_default_settings_url
+
+    assert_response :success
+    assert_select 'h1', /Map Defaults/
+    assert_match(/Portland/, response.body)
+    assert_match(/Oregon/, response.body)
+  end
+
+  test 'should get edit map defaults' do
+    get edit_map_default_settings_url
+
+    assert_response :success
+    assert_select 'h1', /Edit Map Defaults/
+  end
+
   test 'should update default settings' do
     patch default_settings_url, params: {
       default_setting: { site_prefix: 'test-prefix' }
@@ -29,19 +45,23 @@ class DefaultSettingsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should update map defaults' do
-    patch default_settings_url, params: {
+    patch update_map_default_settings_url, params: {
       default_setting: {
         map_center_latitude: '45.500000',
         map_center_longitude: '-122.600000',
-        map_radius_miles: '6.5'
+        map_radius_miles: '6.5',
+        map_default_city: 'Beaverton',
+        map_default_state: 'Oregon'
       }
     }
 
-    assert_redirected_to default_settings_url
+    assert_redirected_to map_default_settings_url
     setting = DefaultSetting.instance
     assert_equal 45.5, setting.map_center_latitude.to_f
     assert_equal(-122.6, setting.map_center_longitude.to_f)
     assert_equal 6.5, setting.map_radius_miles.to_f
+    assert_equal 'Beaverton', setting.map_default_city
+    assert_equal 'Oregon', setting.map_default_state
   end
 
   private

--- a/test/controllers/member_maps_controller_test.rb
+++ b/test/controllers/member_maps_controller_test.rb
@@ -18,6 +18,7 @@ class MemberMapsControllerTest < ActionDispatch::IntegrationTest
     assert_select '#member-map[data-markers]'
     assert_select 'link[href*="leaflet.css"]', false
     assert_select '.status-panel', text: /Default view/, count: 0
+    assert_select 'a[href=?]', edit_map_default_settings_path, text: /Map settings/
   end
 
   test 'should show mapped members' do

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -16,6 +16,14 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'settings index links map defaults separately from application group defaults' do
+    get settings_url
+
+    assert_response :success
+    assert_select 'a[href=?]', default_settings_path, text: /Application group defaults/
+    assert_select 'a[href=?]', map_default_settings_path, text: /Map defaults/
+  end
+
   private
 
   def sign_in_as_admin

--- a/test/fixtures/default_settings.yml
+++ b/test/fixtures/default_settings.yml
@@ -13,4 +13,6 @@ one:
   rfid_facility_code: 127
   map_center_latitude: 45.581678
   map_center_longitude: -122.682156
+  map_default_city: Portland
+  map_default_state: Oregon
   map_radius_miles: 4.0

--- a/test/jobs/member_geocoding_job_test.rb
+++ b/test/jobs/member_geocoding_job_test.rb
@@ -31,6 +31,46 @@ class MemberGeocodingJobTest < ActiveJob::TestCase
     assert_equal ['7608 N Interstate Ave, Portland, OR'], geocoder.addresses
   end
 
+  test 'appends default city and state when mailing address has no locality' do
+    DefaultSetting.instance.update!(map_default_city: 'Portland', map_default_state: 'Oregon')
+    user = users(:one)
+    user.update_columns(
+      mailing_address: '7608 N Interstate Ave',
+      mailing_latitude: nil,
+      mailing_longitude: nil,
+      mailing_geocoded_at: nil
+    )
+    geocoder = FakeGeocoder.new({ latitude: 45.581678.to_d, longitude: -122.682156.to_d }, [])
+
+    with_env('GEOCODING_FUZZ_BLOCKS' => '0') do
+      with_geocoder(geocoder) do
+        MemberGeocodingJob.perform_now(user.id)
+      end
+    end
+
+    assert_equal ['7608 N Interstate Ave, Portland, Oregon'], geocoder.addresses
+  end
+
+  test 'does not append default city and state when mailing address already has them' do
+    DefaultSetting.instance.update!(map_default_city: 'Portland', map_default_state: 'Oregon')
+    user = users(:one)
+    user.update_columns(
+      mailing_address: '7608 N Interstate Ave, Portland, OR',
+      mailing_latitude: nil,
+      mailing_longitude: nil,
+      mailing_geocoded_at: nil
+    )
+    geocoder = FakeGeocoder.new({ latitude: 45.581678.to_d, longitude: -122.682156.to_d }, [])
+
+    with_env('GEOCODING_FUZZ_BLOCKS' => '0') do
+      with_geocoder(geocoder) do
+        MemberGeocodingJob.perform_now(user.id)
+      end
+    end
+
+    assert_equal ['7608 N Interstate Ave, Portland, OR'], geocoder.addresses
+  end
+
   test 'fuzzes coordinates when geocoding stores a result' do
     user = users(:one)
     user.update_columns(

--- a/test/models/default_setting_test.rb
+++ b/test/models/default_setting_test.rb
@@ -27,4 +27,14 @@ class DefaultSettingTest < ActiveSupport::TestCase
     assert_includes setting.errors[:map_center_longitude], 'must be greater than or equal to -180'
     assert_includes setting.errors[:map_radius_miles], 'must be greater than 0'
   end
+
+  test 'map defaults require fallback city and state' do
+    setting = default_settings(:one)
+    setting.map_default_city = ''
+    setting.map_default_state = ''
+
+    assert_not setting.valid?
+    assert_includes setting.errors[:map_default_city], "can't be blank"
+    assert_includes setting.errors[:map_default_state], "can't be blank"
+  end
 end


### PR DESCRIPTION
Split map defaults from application group defaults, add default city/state settings, and use them to improve geocoding for incomplete mailing addresses.