### PR TITLE
Split training topic counts by active status and mark inactive trainees.

### DIFF
--- a/app/controllers/training_catalog_controller.rb
+++ b/app/controllers/training_catalog_controller.rb
@@ -41,18 +41,36 @@ class TrainingCatalogController < AuthenticatedController
   def prepare_training_catalog_counts(topics)
     topic_ids = topics.map(&:id)
     @all_topic_count = topics.size
-    @topic_trainer_counts = grouped_training_count(TrainerCapability, topic_ids, :user_id)
-    @topic_trained_counts = grouped_training_count(Training, topic_ids, :trainee_id)
+    @topic_trainer_counts = topic_member_status_counts(
+      TrainerCapability, topic_ids, user_association: :user, member_column: :user_id
+    )
+    @topic_trained_counts = topic_member_status_counts(
+      Training, topic_ids, user_association: :trainee, member_column: :trainee_id
+    )
     @trained_topic_ids = Training.where(trainee: current_user).pluck(:training_topic_id).to_set
     @needs_trainers_count = topics.count { |topic| needs_trainers?(topic) }
     @offered_topic_count = topics.count(&:offered_to_members?)
   end
 
-  def grouped_training_count(model, topic_ids, column)
-    model.where(training_topic_id: topic_ids)
-         .group(:training_topic_id)
-         .distinct
-         .count(column)
+  def topic_member_status_counts(model, topic_ids, user_association:, member_column:)
+    return {} if topic_ids.empty?
+
+    total_by_topic = model.where(training_topic_id: topic_ids)
+                          .group(:training_topic_id)
+                          .distinct
+                          .count(member_column)
+    active_by_topic = model.where(training_topic_id: topic_ids)
+                           .joins(user_association)
+                           .merge(User.active)
+                           .group(:training_topic_id)
+                           .distinct
+                           .count(member_column)
+
+    topic_ids.index_with do |topic_id|
+      total = total_by_topic[topic_id].to_i
+      active = active_by_topic[topic_id].to_i
+      { total: total, active: active, inactive: total - active }
+    end
   end
 
   def filtered_training_topics(topics)
@@ -67,7 +85,7 @@ class TrainingCatalogController < AuthenticatedController
   end
 
   def needs_trainers?(topic)
-    topic.offered_to_members? && @topic_trainer_counts[topic.id].to_i.zero?
+    topic.offered_to_members? && @topic_trainer_counts.dig(topic.id, :active).to_i.zero?
   end
 
   def set_training_topic

--- a/app/views/training_catalog/_member_status_counts.html.erb
+++ b/app/views/training_catalog/_member_status_counts.html.erb
@@ -1,0 +1,10 @@
+<% counts = local_assigns.fetch(:counts, { total: 0, active: 0, inactive: 0 }) %>
+<% highlight = local_assigns[:highlight] %>
+<td class="num <%= highlight ? 'text-warning' : (counts[:total].zero? ? 'muted-num' : '') %>">
+  <div><%= counts[:total] %></div>
+  <div class="text-12 text-secondary">
+    <span class="<%= counts[:active].positive? ? 'text-body' : '' %>"><%= counts[:active] %> active</span>
+    ·
+    <span class="<%= counts[:inactive].positive? ? 'fw-medium text-body' : '' %>"><%= counts[:inactive] %> inactive</span>
+  </div>
+</td>

--- a/app/views/training_catalog/index.html.erb
+++ b/app/views/training_catalog/index.html.erb
@@ -48,9 +48,9 @@
           </thead>
           <tbody>
             <% @training_topics.each do |topic| %>
-              <% trainer_count = @topic_trainer_counts[topic.id].to_i %>
-              <% trained_count = @topic_trained_counts[topic.id].to_i %>
-              <% needs_trainers = topic.offered_to_members? && trainer_count.zero? %>
+              <% trainer_counts = @topic_trainer_counts[topic.id] || { total: 0, active: 0, inactive: 0 } %>
+              <% trained_counts = @topic_trained_counts[topic.id] || { total: 0, active: 0, inactive: 0 } %>
+              <% needs_trainers = topic.offered_to_members? && trainer_counts[:active].zero? %>
               <tr onclick="if (!event.target.closest('a, button')) window.location='<%= training_catalog_topic_path(topic) %>'" style="cursor: pointer;">
                 <td>
                   <strong><%= link_to topic.name, training_catalog_topic_path(topic), class: 'text-decoration-none' %></strong>
@@ -67,12 +67,19 @@
                     <% end %>
                   </td>
                 <% end %>
