### PR TITLE
Add option to sync inactive members as active in Authentik.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -352,6 +352,14 @@ class UsersController < AuthenticatedController
                         'All members, application groups, and the active members group will be synced.'
   end
 
+  def toggle_authentik_sync_inactive_as_active
+    settings = DefaultSetting.instance
+    settings.update!(authentik_sync_inactive_as_active: !settings.authentik_sync_inactive_as_active)
+    status = settings.authentik_sync_inactive_as_active? ? 'active in Authentik' : 'inactive in Authentik'
+    redirect_to users_path,
+                notice: "Authentik sync updated: inactive members will be synced as #{status}."
+  end
+
   def activate
     unless @user.service_account?
       redirect_to user_path(@user),

--- a/app/jobs/authentik/full_sync_to_authentik_job.rb
+++ b/app/jobs/authentik/full_sync_to_authentik_job.rb
@@ -108,7 +108,7 @@ module Authentik
         username: username,
         name: name,
         email: user.email,
-        is_active: user.active?,
+        is_active: Authentik::ActiveStatus.for(user),
         attributes: Authentik::UserAttributes.for(user)
       )
 
@@ -135,7 +135,7 @@ module Authentik
       attrs[:email] = user.email if user.email.present?
       attrs[:name] = user.full_name if user.full_name.present?
       attrs[:username] = user.username if user.username.present?
-      attrs[:is_active] = user.active?
+      attrs[:is_active] = Authentik::ActiveStatus.for(user)
 
       attrs[:attributes] = Authentik::UserAttributes.for(user)
 

--- a/app/jobs/authentik/provision_user_job.rb
+++ b/app/jobs/authentik/provision_user_job.rb
@@ -42,7 +42,7 @@ module Authentik
         username: username,
         name: name,
         email: user.email,
-        is_active: user.active?,
+        is_active: Authentik::ActiveStatus.for(user),
         attributes: Authentik::UserAttributes.for(user)
       )
 

--- a/app/models/default_setting.rb
+++ b/app/models/default_setting.rb
@@ -11,6 +11,7 @@ class DefaultSetting < ApplicationRecord
   validates :trained_on_prefix, presence: true
   validates :can_train_prefix, presence: true
   validates :sync_inactive_members, inclusion: { in: [true, false] }
+  validates :authentik_sync_inactive_as_active, inclusion: { in: [true, false] }
   validates :rfid_facility_code, presence: true,
                                  numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :map_center_latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }

--- a/app/services/authentik/active_status.rb
+++ b/app/services/authentik/active_status.rb
@@ -1,0 +1,11 @@
+module Authentik
+  module ActiveStatus
+    def self.for(user)
+      user.active? || sync_inactive_as_active?
+    end
+
+    def self.sync_inactive_as_active?
+      DefaultSetting.instance.authentik_sync_inactive_as_active
+    end
+  end
+end

--- a/app/services/authentik/user_sync.rb
+++ b/app/services/authentik/user_sync.rb
@@ -106,8 +106,10 @@ module Authentik
     end
 
     def build_update_payload(fields_to_sync)
-      attrs = fields_to_sync.index_with { |field| user.send(field) }
-                            .transform_keys { |field| FIELD_MAPPING[field] }
+      field_values = fields_to_sync.index_with do |field|
+        field == 'active' ? Authentik::ActiveStatus.for(user) : user.send(field)
+      end
+      attrs = field_values.transform_keys { |field| FIELD_MAPPING[field] }
       attrs[:attributes] = UserAttributes.for(user)
       attrs
     end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,7 +14,12 @@
       <% end %>
     </p>
   </div>
-  <div class="d-flex gap-2">
+  <div class="d-flex gap-2 align-items-center">
+    <% settings = DefaultSetting.instance %>
+    <%= button_to toggle_authentik_sync_inactive_as_active_users_path, method: :post, class: "btn btn-sm #{settings.authentik_sync_inactive_as_active? ? 'btn-outline-secondary' : 'btn-warning'}", data: { turbo: false }, title: "When enabled, inactive members keep Authentik access" do %>
+      <i class="bi bi-<%= settings.authentik_sync_inactive_as_active? ? 'toggle-on' : 'toggle-off' %> me-1"></i>
+      Sync inactive as active
+    <% end %>
     <% if MemberSource.enabled?('member_manager') %>
       <%= button_to "Sync to Authentik", sync_all_to_authentik_users_path, method: :post, class: "btn btn-outline-secondary btn-sm", data: { turbo: false, turbo_confirm: "This will sync all members, groups, and the active members group to Authentik. Continue?" } %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
     collection do
       post :sync
       post :sync_all_to_authentik
+      post :toggle_authentik_sync_inactive_as_active
     end
     resources :user_links, only: [:create, :update, :destroy]
   end

--- a/db/migrate/20260610120000_add_authentik_sync_inactive_as_active_to_default_settings.rb
+++ b/db/migrate/20260610120000_add_authentik_sync_inactive_as_active_to_default_settings.rb
@@ -1,0 +1,5 @@
+class AddAuthentikSyncInactiveAsActiveToDefaultSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :default_settings, :authentik_sync_inactive_as_active, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_16_071100) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_10_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -274,20 +274,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_16_071100) do
     t.string "admins_group", null: false
     t.string "all_members_group", null: false
     t.string "app_prefix", null: false
+    t.boolean "authentik_sync_inactive_as_active", default: true, null: false
     t.string "can_train_prefix", null: false
     t.datetime "created_at", null: false
