### PR TITLE
Use day intervals for custom cash plans

### DIFF
--- a/app/controllers/membership_plans_controller.rb
+++ b/app/controllers/membership_plans_controller.rb
@@ -129,7 +129,7 @@ class MembershipPlansController < AdminController
   end
 
   def membership_plan_params
-    params.expect(membership_plan: %i[name cost billing_frequency description payment_link plan_type
+    params.expect(membership_plan: %i[name cost billing_frequency billing_period_days description payment_link plan_type
                                       paypal_transaction_subject manual visible display_order user_id])
   end
 end

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -32,7 +32,7 @@ class OnboardingController < AdminController
         plan = MembershipPlan.create!(
           name: "Cash - #{@user.display_name}",
           cost: params[:plan_cost].to_f.positive? ? params[:plan_cost].to_f : 0,
-          billing_frequency: params[:plan_billing_frequency] || 'monthly',
+          billing_period_days: onboarding_cash_plan_billing_period_days,
           description: params[:plan_notes].presence,
           plan_type: 'primary',
           manual: true,
@@ -180,6 +180,11 @@ class OnboardingController < AdminController
     return {} unless m.present? && m.positive?
 
     { dues_due_at: Time.current + m.months }
+  end
+
+  def onboarding_cash_plan_billing_period_days
+    days = params[:plan_billing_period_days].to_i
+    days.positive? ? days : 30
   end
 
   def set_user

--- a/app/models/membership_plan.rb
+++ b/app/models/membership_plan.rb
@@ -1,5 +1,6 @@
 class MembershipPlan < ApplicationRecord
   PLAN_TYPES = %w[primary supplementary].freeze
+  BILLING_FREQUENCIES = %w[monthly yearly one-time custom_days].freeze
 
   belongs_to :user, optional: true
 
@@ -11,7 +12,9 @@ class MembershipPlan < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: true, if: -> { user_id.nil? }
   validates :cost, presence: true, numericality: { greater_than_or_equal_to: 0 }
-  validates :billing_frequency, presence: true, inclusion: { in: %w[monthly yearly one-time] }
+  validates :billing_frequency, presence: true, inclusion: { in: BILLING_FREQUENCIES }
+  validates :billing_period_days, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validates :billing_period_days, presence: true, if: :personal?
   validates :plan_type, presence: true, inclusion: { in: PLAN_TYPES }
   validates :display_order, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
   validates :payment_link,
@@ -33,10 +36,16 @@ class MembershipPlan < ApplicationRecord
 
   def display_name
     if personal?
-      "#{name} (#{user&.display_name}) - $#{format('%.2f', cost)}/#{billing_frequency}"
+      "#{name} (#{user&.display_name}) - $#{format('%.2f', cost)}/#{billing_label}"
     else
-      "#{name} - $#{format('%.2f', cost)}/#{billing_frequency}"
+      "#{name} - $#{format('%.2f', cost)}/#{billing_label}"
     end
+  end
+
+  def billing_label
+    return "#{billing_period_days} #{'day'.pluralize(billing_period_days)}" if billing_period_days.present?
+
+    billing_frequency.to_s.humanize
   end
 
   def has_payment_link?
@@ -56,6 +65,8 @@ class MembershipPlan < ApplicationRecord
   end
 
   def billing_cycle_duration
+    return billing_period_days.days if billing_period_days.present?
+
     case billing_frequency
     when 'monthly'  then 1.month
     when 'yearly'   then 1.year
@@ -74,5 +85,6 @@ class MembershipPlan < ApplicationRecord
   def enforce_personal_plan_defaults
     self.manual = true
     self.visible = false
+    self.billing_frequency = 'custom_days'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -216,11 +216,10 @@ class User < ApplicationRecord
   def self.dues_due_at_from_payment_cycle(anchor_date, plan)
     return nil if anchor_date.blank? || plan.blank?
 
-    d = case plan.billing_frequency
-        when 'monthly' then anchor_date.to_date + 1.month
-        when 'yearly' then anchor_date.to_date + 1.year
-        when 'one-time' then nil
-        end
+    duration = plan.billing_cycle_duration
+    return nil if duration.blank?
+
+    d = anchor_date.to_date + duration
     d&.in_time_zone&.beginning_of_day
   end
 

--- a/app/views/cash_payments/show.html.erb
+++ b/app/views/cash_payments/show.html.erb
@@ -25,7 +25,7 @@
       <dd class="col-sm-9">
         <span class="badge text-bg-info"><%= @cash_payment.membership_plan.name %></span>
         <span class="text-muted ms-1">
-          <%= number_to_currency(@cash_payment.membership_plan.cost) %>/<%= @cash_payment.membership_plan.billing_frequency %>
+          <%= number_to_currency(@cash_payment.membership_plan.cost) %>/<%= @cash_payment.membership_plan.billing_label %>
         </span>
       </dd>
 

--- a/app/views/membership_plans/edit.html.erb
+++ b/app/views/membership_plans/edit.html.erb
@@ -35,15 +35,32 @@
         <% end %>
       </div>
       <div class="col-md-3">
-        <%= f.label :billing_frequency, "Billing Frequency", class: "form-label" %>
-        <%= f.select :billing_frequency, 
-            options_for_select([['Monthly', 'monthly'], ['Yearly', 'yearly'], ['One-time', 'one-time']], @membership_plan.billing_frequency),
-            {},
-            { class: "form-select #{'is-invalid' if @membership_plan.errors.key?(:billing_frequency)}", required: true } %>
-        <% if @membership_plan.errors.key?(:billing_frequency) %>
-          <div class="invalid-feedback">
-            <%= @membership_plan.errors[:billing_frequency].first %>
+        <% if @membership_plan.personal? %>
+          <%= f.label :billing_period_days, "Billing Frequency", class: "form-label" %>
+          <div class="input-group">
+            <%= f.number_field :billing_period_days,
+                min: 1,
+                step: 1,
+                class: "form-control #{'is-invalid' if @membership_plan.errors.key?(:billing_period_days)}",
+                required: true %>
+            <span class="input-group-text">Days</span>
           </div>
+          <% if @membership_plan.errors.key?(:billing_period_days) %>
+            <div class="invalid-feedback d-block">
+              <%= @membership_plan.errors[:billing_period_days].first %>
+            </div>
+          <% end %>
+        <% else %>
+          <%= f.label :billing_frequency, "Billing Frequency", class: "form-label" %>
+          <%= f.select :billing_frequency,
+              options_for_select([['Monthly', 'monthly'], ['Yearly', 'yearly'], ['One-time', 'one-time']], @membership_plan.billing_frequency),
+              {},
+              { class: "form-select #{'is-invalid' if @membership_plan.errors.key?(:billing_frequency)}", required: true } %>
+          <% if @membership_plan.errors.key?(:billing_frequency) %>
+            <div class="invalid-feedback">
+              <%= @membership_plan.errors[:billing_frequency].first %>
+            </div>
+          <% end %>
         <% end %>
       </div>
       <div class="col-md-2">

--- a/app/views/membership_plans/index.html.erb
+++ b/app/views/membership_plans/index.html.erb
@@ -100,7 +100,7 @@
                   <% else %>
                     <span class="badge text-bg-info">Supplementary</span>
                   <% end %>
-                  <span class="text-muted">$<%= format('%.2f', plan.cost) %>/<%= plan.billing_frequency %></span>
+                  <span class="text-muted">$<%= format('%.2f', plan.cost) %>/<%= plan.billing_label %></span>
                   <% member_count = plan.primary? ? plan.users.count : plan.supplementary_users.count %>
                   <span class="badge text-bg-secondary"><%= member_count %> member<%= member_count == 1 ? '' : 's' %></span>
                   <% if plan.manual? %>
@@ -135,7 +135,7 @@
                       <dd class="col-sm-8">$<%= format('%.2f', plan.cost) %></dd>
                       
                       <dt class="col-sm-4">Frequency</dt>
-                      <dd class="col-sm-8"><span class="badge text-bg-secondary"><%= plan.billing_frequency.humanize %></span></dd>
+                      <dd class="col-sm-8"><span class="badge text-bg-secondary"><%= plan.billing_label %></span></dd>
                       
                       <dt class="col-sm-4">Payment Link</dt>
                       <dd class="col-sm-8">
@@ -293,10 +293,19 @@
           <% end %>
         </div>
         <div class="col-md-2">
-          <%= f.select :billing_frequency,
-              options_for_select([['Monthly', 'monthly'], ['Yearly', 'yearly'], ['One-time', 'one-time']], @personal_plan&.billing_frequency),
-              { prompt: 'Frequency' },
-              { class: "form-select", required: true } %>
+          <%= f.label :billing_period_days, "Billing Frequency", class: "form-label" %>
+          <div class="input-group">
+            <%= f.number_field :billing_period_days,
+                value: @personal_plan&.billing_period_days,
+                min: 1,
+                step: 1,
+                class: "form-control #{'is-invalid' if @personal_plan&.errors&.key?(:billing_period_days)}",
+                required: true %>
+            <span class="input-group-text">Days</span>
+          </div>
+          <% if @personal_plan&.errors&.key?(:billing_period_days) %>
+            <div class="invalid-feedback d-block"><%= @personal_plan.errors[:billing_period_days].first %></div>
+          <% end %>
         </div>
         <div class="col-md-8">
           <%= f.text_area :description, class: "form-control", placeholder: "Description / notes about this arrangement (e.g., Donated CNC router, covers 12 months)", rows: 2 %>
@@ -331,7 +340,7 @@
                 </td>
                 <td><%= plan.name %></td>
                 <td><strong>$<%= format('%.2f', plan.cost) %></strong></td>
-                <td><span class="badge text-bg-secondary"><%= plan.billing_frequency.humanize %></span></td>
+                <td><span class="badge text-bg-secondary"><%= plan.billing_label %></span></td>
                 <td>
                   <% if plan.description.present? %>
                     <span class="text-muted small"><%= truncate(plan.description, length: 80) %></span>

--- a/app/views/membership_plans/manual_payments.html.erb
+++ b/app/views/membership_plans/manual_payments.html.erb
@@ -41,7 +41,7 @@
               </td>
               <td>
                 <strong>$<%= format('%.2f', plan.cost) %></strong>
-                <span class="text-muted">/ <%= plan.billing_frequency %></span>
+                <span class="text-muted">/ <%= plan.billing_label %></span>
               </td>
               <td>
                 <% dues_badge = case user.dues_status

--- a/app/views/membership_plans/show.html.erb
+++ b/app/views/membership_plans/show.html.erb
@@ -31,12 +31,12 @@
           <dt class="col-sm-4">Cost</dt>
           <dd class="col-sm-8">
             <span class="fs-4 fw-bold text-primary">$<%= format('%.2f', @membership_plan.cost) %></span>
-            <span class="text-muted">/ <%= @membership_plan.billing_frequency %></span>
+            <span class="text-muted">/ <%= @membership_plan.billing_label %></span>
           </dd>
 
           <dt class="col-sm-4">Billing Frequency</dt>
           <dd class="col-sm-8">
-            <span class="badge text-bg-secondary fs-6"><%= @membership_plan.billing_frequency.humanize %></span>
+            <span class="badge text-bg-secondary fs-6"><%= @membership_plan.billing_label %></span>
           </dd>
 
           <% if @membership_plan.description.present? %>
@@ -114,7 +114,7 @@
                       <strong>$<%= format('%.2f', plan.cost) %></strong>
                     </td>
                     <td>
-                      <span class="badge text-bg-secondary"><%= plan.billing_frequency.humanize %></span>
+                      <span class="badge text-bg-secondary"><%= plan.billing_label %></span>
                     </td>
                     <td class="text-end">
                       <% if plan.payment_link.present? %>
@@ -139,7 +139,7 @@
         <div class="display-4 text-primary mb-2">
           $<%= format('%.2f', @membership_plan.cost) %>
         </div>
-        <p class="text-muted mb-3">per <%= @membership_plan.billing_frequency %></p>
+        <p class="text-muted mb-3">per <%= @membership_plan.billing_label %></p>
         
         <% if @membership_plan.payment_link.present? %>
           <%= link_to @membership_plan.payment_link, class: "btn btn-primary btn-lg w-100", target: "_blank", rel: "noopener" do %>

--- a/app/views/onboarding/payment.html.erb
+++ b/app/views/onboarding/payment.html.erb
@@ -91,11 +91,10 @@
                   </div>
                   <div class="col-md-4">
                     <label class="form-label">Billing Frequency</label>
-                    <select name="plan_billing_frequency" class="form-select">
-                      <option value="monthly">Monthly</option>
-                      <option value="yearly">Yearly</option>
-                      <option value="one-time">One-time</option>
-                    </select>
+                    <div class="input-group">
+                      <input type="number" name="plan_billing_period_days" class="form-control" min="1" step="1" value="30">
+                      <span class="input-group-text">Days</span>
+                    </div>
                   </div>
                   <div class="col-md-4">
                     <label class="form-label">Notes</label>

--- a/app/views/users/_member_membership_card.html.erb
+++ b/app/views/users/_member_membership_card.html.erb
@@ -28,7 +28,7 @@
   <div class="text-14 fw-medium"><%= plan_name %></div>
   <div class="text-12 text-secondary mb-3">
     <% if plan.present? %>
-      $<%= format('%.2f', plan.cost) %> / <%= plan.billing_frequency %> · <%= payment_method %>
+      $<%= format('%.2f', plan.cost) %> / <%= plan.billing_label %> · <%= payment_method %>
     <% else %>
       <%= payment_method %>
     <% end %>

--- a/app/views/users/_status_panel.html.erb
+++ b/app/views/users/_status_panel.html.erb
@@ -77,7 +77,7 @@
                 <strong><%= link_to user.membership_plan.name, membership_plan_path(user.membership_plan), class: "text-decoration-none" %></strong>
                 <span class="badge text-bg-primary ms-1">Primary</span>
                 <br>
-                <span class="text-muted">$<%= format('%.2f', user.membership_plan.cost) %>/<%= user.membership_plan.billing_frequency %></span>
+                <span class="text-muted">$<%= format('%.2f', user.membership_plan.cost) %>/<%= user.membership_plan.billing_label %></span>
               </div>
             <% end %>
             <% user.supplementary_plans.order(:name).each do |plan| %>
@@ -85,7 +85,7 @@
                 <strong><%= link_to plan.name, membership_plan_path(plan), class: "text-decoration-none" %></strong>
                 <span class="badge text-bg-info ms-1">Supplementary</span>
                 <br>
-                <span class="text-muted">$<%= format('%.2f', plan.cost) %>/<%= plan.billing_frequency %></span>
+                <span class="text-muted">$<%= format('%.2f', plan.cost) %>/<%= plan.billing_label %></span>
               </div>
             <% end %>
           </div>
@@ -172,7 +172,7 @@
                 <% plans_with_links.each do |plan| %>
                   <%= link_to plan.payment_link, class: "btn btn-outline-primary btn-sm", target: "_blank", rel: "noopener" do %>
                     <i class="bi bi-credit-card me-1"></i>
-                    <%= plan.name %> - $<%= format('%.2f', plan.cost) %>/<%= plan.billing_frequency %>
+                    <%= plan.name %> - $<%= format('%.2f', plan.cost) %>/<%= plan.billing_label %>
                   <% end %>
                 <% end %>
               </div>

--- a/db/migrate/20260515095300_add_billing_period_days_to_membership_plans.rb
+++ b/db/migrate/20260515095300_add_billing_period_days_to_membership_plans.rb
@@ -1,0 +1,19 @@
+class AddBillingPeriodDaysToMembershipPlans < ActiveRecord::Migration[8.1]
+  def up
+    add_column :membership_plans, :billing_period_days, :integer
+
+    execute <<~SQL.squish
+      UPDATE membership_plans
+      SET billing_period_days = CASE billing_frequency
+        WHEN 'yearly' THEN 365
+        ELSE 30
+      END,
+      billing_frequency = 'custom_days'
+      WHERE user_id IS NOT NULL
+    SQL
+  end
+
+  def down
+    remove_column :membership_plans, :billing_period_days
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_15_075600) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_15_095300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -565,6 +565,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_15_075600) do
 
   create_table "membership_plans", force: :cascade do |t|
     t.string "billing_frequency", null: false
+    t.integer "billing_period_days"
     t.decimal "cost", precision: 10, scale: 2, null: false
     t.datetime "created_at", null: false
     t.text "description"

--- a/test/controllers/cash_payments_controller_test.rb
+++ b/test/controllers/cash_payments_controller_test.rb
@@ -55,7 +55,7 @@ class CashPaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'current', @user.dues_status
     assert_equal 'cash', @user.payment_type
     assert @user.dues_due_at.present?
-    assert_equal Date.current + 1.month, @user.dues_due_at.to_date
+    assert_equal Date.current + @plan.billing_period_days.days, @user.dues_due_at.to_date
   end
 
   test 'create sets payment due date when none is recorded' do
@@ -65,7 +65,7 @@ class CashPaymentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to cash_payment_path(CashPayment.last)
     @user.reload
-    assert_equal Date.current + 1.month, @user.dues_due_at.to_date
+    assert_equal Date.current + @plan.billing_period_days.days, @user.dues_due_at.to_date
   end
 
   test 'create advances payment due date when calculated date is later' do
@@ -75,7 +75,7 @@ class CashPaymentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to cash_payment_path(CashPayment.last)
     @user.reload
-    assert_equal Date.current + 1.month, @user.dues_due_at.to_date
+    assert_equal Date.current + @plan.billing_period_days.days, @user.dues_due_at.to_date
   end
 
   test 'create does not move payment due date earlier' do
@@ -163,7 +163,7 @@ class CashPaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to cash_payment_path(payment)
     @user.reload
     assert_equal 2.months.ago.to_date, @user.last_payment_date
-    assert_equal 1.month.ago.to_date, @user.dues_due_at.to_date
+    assert_equal 2.months.ago.to_date + @plan.billing_period_days.days, @user.dues_due_at.to_date
     assert_equal 'lapsed', @user.dues_status
     assert_not @user.active?
   end
@@ -195,7 +195,7 @@ class CashPaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to cash_payment_path(older_payment)
     @user.reload
     assert_equal latest_paid_on, @user.last_payment_date
-    assert_equal latest_paid_on + 1.month, @user.dues_due_at.to_date
+    assert_equal latest_paid_on + @plan.billing_period_days.days, @user.dues_due_at.to_date
     assert_equal 'current', @user.dues_status
     assert @user.active?
   end

--- a/test/controllers/membership_plans_controller_test.rb
+++ b/test/controllers/membership_plans_controller_test.rb
@@ -18,7 +18,51 @@ class MembershipPlansControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to manual_payments_membership_plans_path
     @user.reload
     assert_equal 'current', @user.dues_status
-    assert_equal Date.current + 1.month, @user.dues_due_at.to_date
+    assert_equal Date.current + @user.membership_plan.billing_period_days.days, @user.dues_due_at.to_date
+  end
+
+  test 'personal plan edit form uses billing period days field' do
+    plan = membership_plans(:personal_equipment_donation)
+
+    get edit_membership_plan_path(plan)
+
+    assert_response :success
+    assert_select 'input[name=?][value=?]', 'membership_plan[billing_period_days]', plan.billing_period_days.to_s
+    assert_select '.input-group-text', text: 'Days'
+    assert_select 'select[name=?]', 'membership_plan[billing_frequency]', count: 0
+  end
+
+  test 'creates personal plan with billing period days' do
+    assert_difference('MembershipPlan.personal.count', 1) do
+      post membership_plans_path, params: {
+        membership_plan: {
+          user_id: users(:one).id,
+          name: 'Custom Days Plan',
+          cost: '75.00',
+          billing_period_days: '45',
+          plan_type: 'primary',
+          display_order: '1'
+        }
+      }
+    end
+
+    assert_redirected_to membership_plans_path(anchor: 'personal-plans')
+    plan = MembershipPlan.find_by!(name: 'Custom Days Plan')
+    assert_equal 45, plan.billing_period_days
+    assert_equal 'custom_days', plan.billing_frequency
+  end
+
+  test 'updates personal plan billing period days' do
+    plan = membership_plans(:personal_equipment_donation)
+
+    patch membership_plan_path(plan), params: {
+      membership_plan: {
+        billing_period_days: '45'
+      }
+    }
+
+    assert_redirected_to membership_plans_path
+    assert_equal 45, plan.reload.billing_period_days
   end
 
   private

--- a/test/fixtures/membership_plans.yml
+++ b/test/fixtures/membership_plans.yml
@@ -25,7 +25,8 @@ supplementary_storage:
 personal_equipment_donation:
   name: Equipment Donation
   cost: 100.00
-  billing_frequency: monthly
+  billing_frequency: custom_days
+  billing_period_days: 30
   plan_type: primary
   visible: false
   manual: true

--- a/test/models/membership_plan_test.rb
+++ b/test/models/membership_plan_test.rb
@@ -24,7 +24,7 @@ class MembershipPlanTest < ActiveSupport::TestCase
   test 'personal plan enforces manual true' do
     user = users(:cash_payer)
     plan = MembershipPlan.new(
-      name: 'Test Personal', cost: 50, billing_frequency: 'monthly',
+      name: 'Test Personal', cost: 50, billing_period_days: 30,
       plan_type: 'primary', user: user, manual: false, visible: true, display_order: 1
     )
     plan.valid?
@@ -35,7 +35,7 @@ class MembershipPlanTest < ActiveSupport::TestCase
   test 'personal plan enforces visible false' do
     user = users(:cash_payer)
     plan = MembershipPlan.new(
-      name: 'Test Personal Visible', cost: 50, billing_frequency: 'monthly',
+      name: 'Test Personal Visible', cost: 50, billing_period_days: 30,
       plan_type: 'primary', user: user, visible: true, display_order: 1
     )
     plan.valid?
@@ -56,7 +56,7 @@ class MembershipPlanTest < ActiveSupport::TestCase
     user = users(:cash_payer)
     existing = membership_plans(:monthly_standard)
     plan = MembershipPlan.new(
-      name: existing.name, cost: 99, billing_frequency: 'monthly',
+      name: existing.name, cost: 99, billing_period_days: 30,
       plan_type: 'primary', user: user, display_order: 1
     )
     assert plan.valid?, plan.errors.full_messages.join(', ')
@@ -65,7 +65,7 @@ class MembershipPlanTest < ActiveSupport::TestCase
   test 'personal plans can share names with other personal plans' do
     user = users(:one)
     plan = MembershipPlan.new(
-      name: 'Equipment Donation', cost: 50, billing_frequency: 'monthly',
+      name: 'Equipment Donation', cost: 50, billing_period_days: 30,
       plan_type: 'primary', user: user, display_order: 1
     )
     assert plan.valid?, plan.errors.full_messages.join(', ')
@@ -81,5 +81,24 @@ class MembershipPlanTest < ActiveSupport::TestCase
     plan = membership_plans(:monthly_standard)
     assert_includes plan.display_name, plan.name
     assert_includes plan.display_name, format('%.2f', plan.cost)
+  end
+
+  test 'personal plan requires billing period days' do
+    plan = MembershipPlan.new(
+      name: 'Missing Days',
+      cost: 50,
+      plan_type: 'primary',
+      user: users(:cash_payer)
+    )
+
+    assert_not plan.valid?
+    assert_includes plan.errors[:billing_period_days], "can't be blank"
+  end
+
+  test 'personal plan billing cycle uses configured days' do
+    plan = membership_plans(:personal_equipment_donation)
+
+    assert_equal 30.days, plan.billing_cycle_duration
+    assert_equal '30 days', plan.billing_label
   end
 end

--- a/test/models/user_dues_due_at_test.rb
+++ b/test/models/user_dues_due_at_test.rb
@@ -15,6 +15,13 @@ class UserDuesDueAtTest < ActiveSupport::TestCase
     assert_equal Time.zone.local(2026, 1, 15, 0, 0, 0), at
   end
 
+  test 'dues_due_at_from_payment_cycle custom days' do
+    anchor = Date.new(2025, 1, 15)
+    plan = membership_plans(:personal_equipment_donation)
+    at = User.dues_due_at_from_payment_cycle(anchor, plan)
+    assert_equal Time.zone.local(2025, 2, 14, 0, 0, 0), at
+  end
+
   test 'dues_due_at_from_payment_cycle one-time returns nil' do
     plan = MembershipPlan.create!(
       name: "One-shot #{SecureRandom.hex(4)}",


### PR DESCRIPTION
Replace custom plan billing frequency choices with day counts and calculate cash payment due dates from that interval.