### PR TITLE
Admin cleanups: Authentik inactive sync, New Member label, parking self-close, training-driven access sync, dashboard contrast

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -501,6 +501,22 @@
 }
 .btn-link-add:hover { text-decoration: underline; }
 
+// Outline-secondary is the app's default action button, but Bootstrap's dark-mode
+// rendering (muted gray text + dim border) is low-contrast on our dark panels. Brighten the
+// label and border so actions are legible and stand out, without adding any color meaning.
+.btn-outline-secondary {
+  --bs-btn-color: var(--bs-body-color);
+  --bs-btn-border-color: var(--bs-secondary-color);
+  --bs-btn-hover-color: var(--bs-body-color);
+  --bs-btn-hover-bg: var(--bs-secondary-bg);
+  --bs-btn-hover-border-color: var(--bs-body-color);
+  --bs-btn-active-color: var(--bs-body-color);
+  --bs-btn-active-bg: var(--bs-secondary-bg);
+  --bs-btn-active-border-color: var(--bs-body-color);
+  --bs-btn-disabled-color: var(--bs-secondary-color);
+  --bs-btn-disabled-border-color: var(--bs-border-color);
+}
+
 .text-tertiary { color: var(--bs-secondary-color); opacity: 0.7; }
 
 .member-map-card {

--- a/app/controllers/concerns/trainer_capability_actions.rb
+++ b/app/controllers/concerns/trainer_capability_actions.rb
@@ -102,6 +102,8 @@ module TrainerCapabilityActions
   end
 
   def trainer_capability_return_path(trainee)
+    return user_path(trainee, anchor: 'training-access-section') if params[:return_to] == 'profile'
+
     record_training_path(
       trainer_user_id: trainee.id,
       topic_id: params[:return_topic_id].presence,

--- a/app/controllers/member_parking_permits_controller.rb
+++ b/app/controllers/member_parking_permits_controller.rb
@@ -20,6 +20,18 @@ class MemberParkingPermitsController < AuthenticatedController
     end
   end
 
+  # Members may close (clear) only their own active permits — never tickets.
+  def close
+    permit = current_user.parking_notices.permits.active_notices.find(params[:id])
+    permit.clear!(current_user)
+    permit.record_journal_entry!('parking_notice_cleared', actor: current_user)
+
+    redirect_to user_path(current_user, tab: :parking), notice: 'Parking permit closed.'
+  rescue ActiveRecord::RecordNotFound
+    redirect_to user_path(current_user, tab: :parking),
+                alert: 'That parking permit is not available to close.'
+  end
+
   private
 
   def member_parking_permit_params

--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -225,6 +225,8 @@ class TrainingsController < AuthenticatedController
   def redirect_back_path(user_id: nil)
     if params[:return_to] == 'topic' && @training_topic
       edit_training_topic_path(@training_topic)
+    elsif params[:return_to] == 'profile' && (user_id || @trainee)
+      user_path(user_id || @trainee, anchor: 'training-access-section')
     elsif user_id
       record_training_path(user_id: user_id)
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -355,9 +355,18 @@ class UsersController < AuthenticatedController
   def toggle_authentik_sync_inactive_as_active
     settings = DefaultSetting.instance
     settings.update!(authentik_sync_inactive_as_active: !settings.authentik_sync_inactive_as_active)
-    status = settings.authentik_sync_inactive_as_active? ? 'active in Authentik' : 'inactive in Authentik'
+
+    # Inactive members that already exist in Authentik aren't normally re-synced
+    # because their authentik_dirty flag was cleared after their last sync. Toggling
+    # this setting changes what their Authentik is_active value should be, so flag them
+    # dirty and run a sync to reconcile Authentik with the new setting.
+    affected = User.where(active: false).where.not(authentik_id: [nil, '']).update_all(authentik_dirty: true)
+    Authentik::FullSyncToAuthentikJob.perform_later if MemberSource.enabled?('member_manager')
+
+    status = settings.authentik_sync_inactive_as_active? ? 'active' : 'inactive'
     redirect_to users_path,
-                notice: "Authentik sync updated: inactive members will be synced as #{status}."
+                notice: "Inactive members will now be synced as #{status} in Authentik. " \
+                        "Syncing #{affected} inactive #{'member'.pluralize(affected)} now."
   end
 
   def activate

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,4 +1,11 @@
 module UsersHelper
+  # Overrides humanize where an enum key reads poorly (an approved applicant is now a member).
+  MEMBERSHIP_STATUS_LABELS = { 'applicant' => 'New Member' }.freeze
+
+  def membership_status_label(status)
+    MEMBERSHIP_STATUS_LABELS.fetch(status.to_s, status.to_s.humanize)
+  end
+
   # Build a URL that toggles one filter while preserving all other active filters.
   # If the filter is already active with the same value, clicking removes it.
   # Passing nil as filter_value always removes that filter key.

--- a/app/jobs/access_controller_training_sync_job.rb
+++ b/app/jobs/access_controller_training_sync_job.rb
@@ -1,0 +1,23 @@
+class AccessControllerTrainingSyncJob < ApplicationJob
+  queue_as :default
+
+  # Re-syncs every enabled access controller whose (enabled) type requires the given
+  # training topic. A user's training change can grant or revoke their access on those
+  # controllers, so the full authorized-user payload must be pushed again.
+  def perform(training_topic_id)
+    type_ids = AccessControllerType.enabled
+                                   .joins(:access_controller_type_training_topics)
+                                   .where(access_controller_type_training_topics: {
+                                            training_topic_id: training_topic_id
+                                          })
+                                   .distinct
+                                   .pluck(:id)
+    return if type_ids.empty?
+
+    AccessController.enabled
+                    .where(access_controller_type_id: type_ids)
+                    .find_each do |controller|
+      AccessControllerVerbJob.perform_later(controller.id, 'sync')
+    end
+  end
+end

--- a/app/models/training.rb
+++ b/app/models/training.rb
@@ -10,8 +10,18 @@ class Training < ApplicationRecord
   after_create :sync_trained_in_group, :clear_pending_training_requests
   after_destroy :sync_trained_in_group
   after_commit :enqueue_trainee_authentik_sync, on: %i[create destroy]
+  after_commit :sync_required_access_controllers, on: %i[create destroy]
 
   private
+
+  # When a topic is required by an access controller type, a training change alters who
+  # is authorized, so re-sync every controller of that type.
+  def sync_required_access_controllers
+    return if training_topic_id.blank?
+    return unless AccessControllerTypeTrainingTopic.exists?(training_topic_id: training_topic_id)
+
+    AccessControllerTrainingSyncJob.perform_later(training_topic_id)
+  end
 
   def enqueue_trainee_authentik_sync
     return if Current.skip_authentik_sync

--- a/app/views/application_groups/show.html.erb
+++ b/app/views/application_groups/show.html.erb
@@ -178,7 +178,7 @@
                 </td>
                 <td>
                   <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %>">
-                    <%= user.membership_status.humanize %>
+                    <%= membership_status_label(user.membership_status) %>
                   </span>
                   <% if user.active? %>
                     <span class="badge text-bg-success ms-1">Active</span>
@@ -244,7 +244,7 @@
                 </td>
                 <td>
                   <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %>">
-                    <%= user.membership_status.humanize %>
+                    <%= membership_status_label(user.membership_status) %>
                   </span>
                   <% if user.active? %>
                     <span class="badge text-bg-success ms-1">Active</span>
@@ -321,7 +321,7 @@
                   </td>
                   <td>
                     <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %>">
-                      <%= user.membership_status.humanize %>
+                      <%= membership_status_label(user.membership_status) %>
                     </span>
                     <% if user.active? %>
                       <span class="badge text-bg-success ms-1">Active</span>

--- a/app/views/reports/_slack_member_table.html.erb
+++ b/app/views/reports/_slack_member_table.html.erb
@@ -33,7 +33,7 @@
             <% end %>
           </td>
           <td>
-            <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %>"><%= user.membership_status.humanize %></span>
+            <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %>"><%= membership_status_label(user.membership_status) %></span>
             <% if user.legacy? %>
               <span class="badge text-bg-secondary">Legacy</span>
             <% end %>

--- a/app/views/reports/_user_table.html.erb
+++ b/app/views/reports/_user_table.html.erb
@@ -36,7 +36,7 @@
           </td>
           <td>
             <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %>">
-              <%= user.membership_status.humanize %>
+              <%= membership_status_label(user.membership_status) %>
             </span>
             <% if user.active? %>
               <span class="badge text-bg-success ms-1">Active</span>

--- a/app/views/reports/active_no_email_full.html.erb
+++ b/app/views/reports/active_no_email_full.html.erb
@@ -22,7 +22,7 @@
             <% @active_no_email.each do |user| %>
               <tr>
                 <td><%= link_to user.display_name, user_path(user), class: "text-decoration-none" %></td>
-                <td><span class="badge text-bg-secondary"><%= user.membership_status.humanize %></span></td>
+                <td><span class="badge text-bg-secondary"><%= membership_status_label(user.membership_status) %></span></td>
                 <td><span class="badge text-bg-secondary"><%= user.dues_status.humanize %></span></td>
               </tr>
             <% end %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -330,7 +330,7 @@
                       <%= link_to user.display_name, user_path(user), class: "text-decoration-none" %>
                     </td>
                     <td>
-                      <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %>"><%= user.membership_status.humanize %></span>
+                      <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %>"><%= membership_status_label(user.membership_status) %></span>
                     </td>
                     <td>
                       <span class="badge text-bg-info"><%= user.payment_type.humanize %></span>
@@ -544,7 +544,7 @@
                       <%= link_to user.display_name, user_path(user), class: "text-decoration-none" %>
                     </td>
                     <td>
-                      <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %>"><%= user.membership_status.humanize %></span>
+                      <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %>"><%= membership_status_label(user.membership_status) %></span>
                     </td>
                     <td><span class="badge text-bg-secondary"><%= user.payment_type.humanize %></span></td>
                     <td><span class="badge text-bg-secondary"><%= user.dues_status.humanize %></span></td>
@@ -821,7 +821,7 @@
                 <% @active_no_email.each do |user| %>
                   <tr>
                     <td><%= link_to user.display_name, user_path(user), class: "text-decoration-none" %></td>
-                    <td><span class="badge text-bg-secondary"><%= user.membership_status.humanize %></span></td>
+                    <td><span class="badge text-bg-secondary"><%= membership_status_label(user.membership_status) %></span></td>
                     <td><span class="badge text-bg-secondary"><%= user.dues_status.humanize %></span></td>
                   </tr>
                 <% end %>

--- a/app/views/rfids/new.html.erb
+++ b/app/views/rfids/new.html.erb
@@ -63,7 +63,7 @@
             <strong>This key fob is currently assigned to
               <%= link_to @existing_owner.display_name, user_path(@existing_owner), class: "alert-link" %></strong>
             <div class="small mt-1">
-              Membership: <strong><%= @existing_owner.membership_status.humanize %></strong>
+              Membership: <strong><%= membership_status_label(@existing_owner.membership_status) %></strong>
               &middot; Dues: <strong><%= @existing_owner.dues_status.humanize %></strong>
               <% if @existing_owner.legacy? %>
                 &middot; <span class="badge text-bg-secondary">Legacy</span>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -37,7 +37,7 @@
                   </td>
                   <td>
                     <span class="badge text-bg-<%= membership_status_badge_class(u.membership_status) %>">
-                      <%= u.membership_status.humanize %>
+                      <%= membership_status_label(u.membership_status) %>
                     </span>
                   </td>
                 </tr>

--- a/app/views/sheet_entries/test.html.erb
+++ b/app/views/sheet_entries/test.html.erb
@@ -28,7 +28,7 @@
                 <td>
                   <%= mail_to mismatch[:user_email] %>
                         <% unless mismatch[:user].active? %>
-                    <span class="badge text-bg-<%= membership_status_badge_class(mismatch[:user].membership_status) %> ms-2"><%= mismatch[:user].membership_status.humanize %></span>
+                    <span class="badge text-bg-<%= membership_status_badge_class(mismatch[:user].membership_status) %> ms-2"><%= membership_status_label(mismatch[:user].membership_status) %></span>
                   <% end %>
                 </td>
               </tr>
@@ -66,7 +66,7 @@
                 <td>
                   <strong><%= link_to mismatch[:user_name], user_path(mismatch[:user]), class: "text-decoration-none" %></strong>
                         <% unless mismatch[:user].active? %>
-                    <span class="badge text-bg-<%= membership_status_badge_class(mismatch[:user].membership_status) %> ms-2"><%= mismatch[:user].membership_status.humanize %></span>
+                    <span class="badge text-bg-<%= membership_status_badge_class(mismatch[:user].membership_status) %> ms-2"><%= membership_status_label(mismatch[:user].membership_status) %></span>
                   <% end %>
                 </td>
               </tr>
@@ -119,7 +119,7 @@
                     <span class="text-muted ms-2">(not in Sheet)</span>
                   <% end %>
                         <% unless mismatch[:user].active? %>
-                    <span class="badge text-bg-<%= membership_status_badge_class(mismatch[:user].membership_status) %> ms-2"><%= mismatch[:user].membership_status.humanize %></span>
+                    <span class="badge text-bg-<%= membership_status_badge_class(mismatch[:user].membership_status) %> ms-2"><%= membership_status_label(mismatch[:user].membership_status) %></span>
                   <% end %>
                 </td>
                 <td><%= mismatch[:sheet_email] ? mail_to(mismatch[:sheet_email]) : content_tag(:span, "—", class: "text-muted") %></td>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -112,7 +112,7 @@
             ["Banned", "banned"],
             ["Deceased", "deceased"],
             ["Sponsored", "sponsored"],
-            ["Applicant", "applicant"],
+            ["New Member", "applicant"],
             ["Cancelled", "cancelled"],
             ["Unknown", "unknown"]
           ], @user.membership_status),

