### PR TITLE
Improve parking permit creation flow

### DIFF
--- a/app/controllers/parking_notices_controller.rb
+++ b/app/controllers/parking_notices_controller.rb
@@ -29,6 +29,7 @@ class ParkingNoticesController < AdminController
       notice_type: params[:type].presence || 'permit',
       expires_at: 7.days.from_now
     )
+    @parking_notice.assign_attributes(parking_notice_prefill_params) if params[:parking_notice].present?
     load_form_data
   end
 
@@ -46,6 +47,12 @@ class ParkingNoticesController < AdminController
 
       @parking_notice.record_journal_entry!(journal_action, actor: current_user)
       @parking_notice.enqueue_notification!(template_key)
+
+      if create_another_permit?
+        redirect_to new_parking_notice_path(type: 'permit', parking_notice: parking_notice_prefill_params),
+                    notice: 'Parking permit created successfully.'
+        return
+      end
 
       redirect_to parking_notice_path(@parking_notice),
                   notice: "Parking #{@parking_notice.notice_type} created successfully."
@@ -151,5 +158,15 @@ class ParkingNoticesController < AdminController
       parking_notice: [:notice_type, :user_id, :description, :location,
                        :location_detail, :expires_at, :notes, { photos: [] }]
     )
+  end
+
+  def parking_notice_prefill_params
+    params.expect(
+      parking_notice: %i[user_id description expires_at location location_detail]
+    )
+  end
+
+  def create_another_permit?
+    @parking_notice.permit? && params[:create_another_permit].present?
   end
 end

--- a/app/views/member_parking_permits/new.html.erb
+++ b/app/views/member_parking_permits/new.html.erb
@@ -35,6 +35,7 @@
 
       <div class="mt-3 mb-4">
         <%= f.label :expires_at, 'Expiration', class: 'form-label' %>
+        <%= render 'parking_notices/expiration_quick_buttons' %>
         <%= f.datetime_local_field :expires_at,
                                    class: 'form-control',
                                    required: true,
@@ -48,3 +49,34 @@
     <% end %>
   </div>
 </div>
