### PR TITLE
Sync training and trainer topics to Authentik attributes

### DIFF
--- a/app/jobs/authentik/full_sync_to_authentik_job.rb
+++ b/app/jobs/authentik/full_sync_to_authentik_job.rb
@@ -25,12 +25,16 @@ module Authentik
         sync_user_to_authentik(user, client, results)
       end
 
-      slack_linked_users = User.joins(:slack_user).where.not(authentik_id: [nil, '']).where(authentik_dirty: false)
+      supplemental_user_ids = Authentik::UserAttributes.supplemental_sync_user_ids
+      supplemental_users = User.where(id: supplemental_user_ids)
+                               .where.not(authentik_id: [nil, ''])
+                               .where(authentik_dirty: false)
       Rails.logger.info(
-        "[Authentik::FullSyncToAuthentik] Syncing Slack attributes for #{slack_linked_users.count} user(s)..."
+        '[Authentik::FullSyncToAuthentik] Syncing supplemental attributes ' \
+        "for #{supplemental_users.count} user(s)..."
       )
-      slack_linked_users.find_each do |user|
-        sync_slack_attributes_to_authentik(user, client, results)
+      supplemental_users.find_each do |user|
+        sync_supplemental_attributes_to_authentik(user, client, results)
       end
 
       # 2a. Ensure core groups (active, admins, unbanned, all, training) exist
@@ -145,18 +149,19 @@ module Authentik
       Rails.logger.error("[Authentik::FullSyncToAuthentik] Failed to sync user #{user.id}: #{e.message}")
     end
 
-    def sync_slack_attributes_to_authentik(user, client, results)
+    def sync_supplemental_attributes_to_authentik(user, client, results)
       client.update_user(user.authentik_id, attributes: Authentik::UserAttributes.for(user))
       user.update_columns(last_synced_at: Time.current)
       results[:users_synced] += 1
 
       Rails.logger.info(
-        "[Authentik::FullSyncToAuthentik] Synced Slack attributes for user #{user.id} (#{user.display_name})"
+        '[Authentik::FullSyncToAuthentik] Synced supplemental attributes ' \
+        "for user #{user.id} (#{user.display_name})"
       )
     rescue StandardError => e
       results[:users_errored] += 1
       Rails.logger.error(
-        '[Authentik::FullSyncToAuthentik] Failed to sync Slack attributes ' \
+        '[Authentik::FullSyncToAuthentik] Failed to sync supplemental attributes ' \
         "for user #{user.id}: #{e.message}"
       )
     end

--- a/app/models/trainer_capability.rb
+++ b/app/models/trainer_capability.rb
@@ -6,8 +6,15 @@ class TrainerCapability < ApplicationRecord
 
   after_create :sync_can_train_group
   after_destroy :sync_can_train_group
+  after_commit :enqueue_trainer_authentik_sync, on: %i[create destroy]
 
   private
+
+  def enqueue_trainer_authentik_sync
+    return if Current.skip_authentik_sync
+
+    Authentik::UserSyncJob.perform_later(user_id, %w[can_train])
+  end
 
   def sync_can_train_group
     Authentik::ApplicationGroupMembershipSyncJob.perform_later(%w[can_train])

--- a/app/models/training.rb
+++ b/app/models/training.rb
@@ -9,8 +9,16 @@ class Training < ApplicationRecord
 
   after_create :sync_trained_in_group, :clear_pending_training_requests
   after_destroy :sync_trained_in_group
+  after_commit :enqueue_trainee_authentik_sync, on: %i[create destroy]
 
   private
+
+  def enqueue_trainee_authentik_sync
+    return if Current.skip_authentik_sync
+    return if trainee_id.blank?
+
+    Authentik::UserSyncJob.perform_later(trainee_id, %w[trained_on])
+  end
 
   def sync_trained_in_group
     Authentik::ApplicationGroupMembershipSyncJob.perform_later(%w[trained_in])

--- a/app/services/authentik/user_attributes.rb
+++ b/app/services/authentik/user_attributes.rb
@@ -8,8 +8,34 @@ module Authentik
       {
         'member_manager_id' => user.id.to_s,
         'slack_user_id' => slack_id.presence || '',
-        'slack_handle' => slack_handle.presence || ''
+        'slack_handle' => slack_handle.presence || '',
+        'trained_on' => trained_on_topics_for(user),
+        'can_train' => can_train_topics_for(user)
       }