-    t.string "members_prefix", null: false
     t.decimal "map_center_latitude", precision: 10, scale: 6, default: "45.581678", null: false
     t.decimal "map_center_longitude", precision: 10, scale: 6, default: "-122.682156", null: false
     t.string "map_default_city", default: "Portland", null: false
     t.string "map_default_state", default: "Oregon", null: false
     t.decimal "map_radius_miles", precision: 5, scale: 2, default: "4.0", null: false
+    t.string "members_prefix", null: false
+    t.integer "rfid_facility_code", default: 127, null: false
     t.string "site_prefix", default: "ctrlh", null: false
     t.boolean "sync_inactive_members", default: false, null: false
     t.string "trained_on_prefix", null: false
     t.string "unbanned_members_group", null: false
     t.datetime "updated_at", null: false
-    t.integer "rfid_facility_code", default: 127, null: false
   end
 
   create_table "document_training_topics", force: :cascade do |t|
@@ -307,9 +308,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_16_071100) do
   end
 
   create_table "email_templates", force: :cascade do |t|
+    t.boolean "block_send_immediately", default: false, null: false
     t.text "body_html", null: false
     t.text "body_text", null: false
-    t.boolean "block_send_immediately", default: false, null: false
     t.datetime "created_at", null: false
     t.string "description"
     t.boolean "enabled", default: true, null: false
@@ -536,7 +537,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_16_071100) do
 
   create_table "membership_applications", force: :cascade do |t|
     t.text "admin_notes"
-    t.datetime "application_nag_sent_at"
     t.boolean "ai_feedback_garbage", default: false, null: false
     t.text "ai_feedback_garbage_reason"
     t.text "ai_feedback_last_error"
@@ -545,6 +545,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_16_071100) do
     t.string "ai_feedback_recommendation"
     t.integer "ai_feedback_score"
     t.text "ai_feedback_score_rationale"
+    t.datetime "application_nag_sent_at"
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.datetime "reviewed_at"
@@ -1003,8 +1004,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_16_071100) do
     t.boolean "legacy", default: false, null: false
     t.string "login_token"
     t.datetime "login_token_expires_at"
-    t.datetime "mailing_geocoded_at"
     t.text "mailing_address"
+    t.datetime "mailing_geocoded_at"
     t.decimal "mailing_latitude", precision: 10, scale: 6
     t.decimal "mailing_longitude", precision: 10, scale: 6
     t.date "membership_ended_date"

--- a/test/services/authentik/active_status_test.rb
+++ b/test/services/authentik/active_status_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+module Authentik
+  class ActiveStatusTest < ActiveSupport::TestCase
+    setup do
+      @settings = DefaultSetting.instance
+      @original_value = @settings.authentik_sync_inactive_as_active
+    end
+
+    teardown do
+      @settings.update!(authentik_sync_inactive_as_active: @original_value)
+    end
+
+    test 'returns user active status when sync inactive as active is disabled' do
+      @settings.update!(authentik_sync_inactive_as_active: false)
+      active_user = users(:one)
+      inactive_user = users(:two)
+      inactive_user.update_columns(active: false)
+
+      assert Authentik::ActiveStatus.for(active_user)
+      assert_not Authentik::ActiveStatus.for(inactive_user)
+    end
+
+    test 'forces inactive users active when sync inactive as active is enabled' do
+      @settings.update!(authentik_sync_inactive_as_active: true)
+      inactive_user = users(:two)
+      inactive_user.update_columns(active: false)
+
+      assert Authentik::ActiveStatus.for(inactive_user)
+    end
+
+    test 'keeps active users active when sync inactive as active is enabled' do
+      @settings.update!(authentik_sync_inactive_as_active: true)
+
+      assert Authentik::ActiveStatus.for(users(:one))
+    end
+  end
+end

--- a/test/services/authentik/user_sync_test.rb
+++ b/test/services/authentik/user_sync_test.rb
@@ -126,6 +126,44 @@ module Authentik
       assert_equal slack_user.username, captured_attrs[:attributes]['slack_handle']
     end
 
+    test 'sync_to_authentik sends inactive users as active when setting enabled' do
+      DefaultSetting.instance.update!(authentik_sync_inactive_as_active: true)
+      user = users(:two)
+      user.update_columns(authentik_id: 'authentik-inactive-active-test', active: false)
+
+      captured_attrs = nil
+      client = Class.new do
+        define_method(:update_user) do |authentik_id, **attrs|
+          captured_attrs = attrs
+          { 'pk' => authentik_id }
+        end
+      end.new
+
+      result = Authentik::UserSync.new(user, client: client).sync_to_authentik!(changed_fields: %w[active])
+
+      assert_equal 'synced', result[:status]
+      assert_equal true, captured_attrs['is_active']
+    end
+
+    test 'sync_to_authentik sends inactive users as inactive when setting disabled' do
+      DefaultSetting.instance.update!(authentik_sync_inactive_as_active: false)
+      user = users(:two)
+      user.update_columns(authentik_id: 'authentik-inactive-inactive-test', active: false)
+
+      captured_attrs = nil
+      client = Class.new do
+        define_method(:update_user) do |authentik_id, **attrs|
+          captured_attrs = attrs
+          { 'pk' => authentik_id }
+        end
+      end.new
+
+      result = Authentik::UserSync.new(user, client: client).sync_to_authentik!(changed_fields: %w[active])
+
+      assert_equal 'synced', result[:status]
+      assert_equal false, captured_attrs['is_active']
+    end
+
     test 'sync_to_authentik includes training attributes' do
       user = users(:one)
       user.update_columns(authentik_id: 'authentik-training-sync-test')


### PR DESCRIPTION
Keeps inactive members from losing Authentik access by default while allowing admins to disable the override from the Members page.