### PR TITLE
Improve SMTP health detection after delivery failures.

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -16,6 +16,7 @@ class ApplicationMailer < ActionMailer::Base
     yield
     log_direct_mail_delivery!('sent')
   rescue StandardError => e
+    MailerDeliveryMonitor.record_failure!(e, source: "#{self.class.name}##{action_name}")
     log_direct_mail_delivery!('send_failed', details: "#{e.class}: #{e.message}")
     raise
   end

--- a/app/models/queued_mail.rb
+++ b/app/models/queued_mail.rb
@@ -204,6 +204,7 @@ class QueuedMail < ApplicationRecord
   end
 
   def record_delivery_failure!(error)
+    MailerDeliveryMonitor.record_failure!(error, source: "QueuedMail##{id}")
     error_message = "#{error.class}: #{error.message}"
     update!(last_error: error_message, last_error_at: Time.current)
     MailLogEntry.log_once!(self, 'send_failed', details: error_message)

--- a/app/services/mailer_delivery_monitor.rb
+++ b/app/services/mailer_delivery_monitor.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Tracks recent Action Mailer delivery failures so health checks and the admin
+# dashboard can reflect SMTP problems even when a cached connection probe succeeded.
+class MailerDeliveryMonitor
+  FAILURES_KEY = 'mailer_delivery_monitor:failures:v1'
+  FAILURE_WINDOW = 15.minutes
+  MAX_FAILURES = 20
+
+  def self.record_failure!(error, source: nil)
+    Rails.cache.delete(MailerHealthCheck::CACHE_KEY)
+
+    failures = read_failures
+    failures << {
+      'at' => Time.current.iso8601(6),
+      'error_class' => error.class.name,
+      'message' => error.message.to_s,
+      'source' => source.to_s.presence
+    }
+    failures = failures.last(MAX_FAILURES)
+    Rails.cache.write(FAILURES_KEY, failures, expires_in: 1.day)
+
+    Rails.logger.warn(
+      "[MailerDeliveryMonitor] delivery failed source=#{source || 'unknown'} " \
+      "#{error.class}: #{error.message}"
+    )
+  end
+
+  def self.unhealthy_result
+    recent = recent_failures
+    return nil if recent.empty?
+
+    MailerHealthCheck::Result.new('unhealthy', failure_summary(recent), Time.current)
+  end
+
+  def self.recent_failures(within: FAILURE_WINDOW)
+    cutoff = Time.current - within
+    read_failures.filter_map do |entry|
+      at = Time.zone.parse(entry['at'].to_s)
+      next if at.nil? || at < cutoff
+
+      entry
+    end
+  end
+
+  def self.read_failures
+    Array(Rails.cache.read(FAILURES_KEY))
+  end
+  private_class_method :read_failures
+
+  def self.failure_summary(recent)
+    latest = recent.last
+    count = recent.size
+    detail = "#{latest['error_class']}: #{latest['message']}"
+    detail = detail.truncate(240)
+
+    if count == 1
+      "Recent mail delivery failed (#{detail})"
+    else
+      "#{count} mail deliveries failed in the last #{FAILURE_WINDOW.in_minutes.to_i} minutes " \
+        "(latest: #{detail})"
+    end
+  end
+  private_class_method :failure_summary
+end

--- a/app/services/mailer_health_check.rb
+++ b/app/services/mailer_health_check.rb
@@ -2,7 +2,7 @@ require 'net/smtp'
 require 'openssl'
 
 class MailerHealthCheck
-  CACHE_KEY = 'mailer_health_check:v4'.freeze
+  CACHE_KEY = 'mailer_health_check:v5'.freeze
   CACHE_TTL = 5.minutes
   DEFAULT_TIMEOUT = 5
 
@@ -11,6 +11,9 @@ class MailerHealthCheck
   end
 
   def self.call(force: false)
+    recent_failure = MailerDeliveryMonitor.unhealthy_result
+    return recent_failure if recent_failure
+
     return new.call if force
 
     Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) { new.call }
@@ -26,6 +29,8 @@ class MailerHealthCheck
     healthy(success_message)
   rescue Net::SMTPAuthenticationError => e
     unhealthy("SMTP authentication failed: #{e.message}")
+  rescue Net::SMTPServerBusy, Net::SMTPFatalError, Net::SMTPUnknownError, Net::SMTPUnsupportedCommand => e
+    unhealthy("SMTP rejected the health check: #{e.message}")
   rescue Net::OpenTimeout, Net::ReadTimeout
     unhealthy("SMTP connection timed out connecting to #{settings[:address]}:#{settings[:port] || 25}")
   rescue SocketError, SystemCallError, IOError, OpenSSL::SSL::SSLError, Net::SMTPError => e
