### PR TITLE
Fix cash payment updates and Recharge member display

### DIFF
--- a/app/controllers/cash_payments_controller.rb
+++ b/app/controllers/cash_payments_controller.rb
@@ -28,17 +28,7 @@ class CashPaymentsController < AdminController
     @cash_payment.recorded_by = current_user
 
     if @cash_payment.save
-      PaymentEvent.create!(
-        user: @cash_payment.user,
-        event_type: 'payment',
-        source: 'cash',
-        amount: @cash_payment.amount,
-        currency: 'USD',
-        occurred_at: @cash_payment.paid_on&.beginning_of_day || Time.current,
-        external_id: "CASH-#{@cash_payment.id}",
-        details: "Cash payment — #{@cash_payment.membership_plan&.name || 'Unknown plan'}",
-        cash_payment: @cash_payment
-      )
+      sync_payment_event(@cash_payment)
       update_user_dues_status(@cash_payment)
       redirect_to cash_payment_path(@cash_payment),
                   notice: "Cash payment recorded for #{@cash_payment.user.display_name}."
@@ -48,7 +38,12 @@ class CashPaymentsController < AdminController
   end
 
   def update
+    original_user = @cash_payment.user
+
     if @cash_payment.update(cash_payment_params)
+      sync_payment_event(@cash_payment)
+      recalculate_user_cash_dues!(original_user) if original_user != @cash_payment.user
+      recalculate_user_cash_dues!(@cash_payment.user)
       redirect_to cash_payment_path(@cash_payment), notice: 'Cash payment updated.'
     else
       render :edit, status: :unprocessable_content
@@ -94,6 +89,45 @@ class CashPaymentsController < AdminController
         'note' => "Cash payment of $#{format('%.2f', cash_payment.amount)} recorded"
       }
     )
+  end
+
+  def sync_payment_event(cash_payment)
+    event = cash_payment.payment_events.find_or_initialize_by(
+      source: 'cash',
+      external_id: cash_payment.identifier,
+      event_type: 'payment'
+    )
+    event.assign_attributes(
+      user: cash_payment.user,
+      amount: cash_payment.amount,
+      currency: 'USD',
+      occurred_at: cash_payment.paid_on&.beginning_of_day || Time.current,
+      details: "Cash payment - #{cash_payment.membership_plan&.name || 'Unknown plan'}"
+    )
+    event.save!
+  end
+
+  def recalculate_user_cash_dues!(user)
+    latest_payment = user.cash_payments.order(paid_on: :desc, created_at: :desc).first
+    return if latest_payment.blank?
+
+    due_at = User.dues_due_at_from_payment_cycle(latest_payment.paid_on, latest_payment.membership_plan)
+    updates = {
+      payment_type: 'cash',
+      last_payment_date: latest_payment.paid_on,
+      dues_due_at: due_at,
+      dues_status: cash_dues_status(due_at)
+    }
+    updates[:membership_status] = 'paying' unless user.membership_status.in?(%w[cancelled banned deceased sponsored])
+    updates[:membership_ended_date] = nil if updates[:dues_status] == 'current' && user.membership_ended_date.present?
+
+    user.update!(updates)
+  end
+
+  def cash_dues_status(due_at)
+    return 'current' if due_at.blank? || due_at.to_date >= Date.current
+
+    'lapsed'
   end
 
   def keep_later_dues_due_at!(updates, current_dues_due_at)

--- a/app/views/recharge_payments/index.html.erb
+++ b/app/views/recharge_payments/index.html.erb
@@ -116,8 +116,7 @@
           <th scope="col">Charge</th>
           <th scope="col">Status</th>
           <th scope="col">Amount</th>
-          <th scope="col">Customer</th>
-          <th scope="col">Linked Member</th>
+          <th scope="col">Member</th>
           <th scope="col">Processed</th>
         </tr>
       </thead>
@@ -154,21 +153,22 @@
                 <span class="text-secondary">—</span>
               <% end %>
             </td>
-            <td>
-              <% if payment.customer_name.present? %>
-                <div><%= payment.customer_name %></div>
-              <% end %>
-              <% if payment.customer_email.present? %>
-                <div class="text-muted small"><%= payment.customer_email %></div>
-              <% end %>
-            </td>
-            <td>
+            <td class="recharge-payment-member">
               <% if payment.user.present? %>
                 <%= link_to payment.user.display_name, user_path(payment.user), class: "text-decoration-none", data: { turbo_frame: "_top" } %>
               <% elsif unlinked %>
+                <% if payment.customer_name.present? %>
+                  <div class="mb-1"><%= payment.customer_name %></div>
+                <% else %>
+                  <div class="text-muted fst-italic mb-1">Unnamed customer</div>
+                <% end %>
                 <%= link_to "Link member...", recharge_payment_path(payment), class: "btn btn-sm btn-warning", data: { turbo_frame: "_top" } %>
               <% else %>
-                <span class="text-muted fst-italic">Not linked</span>
+                <% if payment.customer_name.present? %>
+                  <div><%= payment.customer_name %></div>
+                <% else %>
+                  <span class="text-muted fst-italic">Not linked</span>
+                <% end %>
               <% end %>
             </td>
             <td>