--- a/app/views/users/_status_panel.html.erb
+++ b/app/views/users/_status_panel.html.erb
@@ -198,7 +198,7 @@
 
         <div class="mb-3">
           <small class="text-muted d-block">Membership Status</small>
-          <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %> fs-6"><%= user.membership_status.humanize %></span>
+          <span class="badge text-bg-<%= membership_status_badge_class(user.membership_status) %> fs-6"><%= membership_status_label(user.membership_status) %></span>
         </div>
 
         <% manage_membership_content = TextFragment.content_for('manage_your_membership') %>

--- a/app/views/users/_tab_parking.html.erb
+++ b/app/views/users/_tab_parking.html.erb
@@ -1,3 +1,6 @@
+<% show_actions = local_assigns[:show_actions] %>
+<% member_close = local_assigns[:member_close] %>
+<% show_actions_column = show_actions || member_close %>
 <% if parking_notices.any? %>
   <div class="card shadow-sm border-0">
     <div class="table-responsive">
@@ -9,7 +12,7 @@
             <th>Description</th>
             <th>Expires</th>
             <th>Status</th>
-            <% if defined?(show_actions) && show_actions %>
+            <% if show_actions_column %>
               <th class="text-end">Actions</th>
             <% end %>
           </tr>
@@ -32,9 +35,17 @@
               <td>
                 <span class="badge bg-<%= notice.status_badge_color %>"><%= notice.status_display %></span>
               </td>
