### PR TITLE
Flag week-old pending applications as urgent on the admin dashboard.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -60,8 +60,9 @@ class DashboardController < AdminController
     # Important: Member-suggested interests needing review
     @interests_needing_review_count = Interest.needs_review.count
 
-    # Important: Pending membership applications (open or under review)
+    # Pending membership applications (open or under review); stale ones (>1 week) are urgent on the dashboard
     @pending_applications_count = MembershipApplication.pending.count
+    @stale_applications_count = MembershipApplication.stale_pending.count
     @submitted_applications_count = MembershipApplication.submitted_apps.count
     @under_review_applications_count = MembershipApplication.under_review_apps.count
 
@@ -174,7 +175,11 @@ class DashboardController < AdminController
       { tier: :urgent, id: :mailer_health, ok: @mailer_health.healthy? },
       { tier: :urgent, id: :ai_ollama, ok: !@ai_ollama_urgent },
       { tier: :urgent, id: :printers, ok: @unhealthy_printers.empty? },
-      { tier: :important, id: :membership_applications, ok: @pending_applications_count.zero? },
+      {
+        tier: @stale_applications_count.positive? ? :urgent : :important,
+        id: :membership_applications,
+        ok: @pending_applications_count.zero?
+      },
       { tier: :important, id: :unlinked_recharge, ok: @unlinked_recharge_count.zero? },
       { tier: :important, id: :mail_queue, ok: @queued_mail_count.zero? },
       { tier: :important, id: :ai_ollama_unconfigured, ok: !@ai_ollama_unconfigured },

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -46,9 +46,12 @@ class MembershipApplication < ApplicationRecord
   scope :rejected, -> { where(status: 'rejected') }
   # Applications awaiting a final decision (Open or Under Review).
   scope :pending, -> { where(status: %w[submitted under_review]) }
-  scope :awaiting_admin_nag, lambda { |stale_cutoff = 1.week.ago, repeat_cutoff = 3.days.ago|
+  scope :stale_pending, lambda { |stale_cutoff = 1.week.ago|
     pending
       .where('COALESCE(membership_applications.submitted_at, membership_applications.created_at) <= ?', stale_cutoff)
+  }
+  scope :awaiting_admin_nag, lambda { |stale_cutoff = 1.week.ago, repeat_cutoff = 3.days.ago|
+    stale_pending(stale_cutoff)
       .where(
         'application_nag_sent_at IS NULL OR application_nag_sent_at <= ?',
         repeat_cutoff

--- a/app/views/dashboard/_attention_item_body.html.erb
+++ b/app/views/dashboard/_attention_item_body.html.erb
@@ -114,16 +114,24 @@ when :unread_messages %>
       No pending membership applications
     </div>
   <% else %>
+    <% stale = @stale_applications_count.to_i > 0 %>
     <div>
-      <i class="bi bi-exclamation-circle-fill text-info me-1"></i>
+      <i class="bi <%= stale ? 'bi-x-circle-fill text-danger' : 'bi-exclamation-circle-fill text-info' %> me-1"></i>
       <%= link_to membership_applications_path(status: 'submitted'), class: 'text-decoration-none fw-semibold' do %>
         <strong><%= @pending_applications_count %></strong> pending membership <%= 'application'.pluralize(@pending_applications_count) %>
       <% end %>
       <div class="text-muted small mt-1">
-        <% parts = [] %>
-        <% parts << "#{@submitted_applications_count} open" if @submitted_applications_count.to_i > 0 %>
-        <% parts << "#{@under_review_applications_count} under review" if @under_review_applications_count.to_i > 0 %>
-        <%= parts.join(', ') if parts.any? %>
+        <% if stale %>
+          <%= @stale_applications_count %> over a week old
+          <% if @pending_applications_count > @stale_applications_count %>
+            · <%= @pending_applications_count - @stale_applications_count %> newer
+          <% end %>
+        <% else %>
+          <% parts = [] %>
+          <% parts << "#{@submitted_applications_count} open" if @submitted_applications_count.to_i > 0 %>
+          <% parts << "#{@under_review_applications_count} under review" if @under_review_applications_count.to_i > 0 %>
+          <%= parts.join(', ') if parts.any? %>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -92,6 +92,36 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'admin dashboard marks stale membership applications urgent' do
+    MembershipApplication.create!(
+      email: 'stale-dashboard@example.com',
+      status: 'submitted',
+      submitted_at: 8.days.ago,
+      created_at: 8.days.ago
+    )
+
+    with_urgent_snapshot(urgent_snapshot) { get root_path }
+
+    assert_response :success
+    assert_match(/1 over a week old/, response.body)
+    assert_match(/pending membership application/i, response.body)
+  end
+
+  test 'admin dashboard shows recent pending applications without stale warning' do
+    MembershipApplication.create!(
+      email: 'recent-dashboard@example.com',
+      status: 'submitted',
+      submitted_at: 2.days.ago,
+      created_at: 2.days.ago
+    )
+
+    with_urgent_snapshot(urgent_snapshot) { get root_path }
+
+    assert_response :success
+    assert_match(/pending membership application/i, response.body)
+    assert_no_match(/over a week old/, response.body)
+  end
+
   test 'admin dashboard urgent items come from shared urgent snapshot' do
     snapshot = AdminDashboard::UrgentItems::Snapshot.new(
       [],

--- a/test/models/membership_application_test.rb
+++ b/test/models/membership_application_test.rb
@@ -84,6 +84,34 @@ class MembershipApplicationTest < ActiveSupport::TestCase
     assert_equal member, qm.recipient
   end
 
+  test 'stale_pending includes pending applications older than one week' do
+    travel_to Time.zone.local(2026, 5, 28, 12, 0, 0) do
+      stale = MembershipApplication.create!(
+        email: 'stale-pending@example.com',
+        status: 'submitted',
+        submitted_at: 8.days.ago,
+        created_at: 8.days.ago
+      )
+      recent = MembershipApplication.create!(
+        email: 'recent-pending@example.com',
+        status: 'under_review',
+        submitted_at: 2.days.ago,
+        created_at: 2.days.ago
+      )
+      approved = MembershipApplication.create!(
+        email: 'old-approved@example.com',
+        status: 'approved',
+        submitted_at: 10.days.ago,
+        created_at: 10.days.ago
+      )
+
+      ids = MembershipApplication.stale_pending.pluck(:id)
+      assert_includes ids, stale.id
+      assert_not_includes ids, recent.id
+      assert_not_includes ids, approved.id
+    end
+  end
+
   test 'newest_first orders by submitted time (fallback created_at), then id desc' do
     travel_to Time.zone.local(2026, 4, 15, 12, 0, 0) do
       older = MembershipApplication.create!(


### PR DESCRIPTION
Uses the same age cutoff as director nag emails so stale applications surface in the urgent attention tier instead of important.