-                <td class="num <%= needs_trainers ? 'text-warning' : (trainer_count.zero? ? 'muted-num' : '') %>">
-                  <%= trainer_count %>
-                </td>
-                <td class="num <%= trained_count.zero? ? 'muted-num' : ('fw-medium' if trained_count >= 50) %>">
-                  <%= trained_count %>
-                </td>
+                <% if current_user_admin? %>
+                  <%= render 'training_catalog/member_status_counts', counts: trainer_counts, highlight: needs_trainers %>
+                  <%= render 'training_catalog/member_status_counts',
+                             counts: trained_counts,
+                             highlight: false %>
+                <% else %>
+                  <td class="num <%= needs_trainers ? 'text-warning' : (trainer_counts[:active].zero? ? 'muted-num' : '') %>">
+                    <%= trainer_counts[:active] %>
+                  </td>
+                  <td class="num <%= trained_counts[:total].zero? ? 'muted-num' : ('fw-medium' if trained_counts[:total] >= 50) %>">
+                    <%= trained_counts[:total] %>
+                  </td>
+                <% end %>
                 <td class="text-end">
                   <div class="d-flex gap-2 justify-content-end">
                     <% if needs_trainers %>

--- a/app/views/training_catalog/show.html.erb
+++ b/app/views/training_catalog/show.html.erb
@@ -112,8 +112,13 @@
         <% if @trainees.any? %>
           <ul class="list-unstyled mb-0">
             <% @trainees.each do |trainee| %>
-              <li class="mb-2">
-                <%= link_to trainee.display_name, user_path(trainee), class: 'text-decoration-none' %>
+              <li class="mb-2 d-flex align-items-center gap-2 flex-wrap">
+                <%= link_to trainee.display_name,
+                            user_path(trainee),
+                            class: "text-decoration-none #{'text-secondary' unless trainee.active?}" %>
+                <% if current_user_admin? && !trainee.active? %>
+                  <span class="badge text-bg-secondary-subtle small fw-normal">Inactive</span>
+                <% end %>
               </li>
             <% end %>
           </ul>

--- a/test/controllers/training_catalog_controller_test.rb
+++ b/test/controllers/training_catalog_controller_test.rb
@@ -203,6 +203,62 @@ class TrainingCatalogControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/#{Regexp.escape(inactive_trainer.display_name)}/, response.body)
   end
 
+  test 'show marks inactive trained members for admins' do
+    trainer = users(:one)
+    inactive_trainee = users(:two)
+    inactive_trainee.update!(active: false)
+    TrainerCapability.find_or_create_by!(user: trainer, training_topic: @laser_topic)
+    Training.find_or_create_by!(trainee: inactive_trainee, training_topic: @laser_topic) do |t|
+      t.trainer = trainer
+      t.trained_at = Time.current
+    end
+
+    sign_in_as_admin
+    get training_catalog_topic_path(@laser_topic)
+
+    assert_response :success
+    assert_match inactive_trainee.display_name, response.body
+    assert_match 'Inactive', response.body
+  end
+
+  test 'admin index shows trainer and trained counts split by active status' do
+    active_trainer = users(:one)
+    inactive_trainer = users(:two)
+    inactive_trainer.update!(active: false)
+    inactive_trainee = users(:no_email)
+    inactive_trainee.update!(active: false)
+
+    TrainerCapability.find_or_create_by!(user: active_trainer, training_topic: @laser_topic)
+    TrainerCapability.find_or_create_by!(user: inactive_trainer, training_topic: @laser_topic)
+    Training.find_or_create_by!(trainee: inactive_trainee, training_topic: @laser_topic) do |t|
+      t.trainer = active_trainer
+      t.trained_at = Time.current
+    end
+
+    sign_in_as_admin
+    get training_catalog_path
+
+    assert_response :success
+    laser_link = css_select("a[href='#{training_catalog_topic_path(@laser_topic)}']").first
+    row_text = laser_link.ancestors('tr').first.text.squish
+    assert_includes row_text, '2'
+    assert_includes row_text, '1 active'
+    assert_includes row_text, '1 inactive'
+  end
+
+  test 'needs trainers filter ignores topics with only inactive trainers' do
+    inactive_trainer = users(:two)
+    inactive_trainer.update!(active: false)
+    TrainerCapability.where(training_topic: @laser_topic).delete_all
+    TrainerCapability.find_or_create_by!(user: inactive_trainer, training_topic: @laser_topic)
+
+    sign_in_as_admin
+    get training_catalog_path(training_filter: 'needs_trainers')
+
+    assert_response :success
+    assert_match @laser_topic.name, response.body
+  end
+
   test 'show does not display request training button when only trainers are inactive' do
     inactive_trainer = users(:two)
     inactive_trainer.update!(active: false)


### PR DESCRIPTION
Admins see total/active/inactive breakdown for trainers and trained members on the catalog index, and inactive badges on trained members in the topic detail view. Needs-trainers now keys off active trainer count only.