-              <% if defined?(show_actions) && show_actions %>
+              <% if show_actions_column %>
                 <td class="text-end">
-                  <%= link_to "View", parking_notice_path(notice), class: "btn btn-sm btn-outline-primary" %>
+                  <% if show_actions %>
+                    <%= link_to "View", parking_notice_path(notice), class: "btn btn-sm btn-outline-primary" %>
+                  <% elsif member_close && notice.permit? && notice.active? %>
+                    <%= button_to "Close", close_member_parking_permit_path(notice), method: :patch,
+                        class: "btn btn-sm btn-outline-secondary",
+                        form: { data: { turbo_confirm: "Close this parking permit? This frees the spot and can't be undone." } } %>
+                  <% else %>
+                    <span class="text-muted">—</span>
+                  <% end %>
                 </td>
               <% end %>
             </tr>

--- a/app/views/users/_tab_profile_admin.html.erb
+++ b/app/views/users/_tab_profile_admin.html.erb
@@ -1,7 +1,12 @@
 <%# Admin Profile Tab %>
 <% visibility_label = { 'public' => 'Public', 'members' => 'Other members', 'private' => 'Private' }[user.profile_visibility] || user.profile_visibility.humanize %>
 <% trained_topics = user.trainings_as_trainee.map(&:training_topic).uniq.sort_by(&:name) %>
