### PR TITLE
Fix SMTP health check calling mailfrom/rcptto with keyword args.

### DIFF
--- a/app/services/mailer_health_check.rb
+++ b/app/services/mailer_health_check.rb
@@ -53,8 +53,8 @@ class MailerHealthCheck
   end
 
   def verify_mail_transaction!(client)
-    client.mailfrom(from_addr: mail_from_address)
-    client.rcptto(to_addr: rcpt_probe_address)
+    client.mailfrom(mail_from_address)
+    client.rcptto(rcpt_probe_address)
     client.rset
   end
 

--- a/test/services/mailer_health_check_test.rb
+++ b/test/services/mailer_health_check_test.rb
@@ -40,13 +40,13 @@ class MailerHealthCheckTest < ActiveSupport::TestCase
       yield self if block_given?
     end
 
-    def mailfrom(from_addr:)
+    def mailfrom(from_addr)
       raise self.class.transaction_error if self.class.transaction_error
 
       @mail_from = from_addr
     end
 
-    def rcptto(to_addr:)
+    def rcptto(to_addr)
       raise self.class.transaction_error if self.class.transaction_error
 
       @rcpt_to = to_addr


### PR DESCRIPTION
Net: :SMTP expects positional addresses; keyword syntax passed a Hash and crashed the admin dashboard on every page load.