### PR TITLE
Show all trainers on topic page for admins, including inactive.

### DIFF
--- a/app/controllers/training_catalog_controller.rb
+++ b/app/controllers/training_catalog_controller.rb
@@ -26,7 +26,8 @@ class TrainingCatalogController < AuthenticatedController
   end
 
   def show
-    @trainers = @training_topic.trainers.active.order(:full_name, :email)
+    trainers_scope = @training_topic.trainers.order(:full_name, :email)
+    @trainers = current_user_admin? ? trainers_scope : trainers_scope.active
     @trainees = User.where(id: @training_topic.trainings.select(:trainee_id).distinct)
                     .order(:full_name, :email)
     @topic_links = @training_topic.links.order(:title)

--- a/app/views/training_catalog/show.html.erb
+++ b/app/views/training_catalog/show.html.erb
@@ -88,8 +88,13 @@
         <% if @trainers.any? %>
           <ul class="list-unstyled mb-0">
             <% @trainers.each do |trainer| %>
-              <li class="mb-2">
-                <%= link_to trainer.display_name, user_path(trainer), class: 'text-decoration-none' %>
+              <li class="mb-2 d-flex align-items-center gap-2 flex-wrap">
+                <%= link_to trainer.display_name,
+                            user_path(trainer),
+                            class: "text-decoration-none #{'text-secondary' unless trainer.active?}" %>
+                <% if current_user_admin? && !trainer.active? %>
+                  <span class="badge text-bg-secondary-subtle small fw-normal">Inactive</span>
+                <% end %>
               </li>
             <% end %>
           </ul>

--- a/test/controllers/training_catalog_controller_test.rb
+++ b/test/controllers/training_catalog_controller_test.rb
@@ -180,7 +180,7 @@ class TrainingCatalogControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/Request Training/i, response.body)
   end
 
-  test 'show does not list trainers whose membership is inactive' do
+  test 'show lists inactive trainers for admins but not for members' do
     active_trainer   = users(:one)
     inactive_trainer = users(:two)
     inactive_trainer.update!(active: false)
@@ -188,6 +188,14 @@ class TrainingCatalogControllerTest < ActionDispatch::IntegrationTest
     TrainerCapability.find_or_create_by!(user: inactive_trainer, training_topic: @laser_topic)
 
     sign_in_as_admin
+    get training_catalog_topic_path(@laser_topic)
+
+    assert_response :success
+    assert_match active_trainer.display_name, response.body
+    assert_match inactive_trainer.display_name, response.body
+    assert_match 'Inactive', response.body
+
+    sign_in_as_member
     get training_catalog_topic_path(@laser_topic)
 
     assert_response :success


### PR DESCRIPTION
The training catalog filtered trainers to active members only, so admins could grant can_train but not see those people listed on /training/:id when membership was inactive.