@@ -42,7 +47,27 @@ class MailerHealthCheck
     smtp.start(settings[:domain].presence || 'localhost',
                settings[:user_name],
                settings[:password],
-               authentication_for_start) { true }
+               authentication_for_start) do |client|
+      verify_mail_transaction!(client) unless skip_transaction_check?
+    end
+  end
+
+  def verify_mail_transaction!(client)
+    client.mailfrom(from_addr: mail_from_address)
+    client.rcptto(to_addr: rcpt_probe_address)
+    client.rset
+  end
+
+  def mail_from_address
+    ENV.fetch('EMAIL_FROM_ADDRESS', 'noreply@example.com').to_s.strip
+  end
+
+  def rcpt_probe_address
+    ENV.fetch('SMTP_HEALTH_CHECK_RCPT_TO', mail_from_address).to_s.strip
+  end
+
+  def skip_transaction_check?
+    ENV.fetch('SMTP_HEALTH_CHECK_SKIP_TRANSACTION', 'false') == 'true'
   end
 
   def configure_tls(smtp)
@@ -83,8 +108,9 @@ class MailerHealthCheck
 
   def success_message
     action = authenticated? ? 'Connected and authenticated' : 'Connected'
+    transaction = skip_transaction_check? ? '' : ', verified MAIL FROM/RCPT TO'
 
-    "#{action} to #{settings[:address]}:#{settings[:port] || 25}"
+    "#{action} to #{settings[:address]}:#{settings[:port] || 25}#{transaction}"
   end
 
   def timeout

--- a/env.example
+++ b/env.example
@@ -74,3 +74,7 @@ SMTP_PASSWORD=your-smtp-password
 SMTP_AUTHENTICATION=plain
 # Set false for unauthenticated local port 25 relays.
 SMTP_ENABLE_STARTTLS=true
+# Optional: recipient used by the admin dashboard SMTP health check (defaults to EMAIL_FROM_ADDRESS).
+# SMTP_HEALTH_CHECK_RCPT_TO=healthcheck@example.com
+# Optional: skip MAIL FROM/RCPT TO probe when your relay rejects synthetic recipients.
+# SMTP_HEALTH_CHECK_SKIP_TRANSACTION=false

--- a/test/mailers/member_mailer_test.rb
+++ b/test/mailers/member_mailer_test.rb
@@ -34,6 +34,9 @@ class MemberMailerTest < ActionMailer::TestCase
   end
 
   test 'application email verification logs failed delivery instead of sent when delivery raises' do
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
+    Rails.cache.clear
     ActionMailer::Base.add_delivery_method :member_manager_failure, FailingDelivery
     original_delivery_method = ActionMailer::Base.delivery_method
     ActionMailer::Base.delivery_method = :member_manager_failure
@@ -61,7 +64,10 @@ class MemberMailerTest < ActionMailer::TestCase
     assert_equal 'applicant@example.com', entry.delivery_to
     assert_match(/smtp down/, entry.details)
     assert_includes entry.delivery_body_html, 'https://example.com/verify'
+    assert_equal 1, MailerDeliveryMonitor.recent_failures.size
+    assert_match(/smtp down/, MailerDeliveryMonitor.recent_failures.last['message'])
   ensure
+    Rails.cache = original_cache if defined?(original_cache)
     ActionMailer::Base.delivery_method = original_delivery_method if defined?(original_delivery_method)
   end
 end

--- a/test/models/queued_mail_test.rb
+++ b/test/models/queued_mail_test.rb
@@ -157,6 +157,22 @@ class QueuedMailTest < ActiveSupport::TestCase
     assert_equal @pending.body_text, entry.message_body_text
   end
 
+  test 'record_delivery_failure registers monitor failure and does not mark sent' do
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
+    Rails.cache.clear
+    @pending.update!(status: 'approved')
+
+    assert_no_changes -> { @pending.reload.sent_at } do
+      @pending.record_delivery_failure!(RuntimeError.new('smtp down'))
+    end
+
+    assert_equal 1, MailerDeliveryMonitor.recent_failures.size
+    assert_match(/smtp down/, MailerDeliveryMonitor.recent_failures.last['message'])
+  ensure
+    Rails.cache = original_cache if defined?(original_cache)
+  end
+
   # ─── Reject ──────────────────────────────────────────────────────
 
   test 'reject! sets status without sending mail' do