+    end
+
+    def self.supplemental_sync_user_ids
+      ids = []
+      ids.concat(User.joins(:slack_user).pluck(:id))
+      ids.concat(Training.distinct.pluck(:trainee_id))
+      ids.concat(TrainerCapability.distinct.pluck(:user_id))
+      ids.compact.uniq
+    end
+
+    def self.trained_on_topics_for(user)
+      user.trainings_as_trainee
+          .joins(:training_topic)
+          .distinct
+          .order('training_topics.name')
+          .pluck('training_topics.name')
+    end
+
+    def self.can_train_topics_for(user)
+      user.trainer_capabilities
+          .joins(:training_topic)
+          .distinct
+          .order('training_topics.name')
+          .pluck('training_topics.name')
     end
   end
 end

--- a/app/services/authentik/user_sync.rb
+++ b/app/services/authentik/user_sync.rb
@@ -4,7 +4,7 @@ module Authentik
     SYNCABLE_FIELDS = %w[email full_name username active].freeze
 
     # User fields stored in Authentik's attributes JSON (not top-level user fields)
-    ATTRIBUTE_SYNC_FIELDS = %w[slack_id slack_handle].freeze
+    ATTRIBUTE_SYNC_FIELDS = %w[slack_id slack_handle trained_on can_train].freeze
 
     # Mapping from MemberManager field names to Authentik field names
     FIELD_MAPPING = {

--- a/test/jobs/authentik_auto_sync_test.rb
+++ b/test/jobs/authentik_auto_sync_test.rb
@@ -50,16 +50,20 @@ class AuthentikAutoSyncTest < ActiveJob::TestCase
     training = nil
 
     assert_enqueued_with(job: Authentik::ApplicationGroupMembershipSyncJob, args: [%w[trained_in]]) do
-      training = Training.create!(
-        trainee: users(:one),
-        trainer: users(:two),
-        training_topic: training_topics(:laser_cutting),
-        trained_at: Time.current
-      )
+      assert_enqueued_with(job: Authentik::UserSyncJob, args: [users(:one).id, %w[trained_on]]) do
+        training = Training.create!(
+          trainee: users(:one),
+          trainer: users(:two),
+          training_topic: training_topics(:laser_cutting),
+          trained_at: Time.current
+        )
+      end
     end
 
     assert_enqueued_with(job: Authentik::ApplicationGroupMembershipSyncJob, args: [%w[trained_in]]) do
-      training.destroy!
+      assert_enqueued_with(job: Authentik::UserSyncJob, args: [users(:one).id, %w[trained_on]]) do
+        training.destroy!
+      end
     end
   end
 
@@ -67,14 +71,18 @@ class AuthentikAutoSyncTest < ActiveJob::TestCase
     capability = nil
 
     assert_enqueued_with(job: Authentik::ApplicationGroupMembershipSyncJob, args: [%w[can_train]]) do
-      capability = TrainerCapability.create!(
-        user: users(:one),
-        training_topic: training_topics(:laser_cutting)
-      )
+      assert_enqueued_with(job: Authentik::UserSyncJob, args: [users(:one).id, %w[can_train]]) do
+        capability = TrainerCapability.create!(
+          user: users(:one),
+          training_topic: training_topics(:laser_cutting)
+        )
+      end
     end
 
     assert_enqueued_with(job: Authentik::ApplicationGroupMembershipSyncJob, args: [%w[can_train]]) do
-      capability.destroy!
+      assert_enqueued_with(job: Authentik::UserSyncJob, args: [users(:one).id, %w[can_train]]) do
+        capability.destroy!
+      end
     end
   end
 

--- a/test/services/authentik/user_attributes_test.rb
+++ b/test/services/authentik/user_attributes_test.rb
@@ -7,11 +7,10 @@ module Authentik
       user.update_columns(slack_id: 'U123SLACK', slack_handle: 'alice')
 
       assert_equal(
-        {
-          'member_manager_id' => user.id.to_s,
+        base_attributes(user).merge(
           'slack_user_id' => 'U123SLACK',
           'slack_handle' => 'alice'
-        },
+        ),
         UserAttributes.for(user)
       )
     end
@@ -20,14 +19,7 @@ module Authentik
       user = users(:two)
       user.update_columns(slack_id: nil, slack_handle: nil)
 
-      assert_equal(
-        {
-          'member_manager_id' => user.id.to_s,
-          'slack_user_id' => '',
-          'slack_handle' => ''
-        },
-        UserAttributes.for(user)
-      )
+      assert_equal base_attributes(user), UserAttributes.for(user)
     end
 
     test 'for falls back to linked slack user when member slack columns are blank' do
@@ -37,13 +29,77 @@ module Authentik
       slack_user.update!(user_id: user.id)
 
       assert_equal(
-        {
-          'member_manager_id' => user.id.to_s,
+        base_attributes(user).merge(
           'slack_user_id' => slack_user.slack_id,
           'slack_handle' => slack_user.username
-        },
+        ),
         UserAttributes.for(user)
       )
+    end
+
+    test 'for includes trained_on topic names sorted alphabetically' do
+      user = users(:one)
+      Training.create!(
+        trainee: user,
+        trainer: users(:two),
+        training_topic: training_topics(:woodworking),
+        trained_at: Time.current
+      )
+      Training.create!(
+        trainee: user,
+        trainer: users(:two),
+        training_topic: training_topics(:laser_cutting),
+        trained_at: Time.current
+      )
+
+      assert_equal(
+        base_attributes(user).merge('trained_on' => ['Laser Cutting', 'Woodworking']),
+        UserAttributes.for(user)
+      )
+    end
+
+    test 'for includes can_train topic names sorted alphabetically' do
+      user = users(:one)
+      TrainerCapability.create!(user: user, training_topic: training_topics(:woodworking))
+      TrainerCapability.create!(user: user, training_topic: training_topics(:laser_cutting))
+
+      assert_equal(
+        base_attributes(user).merge('can_train' => ['Laser Cutting', 'Woodworking']),
+        UserAttributes.for(user)
+      )
+    end
+
+    test 'supplemental_sync_user_ids includes slack linked and training related users' do
+      slack_user = users(:two)
+      slack_users(:with_dept).update!(user_id: slack_user.id)
+
+      trainee = users(:one)
+      trainer = users(:two)
+      Training.create!(
+        trainee: trainee,
+        trainer: trainer,
+        training_topic: training_topics(:laser_cutting),
+        trained_at: Time.current
+      )
+      TrainerCapability.create!(user: trainer, training_topic: training_topics(:woodworking))
+
+      ids = UserAttributes.supplemental_sync_user_ids
+
+      assert_includes ids, slack_user.id
+      assert_includes ids, trainee.id
+      assert_includes ids, trainer.id
+    end
+
+    private
+
+    def base_attributes(user)
+      {
+        'member_manager_id' => user.id.to_s,
+        'slack_user_id' => '',
+        'slack_handle' => '',
+        'trained_on' => [],
+        'can_train' => []
+      }
     end
   end
 end

--- a/test/services/authentik/user_sync_test.rb
+++ b/test/services/authentik/user_sync_test.rb
@@ -73,7 +73,9 @@ module Authentik
         {
           'member_manager_id' => user.id.to_s,
           'slack_user_id' => 'U123SLACK',
-          'slack_handle' => 'alice'
+          'slack_handle' => 'alice',
+          'trained_on' => [],
+          'can_train' => []
         },
         captured_attrs[:attributes]
       )