-<% documents = Document.ordered %>
+<% trained_topic_ids = trained_topics.map(&:id) %>
+<% can_train_topics = user.training_topics.order(:name).to_a %>
+<% can_train_topic_ids = can_train_topics.map(&:id) %>
+<% all_training_topics = TrainingTopic.order(:name).to_a %>
+<% untrained_topics = all_training_topics.reject { |topic| trained_topic_ids.include?(topic.id) } %>
+<% grantable_topics = all_training_topics.reject { |topic| can_train_topic_ids.include?(topic.id) } %>
 
 <div data-controller="sensitive-reveal">
 <div class="alert alert-secondary d-flex flex-column flex-sm-row align-items-sm-center justify-content-between gap-2 mb-3">
@@ -165,28 +170,78 @@
       <div class="profile-field-group">
         <div class="profile-field-row">
           <span class="profile-field-label">Trained on</span>
-          <span class="profile-field-value">
+          <div class="d-flex align-items-center gap-1 flex-wrap">
             <% if trained_topics.any? %>
               <% trained_topics.each do |topic| %>
-                <span class="cert-pill me-1"><%= topic.name %></span>
+                <span class="cert-pill d-inline-flex align-items-center">
+                  <%= topic.name %>
+                  <%= button_to remove_training_path(user_id: user.id, topic_id: topic.id, return_to: 'profile'),
+                      method: :delete,
+                      class: "btn-link-danger ms-1 p-0 border-0 bg-transparent lh-1",
+                      title: "Remove #{topic.name} training",
+                      form: { class: 'd-inline', data: { turbo: false, turbo_confirm: "Remove #{topic.name} training from #{user.display_name}?" } } do %>
+                    <i class="bi bi-x-lg"></i>
+                  <% end %>
+                </span>
               <% end %>
             <% else %>
-              <span class="empty">None recorded</span>
+              <span class="profile-field-value empty">None recorded</span>
             <% end %>
-          </span>
+            <% if untrained_topics.any? %>
+              <div class="dropdown d-inline-block ms-auto">
+                <button class="btn-link-add" type="button" data-bs-toggle="dropdown" aria-expanded="false">+ Add training</button>
+                <ul class="dropdown-menu dropdown-menu-end" style="max-height: 320px; overflow-y: auto;">
+                  <% untrained_topics.each do |topic| %>
+                    <li>
+                      <%= button_to topic.name,
+                          add_training_path(user_id: user.id, topic_id: topic.id, return_to: 'profile'),
+                          method: :post,
+                          class: "dropdown-item text-13",
+                          form: { data: { turbo: false } } %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+          </div>
         </div>
 
         <div class="profile-field-row">
           <span class="profile-field-label">Can train</span>
-          <span class="profile-field-value">
-            <% if user.training_topics.any? %>
-              <% user.training_topics.order(:name).each do |topic| %>
-                <span class="cert-pill me-1"><%= topic.name %></span>
+          <div class="d-flex align-items-center gap-1 flex-wrap">
+            <% if can_train_topics.any? %>
+              <% can_train_topics.each do |topic| %>
+                <span class="cert-pill d-inline-flex align-items-center">
+                  <%= topic.name %>
+                  <%= button_to remove_trainer_capability_path(user_id: user.id, topic_id: topic.id, return_to: 'profile'),
+                      method: :delete,
+                      class: "btn-link-danger ms-1 p-0 border-0 bg-transparent lh-1",
+                      title: "Revoke #{topic.name} trainer capability",
+                      form: { class: 'd-inline', data: { turbo: false, turbo_confirm: "Remove #{topic.name} trainer capability from #{user.display_name}?" } } do %>
+                    <i class="bi bi-x-lg"></i>
+                  <% end %>
+                </span>
               <% end %>
             <% else %>