--- a/test/services/mailer_delivery_monitor_test.rb
+++ b/test/services/mailer_delivery_monitor_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MailerDeliveryMonitorTest < ActiveSupport::TestCase
+  setup do
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
+    Rails.cache.clear
+  end
+
+  teardown do
+    Rails.cache.clear
+    Rails.cache = @original_cache
+  end
+
+  test 'record_failure! invalidates cached health check and stores recent failure' do
+    Rails.cache.write(MailerHealthCheck::CACHE_KEY, 'cached healthy result', expires_in: 5.minutes)
+
+    MailerDeliveryMonitor.record_failure!(RuntimeError.new('smtp down'), source: 'MemberMailer#welcome')
+
+    assert_nil Rails.cache.read(MailerHealthCheck::CACHE_KEY)
+    assert_equal 1, MailerDeliveryMonitor.recent_failures.size
+    assert_equal 'RuntimeError', MailerDeliveryMonitor.recent_failures.last['error_class']
+    assert_equal 'MemberMailer#welcome', MailerDeliveryMonitor.recent_failures.last['source']
+  end
+
+  test 'unhealthy_result summarizes recent failures' do
+    travel_to Time.zone.parse('2026-05-27 12:00:00') do
+      MailerDeliveryMonitor.record_failure!(Net::SMTPFatalError.new('550 relay denied'))
+      MailerDeliveryMonitor.record_failure!(Net::OpenTimeout.new('execution expired'))
+
+      result = MailerDeliveryMonitor.unhealthy_result
+
+      assert_not result.healthy?
+      assert_match(/2 mail deliveries failed/, result.message)
+      assert_match(/Net::OpenTimeout/, result.message)
+    end
+  end
+
+  test 'unhealthy_result ignores failures outside the monitoring window' do
+    travel_to Time.zone.parse('2026-05-27 12:00:00') do
+      MailerDeliveryMonitor.record_failure!(RuntimeError.new('old failure'))
+    end
+
+    travel_to Time.zone.parse('2026-05-27 12:20:00') do
+      assert_nil MailerDeliveryMonitor.unhealthy_result
+    end
+  end
+end

--- a/test/services/mailer_health_check_test.rb
+++ b/test/services/mailer_health_check_test.rb
@@ -66,9 +66,9 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
     Rails.cache.clear
     @original_delivery_method = Rails.configuration.action_mailer.delivery_method
     @original_smtp_settings = Rails.configuration.action_mailer.smtp_settings&.dup
-    @original_from = ENV['EMAIL_FROM_ADDRESS']
-    @original_rcpt = ENV['SMTP_HEALTH_CHECK_RCPT_TO']
-    @original_skip = ENV['SMTP_HEALTH_CHECK_SKIP_TRANSACTION']
+    @original_from = ENV.fetch('EMAIL_FROM_ADDRESS', nil)
+    @original_rcpt = ENV.fetch('SMTP_HEALTH_CHECK_RCPT_TO', nil)
+    @original_skip = ENV.fetch('SMTP_HEALTH_CHECK_SKIP_TRANSACTION', nil)
     @original_smtp_new = Net::SMTP.method(:new)
     FakeSmtp.error = nil
     FakeSmtp.transaction_error = nil
@@ -118,7 +118,7 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
 
     assert result.healthy?
     assert_match(/Connected and authenticated/, result.message)
-    assert_match(/verified MAIL FROM\/RCPT TO/, result.message)
+    assert_match(%r{verified MAIL FROM/RCPT TO}, result.message)
     assert_equal 'smtp.example.test', FakeSmtp.last.address
     assert_equal 587, FakeSmtp.last.port
     assert_equal 'members.example.test', FakeSmtp.last.domain
@@ -242,7 +242,7 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
 
     assert result.healthy?
     assert_match(/Connected and authenticated/, result.message)
-    assert_no_match(/verified MAIL FROM\/RCPT TO/, result.message)
+    assert_no_match(%r{verified MAIL FROM/RCPT TO}, result.message)
     assert_nil FakeSmtp.last.mail_from
   end
 end

--- a/test/services/mailer_health_check_test.rb
+++ b/test/services/mailer_health_check_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class MailerHealthCheckTest < ActiveSupport::TestCase
   class FakeSmtp
     class << self
-      attr_accessor :last, :error
+      attr_accessor :last, :error, :transaction_error
     end
 
     attr_accessor :open_timeout, :read_timeout
@@ -37,27 +37,68 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
       @username = username
       @password = password
       @authentication = authentication
-      yield if block_given?
+      yield self if block_given?
+    end
+
+    def mailfrom(from_addr:)
+      raise self.class.transaction_error if self.class.transaction_error
+
+      @mail_from = from_addr
+    end
+
+    def rcptto(to_addr:)
+      raise self.class.transaction_error if self.class.transaction_error
+
+      @rcpt_to = to_addr
+    end
+
+    def rset
+      @reset = true
     end
 
     attr_reader :address, :port, :domain, :username, :password, :authentication, :tls, :starttls, :starttls_auto,