@@ -122,6 +124,35 @@ module Authentik
       assert_equal 'synced', result[:status]
       assert_equal slack_user.slack_id, captured_attrs[:attributes]['slack_user_id']
       assert_equal slack_user.username, captured_attrs[:attributes]['slack_handle']
+    end
+
+    test 'sync_to_authentik includes training attributes' do
+      user = users(:one)
+      user.update_columns(authentik_id: 'authentik-training-sync-test')
+      Training.create!(
+        trainee: user,
+        trainer: users(:two),
+        training_topic: training_topics(:laser_cutting),
+        trained_at: Time.current
+      )
+      TrainerCapability.create!(user: user, training_topic: training_topics(:woodworking))
+
+      captured_attrs = nil
+      client = Class.new do
+        define_method(:update_user) do |authentik_id, **attrs|
+          captured_attrs = attrs
+          { 'pk' => authentik_id }
+        end
+      end.new
+
+      result = Authentik::UserSync.new(user, client: client).sync_to_authentik!(
+        changed_fields: %w[trained_on can_train]
+      )
+
+      assert_equal 'synced', result[:status]
+      assert_equal %w[trained_on can_train], result[:fields]
+      assert_equal ['Laser Cutting'], captured_attrs[:attributes]['trained_on']
+      assert_equal ['Woodworking'], captured_attrs[:attributes]['can_train']
     end
   end
 end


### PR DESCRIPTION
## Summary
- Adds `trained_on` and `can_train` arrays to Authentik user attributes, populated with alphabetically sorted training topic names from each member's training records and trainer capabilities.
- Enqueues Authentik user sync when trainings or trainer capabilities are created or destroyed.
- Expands full sync supplemental attribute backfill to include members with Slack links, training records, or trainer capabilities (not just Slack-linked members).

## Test plan
- [x] RuboCop clean (398 files)
- [x] Full test suite passing (1166 tests)
- [x] `UserAttributes` tests cover trained/can_train topic lists and supplemental sync user selection
- [x] `UserSync` test covers training attribute payload
- [x] Authentik auto-sync tests cover job enqueue on training/capability changes
- [ ] After deploy: run full Authentik sync or push a trained member and confirm `trained_on` / `can_train` appear in Authentik user attributes JSON


Made with [Cursor](https://cursor.com)