--- a/test/controllers/cash_payments_controller_test.rb
+++ b/test/controllers/cash_payments_controller_test.rb
@@ -137,6 +137,88 @@ class CashPaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Updated notes', @payment.notes
   end
 
+  test 'updating cash payment recalculates overdue dues and active status' do
+    @user.cash_payments.destroy_all
+    payment = CashPayment.create!(
+      user: @user,
+      membership_plan: @plan,
+      amount: 100.00,
+      paid_on: Date.current,
+      recorded_by: users(:one)
+    )
+    @user.update!(
+      membership_status: 'paying',
+      dues_status: 'current',
+      active: true,
+      payment_type: 'cash',
+      dues_due_at: 1.month.from_now
+    )
+
+    patch cash_payment_path(payment), params: {
+      cash_payment: {
+        paid_on: 2.months.ago.to_date
+      }
+    }
+
+    assert_redirected_to cash_payment_path(payment)
+    @user.reload
+    assert_equal 2.months.ago.to_date, @user.last_payment_date
+    assert_equal 1.month.ago.to_date, @user.dues_due_at.to_date
+    assert_equal 'lapsed', @user.dues_status
+    assert_not @user.active?
+  end
+
+  test 'updating older cash payment keeps dues based on latest paid date' do
+    @user.cash_payments.destroy_all
+    latest_paid_on = 3.days.ago.to_date
+    CashPayment.create!(
+      user: @user,
+      membership_plan: @plan,
+      amount: 100.00,
+      paid_on: latest_paid_on,
+      recorded_by: users(:one)
+    )
+    older_payment = CashPayment.create!(
+      user: @user,
+      membership_plan: @plan,
+      amount: 100.00,
+      paid_on: 3.months.ago.to_date,
+      recorded_by: users(:one)
+    )
+
+    patch cash_payment_path(older_payment), params: {
+      cash_payment: {
+        notes: 'Edited older payment'
+      }
+    }
+
+    assert_redirected_to cash_payment_path(older_payment)
+    @user.reload
+    assert_equal latest_paid_on, @user.last_payment_date
+    assert_equal latest_paid_on + 1.month, @user.dues_due_at.to_date
+    assert_equal 'current', @user.dues_status
+    assert @user.active?
+  end
+
+  test 'updating cash payment syncs payment event date and amount' do
+    @user.cash_payments.destroy_all
+    post_cash_payment
+    payment = CashPayment.last
+    event = payment.payment_events.first
+
+    patch cash_payment_path(payment), params: {
+      cash_payment: {
+        amount: 125.50,
+        paid_on: 10.days.ago.to_date
+      }
+    }
+
+    assert_redirected_to cash_payment_path(payment)
+    event.reload
+    assert_equal 125.50, event.amount.to_f
+    assert_equal 10.days.ago.to_date, event.occurred_at.to_date
+  end
+
   test 'deletes cash payment' do
     assert_difference('CashPayment.count', -1) do
       delete cash_payment_path(@payment)

--- a/test/controllers/recharge_payments_controller_test.rb
+++ b/test/controllers/recharge_payments_controller_test.rb
@@ -76,6 +76,40 @@ class RechargePaymentsControllerTest < ActionDispatch::IntegrationTest
                   recharge_payment_path(unlinked), '_top'
   end
 
+  test 'index combines customer and link action in member column for unlinked payments' do
+    unlinked = RechargePayment.create!(
+      recharge_id: 'RC-UNLINKED-MEMBER-COLUMN',
+      status: 'success',
+      amount: 30.00,
+      currency: 'USD',
+      processed_at: Time.current,
+      customer_id: 'recharge-unlinked-member-column',
+      customer_email: 'hidden-customer@example.com',
+      customer_name: 'Visible Customer'
+    )
+
+    get recharge_payments_path(q: unlinked.recharge_id)
+
+    assert_response :success
+    assert_select 'th', text: 'Customer', count: 0
+    assert_select 'th', text: 'Linked Member', count: 0
+    assert_select 'th', text: 'Member'
+    assert_select 'td.recharge-payment-member', text: /Visible Customer/
+    assert_select 'td.recharge-payment-member', text: /hidden-customer@example\.com/, count: 0
+    assert_select 'td.recharge-payment-member a[href=?][data-turbo-frame=?]',
+                  recharge_payment_path(unlinked), '_top',
+                  text: /Link member/
+  end
+
+  test 'index shows linked member in member column' do
+    get recharge_payments_path(q: @payment.recharge_id)
+
+    assert_response :success
+    assert_select 'td.recharge-payment-member a[href=?][data-turbo-frame=?]',
+                  user_path(@payment.user), '_top',
+                  text: @payment.user.display_name
+  end
+
   test 'link member modal can search by member email and username' do
     unlinked = RechargePayment.create!(
       recharge_id: 'RC-LINK-MODAL-SEARCH',


### PR DESCRIPTION
Recalculate cash dues from payment dates when records change and simplify Recharge member display without exposing customer emails.