### PR TITLE
Fix email template preview to show unsaved edits

### DIFF
--- a/app/controllers/email_templates_controller.rb
+++ b/app/controllers/email_templates_controller.rb
@@ -45,6 +45,7 @@ class EmailTemplatesController < AdminController
   end
 
   def preview
+    apply_preview_attributes if preview_request?
     @rendered = @email_template.preview
     render layout: false
   end
@@ -173,6 +174,16 @@ class EmailTemplatesController < AdminController
 
   def rewrite_params
     params.expect(rewrite: %i[subject body_html body_text])
+  end
+
+  def preview_request?
+    request.post? && params[:email_template].present?
+  end
+
+  def apply_preview_attributes
+    attrs = email_template_params.to_h.slice('subject', 'body_html', 'body_text')
+    attrs['body_text'] = html_to_plain_text(attrs['body_html']) if sync_body_text?
+    @email_template.assign_attributes(attrs)
   end
 
   def build_variables_for_user(user, extra = {})

--- a/app/javascript/controllers/email_template_rewrite_controller.js
+++ b/app/javascript/controllers/email_template_rewrite_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
     "sendImmediately",
     "blockSendImmediately"
   ]
-  static values = { url: String }
+  static values = { url: String, previewUrl: String, formId: String }
 
   connect() {
     this.previousState = null
@@ -94,6 +94,40 @@ export default class extends Controller {
 
   syncBodyTextBeforeSubmit() {
     this.syncBodyTextFromHtml()
+  }
+
+  preview(event) {
+    event.preventDefault()
+    if (!this.hasPreviewUrlValue) return
+
+    const editForm = this.editFormElement()
+    if (!editForm) return
+
+    const editor = this.editorControllerFor(editForm)
+    if (editor) editor.syncBodyTextFromHtml()
+
+    const previewForm = document.createElement("form")
+    previewForm.method = "POST"
+    previewForm.action = this.previewUrlValue
+    previewForm.target = "_blank"
+    previewForm.style.display = "none"
+
+    this.appendHiddenInput(previewForm, "authenticity_token", this.csrfToken())
+
+    const subject = editForm.querySelector('[name="email_template[subject]"]')
+    const bodyText = editForm.querySelector('[name="email_template[body_text]"]')
+    const syncBodyText = editForm.querySelector('[name="sync_body_text"]')
+
+    this.appendHiddenInput(previewForm, "email_template[subject]", subject?.value || "")
+    this.appendHiddenInput(previewForm, "email_template[body_html]", this.htmlBodyFrom(editForm))
+    this.appendHiddenInput(previewForm, "email_template[body_text]", bodyText?.value || "")
+    if (syncBodyText?.checked) {
+      this.appendHiddenInput(previewForm, "sync_body_text", "1")
+    }
+
+    document.body.appendChild(previewForm)
+    previewForm.submit()
+    previewForm.remove()
   }
 
   syncImmediateSendControls() {
@@ -194,5 +228,35 @@ export default class extends Controller {
   csrfToken() {
     const tag = document.querySelector("meta[name='csrf-token']")
     return tag ? tag.content : ""
+  }
+
+  editFormElement() {
+    if (this.hasFormIdValue) return document.getElementById(this.formIdValue)
+    if (this.element.tagName === "FORM") return this.element
+    return null
+  }
+
+  editorControllerFor(form) {
+    return this.application.getControllerForElementAndIdentifier(form, "email-template-rewrite")
+  }
+
+  htmlBodyFrom(form) {
+    const textarea = form.querySelector('[data-email-template-rewrite-target="bodyHtml"]')
+    if (!textarea) return ""
+
+    if (typeof tinymce !== "undefined") {
+      const editor = tinymce.get(textarea.id)
+      if (editor) return editor.getContent()
+    }
+
+    return textarea.value
+  }
+
+  appendHiddenInput(form, name, value) {
+    const input = document.createElement("input")
+    input.type = "hidden"
+    input.name = name
+    input.value = value
+    form.appendChild(input)
   }
 }

--- a/app/views/email_templates/edit.html.erb
+++ b/app/views/email_templates/edit.html.erb
@@ -4,7 +4,15 @@
     <p class="text-muted mb-0"><%= @email_template.name %></p>
   </div>
   <div class="d-flex gap-2">
-    <%= link_to "Preview", preview_email_template_path(@email_template), class: "btn btn-outline-info", target: "_blank" %>
+    <%= button_tag "Preview",
+                   type: "button",
+                   class: "btn btn-outline-info",
+                   data: {
+                     controller: "email-template-rewrite",
+                     email_template_rewrite_form_id_value: "email_template_form",
+                     email_template_rewrite_preview_url_value: preview_email_template_path(@email_template),
+                     action: "click->email-template-rewrite#preview"
+                   } %>
     <%= link_to "Cancel", email_templates_path, class: "btn btn-secondary" %>
   </div>
 </div>
@@ -15,6 +23,7 @@
       <div class="card-body">
         <%= form_with model: @email_template,
                       local: true,
+                      html: { id: "email_template_form" },
                       data: {
                         controller: "email-template-rewrite",
                         action: "submit->email-template-rewrite#syncBodyTextBeforeSubmit",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,7 +303,7 @@ Rails.application.routes.draw do
   
   resources :email_templates, only: [:index, :show, :edit, :update] do
     member do
-      get :preview
+      match :preview, via: %i[get post]
       post :toggle
       post :test_send
       post :rewrite_with_ai

--- a/test/controllers/email_templates_controller_test.rb
+++ b/test/controllers/email_templates_controller_test.rb
@@ -19,6 +19,62 @@ class EmailTemplatesControllerTest < ActionDispatch::IntegrationTest
     Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
   end
 
+  test 'preview shows saved template on get' do
+    get preview_email_template_path(@template)
+
+    assert_response :success
+    assert_includes response.body, 'Initial Subject'
+    assert_includes response.body, 'Initial HTML'
+    assert_includes response.body, 'Initial text'
+  end
+
+  test 'preview shows unsaved edits on post' do
+    post preview_email_template_path(@template), params: {
+      email_template: {
+        subject: 'Draft Subject',
+        body_html: '<p>Draft HTML</p>',
+        body_text: 'Draft text'
+      }
+    }
+
+    assert_response :success
+    assert_includes response.body, 'Draft Subject'
+    assert_includes response.body, 'Draft HTML'
+    assert_includes response.body, 'Draft text'
+    assert_not_includes response.body, 'Initial Subject'
+    @template.reload
+    assert_equal 'Initial Subject', @template.subject
+  end
+
+  test 'preview post syncs plain text from html when checkbox is checked' do
+    post preview_email_template_path(@template), params: {
+      sync_body_text: '1',
+      email_template: {
+        subject: 'Draft Subject',
+        body_html: '<h1>Welcome</h1><p>Hello {{member_name}}</p>',
+        body_text: 'Stale plain text'
+      }
+    }
+
+    assert_response :success
+    assert_includes response.body, 'Welcome'
+    assert_includes response.body, 'Hello John Doe'
+    assert_includes response.body, "Welcome\nHello John Doe"
+  end
+
+  test 'edit preview button posts draft content' do
+    get edit_email_template_path(@template)
+
+    assert_response :success
+    assert_select 'button[type=?]', 'button', text: 'Preview' do |buttons|
+      button = buttons.first
+      assert_equal 'email_template_form', button['data-email-template-rewrite-form-id-value']
+      assert_equal preview_email_template_path(@template), button['data-email-template-rewrite-preview-url-value']
+      assert_equal 'click->email-template-rewrite#preview', button['data-action']
+    end
+    assert_select 'form#email_template_form[data-controller=?]', 'email-template-rewrite'
+  end
+
   test 'rewrite_with_ai rewrites subject and body' do
     ai_ollama_profiles(:default).update!(base_url: 'http://ollama.test:11434', model: 'llama3.2')
     ai_ollama_profiles(:email_rewriting).update!(enabled: true, base_url: '', model: '', prompt: 'Rewrite template.')


### PR DESCRIPTION
## Summary
- Preview on the email template edit page now POSTs the current form values (including TinyMCE HTML) instead of opening a GET preview of the saved template
- The preview action accepts POST with draft subject/body and applies the same plain-text sync logic as save when "Keep in sync with HTML" is checked
- Show/index preview links continue to use GET and render the saved template

## Test plan
- [x] `bin/rails test test/controllers/email_templates_controller_test.rb` (18 tests)
- [x] RuboCop clean
- [ ] Edit a template, change subject/body without saving, click Preview — new tab shows draft content
- [ ] Save, then preview from show page — still shows saved content
- [ ] With "Keep in sync with HTML" checked, preview plain text tab matches HTML conversion


Made with [Cursor](https://cursor.com)