### PR TITLE
Clear pending training requests when a member is trained.

### DIFF
--- a/app/models/training.rb
+++ b/app/models/training.rb
@@ -7,12 +7,20 @@ class Training < ApplicationRecord
 
   scope :recent, -> { order(trained_at: :desc) }
 
-  after_create :sync_trained_in_group
+  after_create :sync_trained_in_group, :clear_pending_training_requests
   after_destroy :sync_trained_in_group
 
   private
 
   def sync_trained_in_group
     Authentik::ApplicationGroupMembershipSyncJob.perform_later(%w[trained_in])
+  end
+
+  def clear_pending_training_requests
+    TrainingRequest.clear_pending_for!(
+      user: trainee,
+      training_topic: training_topic,
+      responded_by: trainer
+    )
   end
 end

--- a/app/models/training_request.rb
+++ b/app/models/training_request.rb
@@ -28,4 +28,10 @@ class TrainingRequest < ApplicationRecord
   def respond!(responder)
     update!(status: 'responded', responded_by: responder, responded_at: Time.current)
   end
+
+  def self.clear_pending_for!(user:, training_topic:, responded_by: nil)
+    pending.where(user: user, training_topic: training_topic).find_each do |request|
+      request.update!(status: 'responded', responded_by: responded_by, responded_at: Time.current)
+    end
+  end
 end

--- a/test/models/training_test.rb
+++ b/test/models/training_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+class TrainingTest < ActiveSupport::TestCase
+  setup do
+    @topic = training_topics(:laser_cutting)
+    @trainee = users(:member_with_local_account)
+    @trainer = users(:one)
+    @request = training_requests(:pending_laser_request)
+  end
+
+  test 'creating training clears pending request for same user and topic' do
+    assert @request.pending?
+
+    Training.create!(
+      trainee: @trainee,
+      trainer: @trainer,
+      training_topic: @topic,
+      trained_at: Time.current
+    )
+
+    @request.reload
+    assert @request.responded?
+    assert_equal @trainer, @request.responded_by
+    assert_not_nil @request.responded_at
+  end
+
+  test 'creating training does not affect pending requests for other topics' do
+    other_topic = training_topics(:woodworking)
+    other_request = TrainingRequest.create!(
+      user: @trainee,
+      training_topic: other_topic,
+      share_contact_info: true,
+      status: 'pending'
+    )
+
+    Training.create!(
+      trainee: @trainee,
+      trainer: @trainer,
+      training_topic: @topic,
+      trained_at: Time.current
+    )
+
+    assert @request.reload.responded?
+    assert other_request.reload.pending?
+  end
+
+  test 'creating training does not affect pending requests for other users' do
+    other_user = users(:no_email)
+    other_request = TrainingRequest.create!(
+      user: other_user,
+      training_topic: @topic,
+      share_contact_info: true,
+      status: 'pending'
+    )
+
+    Training.create!(
+      trainee: @trainee,
+      trainer: @trainer,
+      training_topic: @topic,
+      trained_at: Time.current
+    )
+
+    assert @request.reload.responded?
+    assert other_request.reload.pending?
+  end
+end

--- a/test/services/training_recorder_test.rb
+++ b/test/services/training_recorder_test.rb
@@ -43,6 +43,26 @@ class TrainingRecorderTest < ActiveSupport::TestCase
     assert_equal @trainer.display_name, journal.changes_json.dig('training', 'trainer')
   end
 
+  test 'clears pending training request when member is trained' do
+    request = TrainingRequest.create!(
+      user: @trainee,
+      training_topic: @topic,
+      share_contact_info: true,
+      status: 'pending'
+    )
+
+    TrainingRecorder.new(
+      current_user: @trainer,
+      training_topic: @topic,
+      trainee_ids: [@trainee.id.to_s],
+      trainer: @trainer,
+      trained_at: @trained_at
+    ).call
+
+    assert request.reload.responded?
+    assert_equal @trainer, request.responded_by
+  end
+
   test 'skips already trained inactive and missing trainees' do
     already_trained = users(:two)
     inactive = users(:three)


### PR DESCRIPTION
Mark matching topic requests as responded so trainers no longer see stale open requests after training is recorded.