-              <span class="empty">None</span>
+              <span class="profile-field-value empty">None</span>
             <% end %>
-          </span>
+            <% if grantable_topics.any? %>
+              <div class="dropdown d-inline-block ms-auto">
+                <button class="btn-link-add" type="button" data-bs-toggle="dropdown" aria-expanded="false">+ Grant can train</button>
+                <ul class="dropdown-menu dropdown-menu-end" style="max-height: 320px; overflow-y: auto;">
+                  <% grantable_topics.each do |topic| %>
+                    <li>
+                      <%= button_to topic.name,
+                          add_trainer_capability_path(user_id: user.id, topic_id: topic.id, return_to: 'profile'),
+                          method: :post,
+                          class: "dropdown-item text-13",
+                          form: { data: { turbo: false } } %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+          </div>
         </div>
 
         <div class="profile-field-row">
@@ -314,22 +369,9 @@
   <div class="col-lg-4">
     <%= render 'users/member_membership_card', user: user %>
 
-    <div class="sidebar-card mb-2">
-      <div class="h-section-label mb-2">Documents</div>
-      <% if documents.any? %>
-        <div class="d-flex flex-column gap-1">
-          <% documents.each do |document| %>
-            <%= link_to download_document_path(document), class: "resource-link" do %>
-              &darr; <%= document.title %>
-            <% end %>
-          <% end %>
-        </div>
-      <% else %>
-        <div class="text-12 text-secondary">No documents published.</div>
-      <% end %>
-    </div>
-
     <%= render 'users/member_training_card', user: user, show_request_link: false %>
+
+    <%= render 'users/member_resources_card', user: user %>
   </div>
 </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -16,9 +16,13 @@
   </div>
   <div class="d-flex gap-2 align-items-center">
     <% settings = DefaultSetting.instance %>
-    <%= button_to toggle_authentik_sync_inactive_as_active_users_path, method: :post, class: "btn btn-sm #{settings.authentik_sync_inactive_as_active? ? 'btn-outline-secondary' : 'btn-warning'}", data: { turbo: false }, title: "When enabled, inactive members keep Authentik access" do %>
-      <i class="bi bi-<%= settings.authentik_sync_inactive_as_active? ? 'toggle-on' : 'toggle-off' %> me-1"></i>
-      Sync inactive as active
+    <% sync_inactive_as_active = settings.authentik_sync_inactive_as_active? %>
+    <%= button_to toggle_authentik_sync_inactive_as_active_users_path, method: :post,
+        class: "btn btn-sm #{sync_inactive_as_active ? 'btn-outline-success' : 'btn-outline-secondary'}",
+        data: { turbo: false, turbo_confirm: sync_inactive_as_active ? 'Stop keeping inactive members active in Authentik? They will be set inactive there.' : 'Keep inactive members active in Authentik? They will be re-synced as active.' },
+        title: sync_inactive_as_active ? 'On — inactive members are kept active in Authentik. Click to turn off.' : 'Off — inactive members are set inactive in Authentik. Click to turn on.' do %>
+      <i class="bi bi-<%= sync_inactive_as_active ? 'check-circle-fill' : 'x-circle' %> me-1"></i>
+      Inactive synced as active: <span class="fw-medium"><%= sync_inactive_as_active ? 'On' : 'Off' %></span>
     <% end %>
     <% if MemberSource.enabled?('member_manager') %>
       <%= button_to "Sync to Authentik", sync_all_to_authentik_users_path, method: :post, class: "btn btn-outline-secondary btn-sm", data: { turbo: false, turbo_confirm: "This will sync all members, groups, and the active members group to Authentik. Continue?" } %>
@@ -32,7 +36,7 @@
   <%
     filter_labels = []
     filter_labels << "Including legacy" if @include_legacy
-    filter_labels << "Membership: #{params[:membership_status].humanize}" if params[:membership_status].present?
+    filter_labels << "Membership: #{membership_status_label(params[:membership_status])}" if params[:membership_status].present?
     filter_labels << "Payment: #{params[:payment_type].humanize}" if params[:payment_type].present?
     filter_labels << "Dues: #{params[:dues_status].humanize}" if params[:dues_status].present?
     filter_labels << "Search: #{params[:q]}" if params[:q].present?
@@ -94,7 +98,7 @@
         <%= '✓ ' if params[:membership_status] == 'paying' %>Paying <span class="count"><%= @membership_status_paying %></span>
       <% end %>
       <%= link_to stacking_filter_path(:membership_status, 'applicant'), class: "filter-chip warning text-decoration-none #{'active' if params[:membership_status] == 'applicant'} #{'muted' if @membership_status_applicant.zero?}" do %>