+
+<script>
+  (function() {
+    function initMemberParkingPermitForm() {
+      var expiresField = document.querySelector('input[name="parking_notice[expires_at]"]');
+
+      if (!expiresField) return;
+
+      document.querySelectorAll('.quick-expire').forEach(function(btn) {
+        if (btn.dataset.quickExpireBound === 'true') return;
+        btn.dataset.quickExpireBound = 'true';
+
+        btn.addEventListener('click', function() {
+          var date = new Date();
+          if (this.dataset.years) {
+            date.setFullYear(date.getFullYear() + parseInt(this.dataset.years, 10));
+          } else {
+            date.setDate(date.getDate() + parseInt(this.dataset.days, 10));
+          }
+          date.setHours(17, 0, 0, 0);
+          var pad = function(n) { return n < 10 ? '0' + n : n; };
+          expiresField.value = date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' +
+                               pad(date.getDate()) + 'T' + pad(date.getHours()) + ':' + pad(date.getMinutes());
+        });
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', initMemberParkingPermitForm);
+    document.addEventListener('turbo:load', initMemberParkingPermitForm);
+  })();
+</script>

--- a/app/views/parking_notices/_expiration_quick_buttons.html.erb
+++ b/app/views/parking_notices/_expiration_quick_buttons.html.erb
@@ -1,0 +1,9 @@
+<div class="d-flex flex-wrap gap-2 mb-2">
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="1">1 day</button>
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="3">3 days</button>
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="7">1 week</button>
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="14">2 weeks</button>
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="30">30 days</button>
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="180">180 days</button>
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-years="1">1 year</button>
+</div>

--- a/app/views/parking_notices/_form.html.erb
+++ b/app/views/parking_notices/_form.html.erb
@@ -81,12 +81,7 @@
       <div class="mb-3">
         <%= f.label :expires_at, 'Expiration', class: 'form-label' %>
         <span class="text-danger">*</span>
-        <div class="d-flex flex-wrap gap-2 mb-2">
-          <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="1">1 Day</button>
-          <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="3">3 Days</button>
-          <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="7">1 Week</button>
-          <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="10">10 Days</button>
-        </div>
+        <%= render 'parking_notices/expiration_quick_buttons' %>
         <%= f.datetime_local_field :expires_at, class: 'form-control', required: true,
             value: parking_notice.expires_at&.strftime('%Y-%m-%dT%H:%M') %>
       </div>
@@ -150,6 +145,11 @@
     <% label = parking_notice.persisted? ? "Update" : "Create" %>
     <%= f.submit "#{label} Parking #{parking_notice.notice_type_display}",
         class: "btn btn-#{parking_notice.permit? ? 'success' : 'danger'}" %>
+    <% if parking_notice.new_record? && parking_notice.permit? %>
+      <%= f.submit 'Save and Create Another Permit',
+          name: 'create_another_permit',
+          class: 'btn btn-outline-secondary' %>
+    <% end %>
     <%= link_to "Cancel", parking_notice.persisted? ? parking_notice_path(parking_notice) : parking_notices_path, class: "btn btn-outline-secondary" %>
   </div>
 <% end %>
@@ -163,10 +163,16 @@
       if (!expiresField) return;
 
       document.querySelectorAll('.quick-expire').forEach(function(btn) {
+        if (btn.dataset.quickExpireBound === 'true') return;
+        btn.dataset.quickExpireBound = 'true';
+
         btn.addEventListener('click', function() {
-          var days = parseInt(this.dataset.days);
           var date = new Date();
-          date.setDate(date.getDate() + days);
+          if (this.dataset.years) {
+            date.setFullYear(date.getFullYear() + parseInt(this.dataset.years, 10));
+          } else {
+            date.setDate(date.getDate() + parseInt(this.dataset.days, 10));
+          }
           date.setHours(17, 0, 0, 0);
           var pad = function(n) { return n < 10 ? '0' + n : n; };
           expiresField.value = date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' +

--- a/test/controllers/member_parking_permits_controller_test.rb
+++ b/test/controllers/member_parking_permits_controller_test.rb
@@ -16,6 +16,7 @@ class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
     get new_member_parking_permit_path
     assert_response :success
     assert_match(/New Parking Permit/i, response.body)
+    assert_expiration_quick_buttons
   end
 
   test 'member can create own parking permit' do
@@ -52,5 +53,16 @@ class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
     post local_login_path, params: {
       session: { email: local_accounts(:regular_member).email, password: 'memberpassword123' }
     }
+  end
+
+  def assert_expiration_quick_buttons
+    assert_select '.quick-expire', 7
+    assert_select '.quick-expire[data-days="1"]', text: '1 day'
+    assert_select '.quick-expire[data-days="3"]', text: '3 days'
+    assert_select '.quick-expire[data-days="7"]', text: '1 week'
+    assert_select '.quick-expire[data-days="14"]', text: '2 weeks'
+    assert_select '.quick-expire[data-days="30"]', text: '30 days'
+    assert_select '.quick-expire[data-days="180"]', text: '180 days'
+    assert_select '.quick-expire[data-years="1"]', text: '1 year'
   end
 end

--- a/test/controllers/parking_notices_controller_test.rb
+++ b/test/controllers/parking_notices_controller_test.rb
@@ -44,6 +44,31 @@ class ParkingNoticesControllerTest < ActionDispatch::IntegrationTest
     get new_parking_notice_url(type: 'permit')
     assert_response :success
     assert_select 'input[name="parking_notice[notice_type]"][value="permit"]'
+    assert_select 'input[name="create_another_permit"][value="Save and Create Another Permit"]'
+    assert_expiration_quick_buttons
+  end
+
+  test 'new pre-fills permit form from params' do
+    user = users(:one)
+
+    get new_parking_notice_url(
+      type: 'permit',
+      parking_notice: {
+        user_id: user.id,
+        description: 'Repeat permit',
+        expires_at: '2026-06-01T17:00',
+        location: 'Woodshop',
+        location_detail: 'South wall shelf'
+      }
+    )
+
+    assert_response :success
+    assert_select 'input[name="parking_notice[user_id]"][value=?]', user.id.to_s
+    assert_select 'input#pn_member_search[value=?]', user.display_name
+    assert_select 'textarea[name="parking_notice[description]"]', text: 'Repeat permit'
+    assert_select 'input[name="parking_notice[expires_at]"][value="2026-06-01T17:00"]'
+    assert_select 'input[name="parking_notice[location]"][value="Woodshop"]'
+    assert_select 'input[name="parking_notice[location_detail]"][value="South wall shelf"]'
   end
 
   test 'member search includes email and username fields' do
@@ -60,6 +85,8 @@ class ParkingNoticesControllerTest < ActionDispatch::IntegrationTest
     get new_parking_notice_url(type: 'ticket')
     assert_response :success
     assert_select 'input[name="parking_notice[notice_type]"][value="ticket"]'
+    assert_select 'input[name="create_another_permit"]', false
+    assert_expiration_quick_buttons
   end
 
   # --- Create ---
@@ -78,6 +105,36 @@ class ParkingNoticesControllerTest < ActionDispatch::IntegrationTest
       }
     end
     assert_redirected_to parking_notice_path(ParkingNotice.last)
+  end
+
+  test 'create can save and start another permit with matching fields' do
+    user = users(:one)
+    expires_at = '2026-06-01T17:00'
+
+    assert_difference 'ParkingNotice.count', 1 do
+      post parking_notices_url, params: {
+        create_another_permit: 'Save and Create Another Permit',
+        parking_notice: {
+          notice_type: 'permit',
+          user_id: user.id,
+          description: 'Repeat permit',
+          expires_at: expires_at,
+          location: 'Woodshop',
+          location_detail: 'South wall shelf'
+        }
+      }
+    end
+
+    location = URI.parse(response.location)
+    redirect_params = Rack::Utils.parse_nested_query(location.query)
+
+    assert_equal new_parking_notice_path, location.path
+    assert_equal 'permit', redirect_params['type']
+    assert_equal user.id.to_s, redirect_params.dig('parking_notice', 'user_id')
+    assert_equal 'Repeat permit', redirect_params.dig('parking_notice', 'description')
+    assert_equal expires_at, redirect_params.dig('parking_notice', 'expires_at')
+    assert_equal 'Woodshop', redirect_params.dig('parking_notice', 'location')
+    assert_equal 'South wall shelf', redirect_params.dig('parking_notice', 'location_detail')
   end
 
   test 'create saves a ticket without user' do
@@ -146,5 +203,16 @@ class ParkingNoticesControllerTest < ActionDispatch::IntegrationTest
       session: { email: 'admin@example.com', password: 'localpassword123' }
     }
     User.find_by('authentik_id LIKE ?', 'local:%')&.tap { |u| u.update!(is_admin: true) }
+  end
+
+  def assert_expiration_quick_buttons
+    assert_select '.quick-expire', 7
+    assert_select '.quick-expire[data-days="1"]', text: '1 day'
+    assert_select '.quick-expire[data-days="3"]', text: '3 days'
+    assert_select '.quick-expire[data-days="7"]', text: '1 week'
+    assert_select '.quick-expire[data-days="14"]', text: '2 weeks'
+    assert_select '.quick-expire[data-days="30"]', text: '30 days'
+    assert_select '.quick-expire[data-days="180"]', text: '180 days'
+    assert_select '.quick-expire[data-years="1"]', text: '1 year'
   end
 end


### PR DESCRIPTION
Add reusable expiration quick-select options and let admins save a permit while starting another with matching form details.