-                :starttls_disabled
+                :starttls_disabled, :mail_from, :rcpt_to, :reset
   end
 
   setup do
-    Rails.cache.delete(MailerHealthCheck::CACHE_KEY)
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
+    Rails.cache.clear
     @original_delivery_method = Rails.configuration.action_mailer.delivery_method
     @original_smtp_settings = Rails.configuration.action_mailer.smtp_settings&.dup
+    @original_from = ENV['EMAIL_FROM_ADDRESS']
+    @original_rcpt = ENV['SMTP_HEALTH_CHECK_RCPT_TO']
+    @original_skip = ENV['SMTP_HEALTH_CHECK_SKIP_TRANSACTION']
     @original_smtp_new = Net::SMTP.method(:new)
     FakeSmtp.error = nil
+    FakeSmtp.transaction_error = nil
     FakeSmtp.last = nil
+    ENV['EMAIL_FROM_ADDRESS'] = 'noreply@example.test'
+    ENV.delete('SMTP_HEALTH_CHECK_RCPT_TO')
+    ENV.delete('SMTP_HEALTH_CHECK_SKIP_TRANSACTION')
     Net::SMTP.define_singleton_method(:new) { |address, port| FakeSmtp.new(address, port) }
   end
 
   teardown do
-    Rails.cache.delete(MailerHealthCheck::CACHE_KEY)
+    Rails.cache.clear
+    Rails.cache = @original_cache
     Rails.configuration.action_mailer.delivery_method = @original_delivery_method
     Rails.configuration.action_mailer.smtp_settings = @original_smtp_settings
+    if @original_from
+      ENV['EMAIL_FROM_ADDRESS'] = @original_from
+    else
+      ENV.delete('EMAIL_FROM_ADDRESS')
+    end
+    if @original_rcpt
+      ENV['SMTP_HEALTH_CHECK_RCPT_TO'] = @original_rcpt
+    else
+      ENV.delete('SMTP_HEALTH_CHECK_RCPT_TO')
+    end
+    if @original_skip
+      ENV['SMTP_HEALTH_CHECK_SKIP_TRANSACTION'] = @original_skip
+    else
+      ENV.delete('SMTP_HEALTH_CHECK_SKIP_TRANSACTION')
+    end
     Net::SMTP.define_singleton_method(:new, @original_smtp_new)
   end
 
@@ -77,6 +118,7 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
 
     assert result.healthy?
     assert_match(/Connected and authenticated/, result.message)
+    assert_match(/verified MAIL FROM\/RCPT TO/, result.message)
     assert_equal 'smtp.example.test', FakeSmtp.last.address
     assert_equal 587, FakeSmtp.last.port
     assert_equal 'members.example.test', FakeSmtp.last.domain
@@ -85,6 +127,9 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
     assert_equal :plain, FakeSmtp.last.authentication
     assert_equal true, FakeSmtp.last.starttls_auto
     assert_nil FakeSmtp.last.starttls_disabled
+    assert_equal 'noreply@example.test', FakeSmtp.last.mail_from
+    assert_equal 'noreply@example.test', FakeSmtp.last.rcpt_to
+    assert_equal true, FakeSmtp.last.reset
   end
 
   test 'healthy for local SMTP relay without TLS' do
@@ -102,7 +147,7 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
     result = MailerHealthCheck.call(force: true)
 
     assert result.healthy?
-    assert_equal 'Connected and authenticated to localhost:25', result.message
+    assert_equal 'Connected and authenticated to localhost:25, verified MAIL FROM/RCPT TO', result.message
     assert_equal 'localhost', FakeSmtp.last.address
     assert_equal 25, FakeSmtp.last.port
     assert_equal 'mailer', FakeSmtp.last.username
@@ -150,5 +195,54 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
 
     assert_not result.healthy?
     assert_equal 'SMTP is not configured', result.message