-        <%= '✓ ' if params[:membership_status] == 'applicant' %>Applicant <span class="count"><%= @membership_status_applicant %></span>
+        <%= '✓ ' if params[:membership_status] == 'applicant' %>New Member <span class="count"><%= @membership_status_applicant %></span>
       <% end %>
       <%= link_to stacking_filter_path(:membership_status, 'banned'), class: "filter-chip danger text-decoration-none #{'active' if params[:membership_status] == 'banned'} #{'muted' if @membership_status_banned.zero?}" do %>
         <%= '✓ ' if params[:membership_status] == 'banned' %>Banned <span class="count"><%= @membership_status_banned %></span>
@@ -245,7 +249,7 @@
                   <% end %>
                 </td>
                 <td>
-                  <span class="badge <%= membership_status_badge_subtle_class(user.membership_status) %>"><%= user.membership_status&.humanize %></span>
+                  <span class="badge <%= membership_status_badge_subtle_class(user.membership_status) %>"><%= membership_status_label(user.membership_status) %></span>
                 </td>
                 <td class="text-muted small"><%= time_ago_in_words(user.created_at) %> ago</td>
               </tr>
@@ -305,7 +309,7 @@
                 <span class="text-muted">–</span>
               <% else %>
                 <span class="badge <%= membership_status_badge_subtle_class(user.membership_status) %>">
-                  <%= user.membership_status.humanize %>
+                  <%= membership_status_label(user.membership_status) %>
                 </span>
                 <% if user.active? %>
                   <span class="badge text-bg-success-subtle ms-1">Active</span>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -402,7 +402,7 @@
     <% elsif @active_tab == :payments %>
       <%= render 'users/tab_payments', payments: @payments, pagy: @pagy_payments, user: @user, show_payment_links: false %>
     <% elsif @active_tab == :parking %>
-      <%= render 'users/tab_parking', parking_notices: @parking_notices_list, show_actions: false %>
+      <%= render 'users/tab_parking', parking_notices: @parking_notices_list, show_actions: false, member_close: true %>
     <% elsif @active_tab == :messages %>
       <%= render 'users/tab_messages', messages: @messages, pagy: @pagy_messages, user: @user, show_send: false %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,11 @@ Rails.application.routes.draw do
   get '/training/record', to: 'trainings#record', as: :record_training
   post '/training/record', to: 'trainings#create_bulk'
   get '/training/:id',  to: 'training_catalog#show',  as: :training_catalog_topic, constraints: { id: /\d+/ }
-  resources :member_parking_permits, only: %i[new create]
+  resources :member_parking_permits, only: %i[new create] do
+    member do
+      patch :close
+    end
+  end
 
   resources :users, only: [:index, :show, :new, :create, :edit, :update, :destroy], constraints: { id: /[^\/]+/ } do
     member do

--- a/test/controllers/member_parking_permits_controller_test.rb
+++ b/test/controllers/member_parking_permits_controller_test.rb
@@ -47,6 +47,54 @@ class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to login_path
   end
 
+  test 'member can close own active permit' do
+    sign_in_as_member
+    member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
+    permit = member.parking_notices.create!(
+      notice_type: 'permit', status: 'active', issued_by: member,
+      expires_at: 3.days.from_now, description: 'Done early', location: 'Woodshop'
+    )
+
+    patch close_member_parking_permit_path(permit)
+
+    assert_redirected_to user_path(member, tab: :parking)
+    permit.reload
+    assert_equal 'cleared', permit.status
+    assert_equal member.id, permit.cleared_by_id
+  end
+
+  test 'member cannot close their own ticket' do
+    sign_in_as_member
+    member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
+    ticket = ParkingNotice.create!(
+      notice_type: 'ticket', status: 'active', user: member, issued_by: member,
+      expires_at: 3.days.from_now, description: 'Enforcement', location: 'Main Area'
+    )
+
+    patch close_member_parking_permit_path(ticket)
+
+    assert_redirected_to user_path(member, tab: :parking)
+    assert_equal 'active', ticket.reload.status
+  end
+
+  test "member cannot close another member's permit" do
+    sign_in_as_member
+    other_permit = parking_notices(:active_permit)
+
+    patch close_member_parking_permit_path(other_permit)
+
+    assert_equal 'active', other_permit.reload.status
+  end
+
+  test 'anonymous user cannot close a permit' do
+    permit = parking_notices(:active_permit)
+
+    patch close_member_parking_permit_path(permit)
+
+    assert_redirected_to login_path
+    assert_equal 'active', permit.reload.status
+  end
+
   private
 
   def sign_in_as_member

--- a/test/controllers/trainings_controller_test.rb
+++ b/test/controllers/trainings_controller_test.rb
@@ -177,6 +177,48 @@ class TrainingsControllerTest < ActionDispatch::IntegrationTest
     assert_match 'can now train others', flash[:notice]
   end
 
+  test 'add_training with return_to profile redirects to the member profile training section' do
+    sign_in_as_admin
+    trainee = users(:no_email)
+
+    assert_difference 'Training.count', 1 do
+      post add_training_path(user_id: trainee.id, topic_id: @laser_topic.id, return_to: 'profile')
+    end
+
+    assert_redirected_to user_path(trainee.id, anchor: 'training-access-section')
+  end
+
+  test 'remove_training with return_to profile redirects to the member profile training section' do
+    sign_in_as_admin
+    trainee = users(:no_email)
+    Training.create!(trainee: trainee, trainer: users(:one), training_topic: @laser_topic, trained_at: 1.day.ago)
+
+    assert_difference 'Training.count', -1 do
+      delete remove_training_path(user_id: trainee.id, topic_id: @laser_topic.id, return_to: 'profile')
+    end
+
+    assert_redirected_to user_path(trainee.id, anchor: 'training-access-section')
+  end
+
+  test 'add_trainer_capability with return_to profile redirects to the member profile training section' do
+    sign_in_as_admin
+    trainee = users(:no_email)
+
+    post add_trainer_capability_path(user_id: trainee.id, topic_id: @laser_topic.id, return_to: 'profile')
+
+    assert_redirected_to user_path(trainee, anchor: 'training-access-section')
+  end
+
+  test 'remove_trainer_capability with return_to profile redirects to the member profile training section' do
+    sign_in_as_admin
+    trainee = users(:no_email)
+    TrainerCapability.create!(user: trainee, training_topic: @laser_topic)
+
+    delete remove_trainer_capability_path(user_id: trainee.id, topic_id: @laser_topic.id, return_to: 'profile')
+
+    assert_redirected_to user_path(trainee, anchor: 'training-access-section')
+  end
+
   private
 
   def sign_in_as_admin

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -368,6 +368,30 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Member Manager source is disabled.', flash[:alert]
   end
 
+  test 'toggle_authentik_sync_inactive_as_active flips the setting, flags inactive members, and syncs' do
+    DefaultSetting.instance.update!(authentik_sync_inactive_as_active: true)
+    inactive = users(:one)
+    inactive.update_columns(active: false, authentik_dirty: false)
+
+    assert_enqueued_with(job: Authentik::FullSyncToAuthentikJob) do
+      post toggle_authentik_sync_inactive_as_active_users_path
+    end
+
+    assert_redirected_to users_path
+    assert_not DefaultSetting.instance.authentik_sync_inactive_as_active
+    assert inactive.reload.authentik_dirty, 'inactive member with an Authentik ID should be flagged for re-sync'
+  end
+
+  test 'toggle_authentik_sync_inactive_as_active does not flag active members for re-sync' do
+    active_member = users(:two)
+    active_member.update_columns(active: true, authentik_dirty: false)
+
+    post toggle_authentik_sync_inactive_as_active_users_path
+
+    assert_redirected_to users_path
+    assert_not active_member.reload.authentik_dirty, 'active members should not be flagged by the toggle'
+  end
+
   test 'per-user sync_from_authentik redirects with alert when authentik source is disabled' do
     member_sources(:authentik).update!(enabled: false)
 

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -20,4 +20,18 @@ class UsersHelperTest < ActionView::TestCase
     assert_includes text, user.display_name.downcase
     assert_no_match(/\s{2,}/, text)
   end
+
+  test 'membership_status_label renders an approved applicant as New Member' do
+    assert_equal 'New Member', membership_status_label('applicant')
+  end
+
+  test 'membership_status_label humanizes other statuses' do
+    assert_equal 'Paying', membership_status_label('paying')
+    assert_equal 'Cancelled', membership_status_label('cancelled')
+    assert_equal 'Unknown', membership_status_label('unknown')
+  end
+
+  test 'membership_status_label handles a blank status' do
+    assert_equal '', membership_status_label(nil)
+  end
 end

--- a/test/jobs/access_controller_training_sync_job_test.rb
+++ b/test/jobs/access_controller_training_sync_job_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class AccessControllerTrainingSyncJobTest < ActiveJob::TestCase
+  setup do
+    @laser_topic = training_topics(:laser_cutting)
+    @laser_type = access_controller_types(:laser_controller)
+    @door_type = access_controller_types(:door_lock)
+
+    # laser_controller type requires laser_cutting (see fixtures).
+    @laser_one = AccessController.create!(name: 'Laser 1', hostname: 'laser1.local',
+                                          access_controller_type: @laser_type)
+    @laser_two = AccessController.create!(name: 'Laser 2', hostname: 'laser2.local',
+                                          access_controller_type: @laser_type)
+    @laser_disabled = AccessController.create!(name: 'Laser 3', hostname: 'laser3.local',
+                                               access_controller_type: @laser_type, enabled: false)
+    @door = AccessController.create!(name: 'Door 1', hostname: 'door1.local', access_controller_type: @door_type)
+  end
+
+  test 'syncs only enabled controllers of types requiring the topic' do
+    assert_enqueued_jobs 2, only: AccessControllerVerbJob do
+      AccessControllerTrainingSyncJob.perform_now(@laser_topic.id)
+    end
+
+    assert_enqueued_with(job: AccessControllerVerbJob, args: [@laser_one.id, 'sync'])
+    assert_enqueued_with(job: AccessControllerVerbJob, args: [@laser_two.id, 'sync'])
+  end
+
+  test 'does nothing when no controller type requires the topic' do
+    woodworking = training_topics(:woodworking)
+
+    assert_no_enqueued_jobs only: AccessControllerVerbJob do
+      AccessControllerTrainingSyncJob.perform_now(woodworking.id)
+    end
+  end
+
+  test 'skips controllers whose type is disabled' do
+    AccessControllerTypeTrainingTopic.create!(
+      access_controller_type: access_controller_types(:disabled_type),
+      training_topic: @laser_topic
+    )
+    AccessController.create!(name: 'Disabled C', hostname: 'd.local',
+                             access_controller_type: access_controller_types(:disabled_type))
+
+    # Still only the two enabled laser controllers, not the disabled-type controller.
+    assert_enqueued_jobs 2, only: AccessControllerVerbJob do
+      AccessControllerTrainingSyncJob.perform_now(@laser_topic.id)
+    end
+  end
+end