+  end
+
+  test 'unhealthy when SMTP rejects the transaction probe' do
+    Rails.configuration.action_mailer.delivery_method = :smtp
+    Rails.configuration.action_mailer.smtp_settings = {
+      address: 'smtp.example.test',
+      user_name: 'mailer',
+      password: 'secret'
+    }
+    FakeSmtp.transaction_error = Net::SMTPFatalError.new('550 relay access denied')
+
+    result = MailerHealthCheck.call(force: true)
+
+    assert_not result.healthy?
+    assert_match(/rejected the health check/i, result.message)
+    assert_match(/550 relay access denied/, result.message)
+  end
+
+  test 'unhealthy when recent delivery failures were recorded' do
+    Rails.configuration.action_mailer.delivery_method = :smtp
+    Rails.configuration.action_mailer.smtp_settings = {
+      address: 'smtp.example.test',
+      user_name: 'mailer',
+      password: 'secret'
+    }
+    MailerDeliveryMonitor.record_failure!(RuntimeError.new('smtp down'), source: 'MemberMailer#welcome')
+
+    result = MailerHealthCheck.call(force: true)
+
+    assert_not result.healthy?
+    assert_match(/Recent mail delivery failed/, result.message)
+    assert_match(/smtp down/, result.message)
+  end
+
+  test 'can skip transaction probe when relay rejects synthetic recipients' do
+    ENV['SMTP_HEALTH_CHECK_SKIP_TRANSACTION'] = 'true'
+    Rails.configuration.action_mailer.delivery_method = :smtp
+    Rails.configuration.action_mailer.smtp_settings = {
+      address: 'smtp.example.test',
+      user_name: 'mailer',
+      password: 'secret'
+    }
+
+    result = MailerHealthCheck.call(force: true)
+
+    assert result.healthy?
+    assert_match(/Connected and authenticated/, result.message)
+    assert_no_match(/verified MAIL FROM\/RCPT TO/, result.message)
+    assert_nil FakeSmtp.last.mail_from
   end
 end

--- a/test/services/membership_applications/notify_directors_of_stale_applications_test.rb
+++ b/test/services/membership_applications/notify_directors_of_stale_applications_test.rb
@@ -8,6 +8,7 @@ module MembershipApplications
 
     setup do
       ActionMailer::Base.deliveries.clear
+      clear_enqueued_jobs
       EmailTemplate.where(key: 'staff_application_nag').delete_all
       EmailTemplate.create!(
         key: 'staff_application_nag',
@@ -17,6 +18,10 @@ module MembershipApplications
         body_text: "Open: {{application_url}}\nSubmitted: {{submitted_at}}",
         enabled: true
       )
+    end
+
+    teardown do
+      clear_enqueued_jobs
     end
 
     test 'emails executive application reviewers for applications pending after a week' do
@@ -53,6 +58,8 @@ module MembershipApplications
           NotifyDirectorsOfStaleApplications.call(now: now)
         end
       end
+    ensure
+      clear_enqueued_jobs
     end
 
     test 'does not email applications that are not stale and pending' do

--- a/test/services/membership_applications/notify_directors_of_submission_test.rb
+++ b/test/services/membership_applications/notify_directors_of_submission_test.rb
@@ -7,7 +7,15 @@ module MembershipApplications
     include ActiveJob::TestHelper
 
     setup do
+      ActionMailer::Base.deliveries.clear
+      clear_enqueued_jobs
+      EmailTemplate.where(key: 'staff_application_nag').delete_all
+      ensure_staff_new_application_template!
       @app = MembershipApplication.create!(email: 'notify-directors@example.com', status: 'submitted')
+    end
+
+    teardown do
+      clear_enqueued_jobs
     end
 
     test 'sends one deliver_later mail per trained staff with email' do
@@ -18,13 +26,16 @@ module MembershipApplications
       Training.create!(trainee: u1, training_topic: ed, trained_at: Time.current)
       Training.create!(trainee: u2, training_topic: aed, trained_at: Time.current)
 
+      delivery_count_before = ActionMailer::Base.deliveries.size
+
       assert_difference 'ActionMailer::Base.deliveries.size', 2 do
         perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
           NotifyDirectorsOfSubmission.call(@app)
         end
       end
 
-      ActionMailer::Base.deliveries.each do |mail|
+      ActionMailer::Base.deliveries.drop(delivery_count_before).each do |mail|
+        assert_equal 'staff_new_application', mail['X-MemberManager-Action']&.decoded
         assert_match(/needs review/i, mail.subject)
       end
     end
@@ -74,6 +85,13 @@ module MembershipApplications
           NotifyDirectorsOfSubmission.call(@app)
         end
       end
+    end
+
+    def ensure_staff_new_application_template!
+      return if EmailTemplate.exists?(key: 'staff_new_application')
+
+      attrs = EmailTemplate::DEFAULT_TEMPLATES.fetch('staff_new_application')
+      EmailTemplate.create!({ key: 'staff_new_application', enabled: true }.merge(attrs))
     end
   end
 end


### PR DESCRIPTION
Probe MAIL FROM/RCPT TO during health checks, track recent send failures, and surface them on the admin dashboard even when a cached connection test still passes.