--- a/test/models/training_test.rb
+++ b/test/models/training_test.rb
@@ -1,11 +1,35 @@
 require 'test_helper'
 
 class TrainingTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   setup do
     @topic = training_topics(:laser_cutting)
     @trainee = users(:member_with_local_account)
     @trainer = users(:one)
     @request = training_requests(:pending_laser_request)
+  end
+
+  test 'creating training for a topic required by an access controller type enqueues a sync' do
+    assert_enqueued_with(job: AccessControllerTrainingSyncJob, args: [@topic.id]) do
+      Training.create!(trainee: @trainee, trainer: @trainer, training_topic: @topic, trained_at: Time.current)
+    end
+  end
+
+  test 'removing training for a required topic enqueues a sync' do
+    training = Training.create!(trainee: @trainee, trainer: @trainer, training_topic: @topic, trained_at: Time.current)
+
+    assert_enqueued_with(job: AccessControllerTrainingSyncJob, args: [@topic.id]) do
+      training.destroy!
+    end
+  end
+
+  test 'training change for a topic no access controller requires does not enqueue a sync' do
+    woodworking = training_topics(:woodworking)
+
+    assert_no_enqueued_jobs only: AccessControllerTrainingSyncJob do
+      Training.create!(trainee: @trainee, trainer: @trainer, training_topic: woodworking, trained_at: Time.current)
+    end
   end
 
   test 'creating training clears pending request for same user and topic' do


### PR DESCRIPTION
## Summary

A batch of admin-tool cleanups (branch `fix/cleanups`, targets `staging`):

- **Inline training management on member profiles** — admins can add/remove trainings and grant/revoke "can train" capability directly from a member's profile, redirecting back to the profile's training section.
- **Authentik "sync inactive as active" actually works** — the previous toggle changed the setting but never re-synced already-inactive members (the full sync only pushes `authentik_dirty` users, and theirs was cleared). Toggling now flags inactive members dirty and runs a full sync so Authentik reconciles. The toggle UI is now an explicit on/off control (check / X, green when on) instead of the previous low-contrast, inverted button.
- **"Applicant" → "New Member"** — once an application is approved the member is no longer an applicant. Relabeled everywhere the status is shown, via a single `membership_status_label` helper (falls back to `humanize` for every other status). The enum key stays `applicant`; no migration.
- **Members can close their own parking permits** — a "Close" action on the member's Parking tab clears their own *active permits* only (never tickets, never other members' records).
- **Training changes auto-sync access controllers** — when a user is trained or untrained in a topic that an access controller *type* requires, all enabled controllers of that type are re-synced (their authorized-user payload is training-gated). Implemented via a `Training` model hook + `AccessControllerTrainingSyncJob`.
- **Dashboard action button contrast** — `btn-outline-secondary` (the app's default action button) was muted gray-on-dark and hard to read on dashboard panels. Brightened the label/border with a subtle hover, no added color meaning.

## Test plan

- [x] Full suite green: `1196 runs, 4364 assertions, 0 failures, 0 errors, 0 skips`
- [x] RuboCop clean on all changed Ruby files
- [x] New tests: Authentik toggle (flips setting, flags inactive members, enqueues sync; leaves active members alone), `membership_status_label` helper, profile training/trainer-capability `return_to: profile` redirects, member parking self-close (own active permit only; not tickets; not others'; anonymous blocked), and `AccessControllerTrainingSyncJob` (syncs only enabled controllers of enabled types requiring the topic) + `Training` callback enqueue.

## Notes

- The dashboard contrast change is global (every `btn-outline-secondary`), intentionally, for consistency.
- With the Authentik override on, banned/deceased members' accounts stay enabled in Authentik (existing feature behavior, unchanged) but remain excluded from the active-members group.
- Bulk training in a required topic enqueues redundant (idempotent) controller syncs; can add a debounce later if volume warrants.

Made with [Cursor](https://cursor.com)