### PR TITLE
Member self-service parking: view/edit/clear own permits, view tickets

### DIFF
--- a/app/controllers/member_parking_permits_controller.rb
+++ b/app/controllers/member_parking_permits_controller.rb
@@ -1,10 +1,19 @@
 class MemberParkingPermitsController < AuthenticatedController
+  before_action :set_owned_notice, only: %i[show edit update close]
+  before_action :require_owned_permit, only: %i[edit update close]
+
+  # Members may view their own permits and tickets.
+  def show; end
+
   def new
     @parking_notice = ParkingNotice.new(
       notice_type: 'permit',
       expires_at: 7.days.from_now
     )
   end
+
+  # Members may edit only their own permits (guarded by require_owned_permit).
+  def edit; end
 
   def create
     @parking_notice = current_user.parking_notices.build(member_parking_permit_params)
@@ -20,19 +29,41 @@ class MemberParkingPermitsController < AuthenticatedController
     end
   end
 
-  # Members may close (clear) only their own active permits — never tickets.
-  def close
-    permit = current_user.parking_notices.permits.active_notices.find(params[:id])
-    permit.clear!(current_user)
-    permit.record_journal_entry!('parking_notice_cleared', actor: current_user)
+  def update
+    if @parking_notice.update(member_parking_permit_params)
+      redirect_to user_path(current_user, tab: :parking), notice: 'Parking permit updated.'
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
 
+  # Members may close (clear) only their own active permits.
+  def close
+    unless @parking_notice.active?
+      redirect_to user_path(current_user, tab: :parking), alert: 'Only active permits can be closed.'
+      return
+    end
+
+    @parking_notice.clear!(current_user)
+    @parking_notice.record_journal_entry!('parking_notice_cleared', actor: current_user)
     redirect_to user_path(current_user, tab: :parking), notice: 'Parking permit closed.'
-  rescue ActiveRecord::RecordNotFound
-    redirect_to user_path(current_user, tab: :parking),
-                alert: 'That parking permit is not available to close.'
   end
 
   private
+
+  def set_owned_notice
+    @parking_notice = current_user.parking_notices.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to user_path(current_user, tab: :parking), alert: 'That parking notice is not available.'
+  end
+
+  # Tickets are issued by staff; members can view them but not edit, update, or clear.
+  def require_owned_permit
+    return if @parking_notice.permit?
+
+    redirect_to user_path(current_user, tab: :parking),
+                alert: 'Parking tickets are issued by staff and can only be viewed.'
+  end
 
   def member_parking_permit_params
     params.expect(

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -289,7 +289,7 @@
   <% elsif @active_tab == :payments %>
     <%= render 'users/tab_payments', payments: @home_payments, pagy: @pagy_payments, user: @home_user, show_payment_links: false, dashboard_mode: true %>
   <% elsif @active_tab == :parking %>
-    <%= render 'users/tab_parking', parking_notices: @home_parking_notices_list, show_actions: false %>
+    <%= render 'users/tab_parking', parking_notices: @home_parking_notices_list, actions: :member %>
   <% else %>
     <%= render 'users/tab_dashboard_self', user: @home_user %>
   <% end %>

--- a/app/views/member_parking_permits/_form.html.erb
+++ b/app/views/member_parking_permits/_form.html.erb
@@ -1,0 +1,75 @@
+<%= form_with model: parking_notice,
+    url: (parking_notice.persisted? ? member_parking_permit_path(parking_notice) : member_parking_permits_path),
+    local: true do |f| %>
+  <% if parking_notice.errors.any? %>
+    <div class="alert alert-danger">
+      <h6><%= pluralize(parking_notice.errors.count, 'error') %> prevented this parking permit from being saved:</h6>
+      <ul class="mb-0">
+        <% parking_notice.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-3">
+    <%= f.label :description, class: 'form-label' %>
+    <%= f.text_area :description, class: 'form-control', rows: 3, placeholder: 'Describe your project or item...' %>
+  </div>
+
+  <div class="row g-3">
+    <div class="col-md-6">
+      <%= f.label :location, 'Room / Location', class: 'form-label' %>
+      <%= f.text_field :location, class: 'form-control', placeholder: 'Example: Woodshop' %>
+    </div>
+    <div class="col-md-6">
+      <%= f.label :location_detail, 'Location detail', class: 'form-label' %>
+      <%= f.text_field :location_detail, class: 'form-control', placeholder: 'Example: South wall shelf' %>
+    </div>
+  </div>
+
+  <div class="mt-3 mb-4">
+    <%= f.label :expires_at, 'Expiration', class: 'form-label' %>
+    <%= render 'parking_notices/expiration_quick_buttons' %>
+    <%= f.datetime_local_field :expires_at,
+                               class: 'form-control',
+                               required: true,
+                               value: parking_notice.expires_at&.strftime('%Y-%m-%dT%H:%M') %>
+  </div>
+
+  <div class="d-flex gap-2">
+    <%= f.submit(parking_notice.persisted? ? 'Save changes' : 'Create Parking Permit', class: 'btn btn-success') %>
+    <%= link_to 'Cancel', user_path(current_user, tab: :parking), class: 'btn btn-outline-secondary' %>
+  </div>
+<% end %>
+
+<script>
+  (function() {
+    function initMemberParkingPermitForm() {
+      var expiresField = document.querySelector('input[name="parking_notice[expires_at]"]');
+
+      if (!expiresField) return;
+
+      document.querySelectorAll('.quick-expire').forEach(function(btn) {
+        if (btn.dataset.quickExpireBound === 'true') return;
+        btn.dataset.quickExpireBound = 'true';
+
+        btn.addEventListener('click', function() {
+          var date = new Date();
+          if (this.dataset.years) {
+            date.setFullYear(date.getFullYear() + parseInt(this.dataset.years, 10));
+          } else {
+            date.setDate(date.getDate() + parseInt(this.dataset.days, 10));
+          }
+          date.setHours(17, 0, 0, 0);
+          var pad = function(n) { return n < 10 ? '0' + n : n; };
+          expiresField.value = date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' +
+                               pad(date.getDate()) + 'T' + pad(date.getHours()) + ':' + pad(date.getMinutes());
+        });
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', initMemberParkingPermitForm);
+    document.addEventListener('turbo:load', initMemberParkingPermitForm);
+  })();
+</script>

--- a/app/views/member_parking_permits/edit.html.erb
+++ b/app/views/member_parking_permits/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <h1 class="h3 mb-0">New Parking Permit</h1>
-  <%= link_to "&larr; Back to profile".html_safe, user_path(current_user, tab: :profile), class: "text-decoration-none" %>
+  <h1 class="h3 mb-0">Edit Parking Permit</h1>
+  <%= link_to "&larr; Back to parking".html_safe, user_path(current_user, tab: :parking), class: "text-decoration-none" %>
 </div>
 
 <div class="card shadow-sm border-0">

--- a/app/views/member_parking_permits/show.html.erb
+++ b/app/views/member_parking_permits/show.html.erb
@@ -1,0 +1,63 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">
+    Parking <%= @parking_notice.notice_type_display %>
+    <span class="badge bg-<%= @parking_notice.status_badge_color %>"><%= @parking_notice.status_display %></span>
+  </h1>
+  <div class="d-flex gap-2">
+    <% if @parking_notice.permit? && !@parking_notice.cleared? %>
+      <%= link_to edit_member_parking_permit_path(@parking_notice), class: 'btn btn-outline-secondary' do %>
+        <i class="bi bi-pencil me-1"></i> Edit
+      <% end %>
+      <% if @parking_notice.active? %>
+        <%= button_to close_member_parking_permit_path(@parking_notice), method: :patch,
+            class: 'btn btn-outline-secondary',
+            form: { data: { turbo_confirm: "Clear this parking permit? This frees the spot and can't be undone." } } do %>
+          <i class="bi bi-check-circle me-1"></i> Clear
+        <% end %>
+      <% end %>
+    <% end %>
+    <%= link_to user_path(current_user, tab: :parking), class: 'btn btn-outline-secondary' do %>
+      <i class="bi bi-arrow-left me-1"></i> Back
+    <% end %>
+  </div>
+</div>
+
+<% if @parking_notice.ticket? %>
+  <p class="text-secondary mb-3">This parking ticket was issued by staff. Contact a member of the team if you have questions.</p>
+<% end %>
+
+<div class="card shadow-sm border-0 mb-4">
+  <div class="card-body">
+    <dl class="row mb-0">
+      <dt class="col-sm-3">Location</dt>
+      <dd class="col-sm-9"><%= @parking_notice.location_display.presence || '—' %></dd>
+
+      <dt class="col-sm-3">Description</dt>
+      <dd class="col-sm-9"><%= simple_format(@parking_notice.description.to_s.presence || '—') %></dd>
+
+      <dt class="col-sm-3">Expires</dt>
+      <dd class="col-sm-9">
+        <% if @parking_notice.active? && @parking_notice.past_expiration? %>
+          <span class="text-danger fw-bold"><%= @parking_notice.expires_at.strftime('%B %d, %Y at %l:%M %p') %></span>
+        <% else %>
+          <%= @parking_notice.expires_at.strftime('%B %d, %Y at %l:%M %p') %>
+        <% end %>
+      </dd>
+    </dl>
+  </div>
+</div>
+
+<% if @parking_notice.photos.attached? %>
+  <div class="card shadow-sm border-0 mb-4">
+    <div class="card-header"><h5 class="mb-0">Photos</h5></div>
+    <div class="card-body">
+      <div class="d-flex flex-wrap gap-3">
+        <% @parking_notice.photos.each do |photo| %>
+          <%= link_to url_for(photo), target: '_blank' do %>
+            <%= image_tag url_for(photo), class: 'rounded shadow-sm', style: 'width: 150px; height: 150px; object-fit: cover;' %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/_tab_parking.html.erb
+++ b/app/views/users/_tab_parking.html.erb
@@ -1,6 +1,6 @@
-<% show_actions = local_assigns[:show_actions] %>
-<% member_close = local_assigns[:member_close] %>
-<% show_actions_column = show_actions || member_close %>
+<%# actions: :admin (view/edit/clear all), :member (own permits editable/clearable, tickets view-only), or nil %>
+<% actions = local_assigns[:actions] %>
+<% show_actions_column = actions.present? %>
 <% if parking_notices.any? %>
   <div class="card shadow-sm border-0">
     <div class="table-responsive">
@@ -37,15 +37,27 @@
               </td>
               <% if show_actions_column %>
                 <td class="text-end">
-                  <% if show_actions %>
-                    <%= link_to "View", parking_notice_path(notice), class: "btn btn-sm btn-outline-primary" %>
-                  <% elsif member_close && notice.permit? && notice.active? %>
-                    <%= button_to "Close", close_member_parking_permit_path(notice), method: :patch,
-                        class: "btn btn-sm btn-outline-secondary",
-                        form: { data: { turbo_confirm: "Close this parking permit? This frees the spot and can't be undone." } } %>
-                  <% else %>
-                    <span class="text-muted">—</span>
-                  <% end %>
+                  <div class="d-flex gap-1 justify-content-end">
+                    <% if actions == :admin %>
+                      <%= link_to "View", parking_notice_path(notice), class: "btn btn-sm btn-outline-secondary" %>
+                      <% unless notice.cleared? %>
+                        <%= link_to "Edit", edit_parking_notice_path(notice), class: "btn btn-sm btn-outline-secondary" %>
+                        <%= button_to "Clear", clear_parking_notice_path(notice), method: :post,
+                            class: "btn btn-sm btn-outline-secondary",
+                            form: { data: { turbo_confirm: "Mark this parking #{notice.notice_type_display.downcase} as cleared?" } } %>
+                      <% end %>
+                    <% elsif actions == :member %>
+                      <%= link_to "View", member_parking_permit_path(notice), class: "btn btn-sm btn-outline-secondary" %>
+                      <% if notice.permit? && !notice.cleared? %>
+                        <%= link_to "Edit", edit_member_parking_permit_path(notice), class: "btn btn-sm btn-outline-secondary" %>
+                        <% if notice.active? %>
+                          <%= button_to "Clear", close_member_parking_permit_path(notice), method: :patch,
+                              class: "btn btn-sm btn-outline-secondary",
+                              form: { data: { turbo_confirm: "Clear this parking permit? This frees the spot and can't be undone." } } %>
+                        <% end %>
+                      <% end %>
+                    <% end %>
+                  </div>
                 </td>
               <% end %>
             </tr>

--- a/app/views/users/_tab_profile_admin.html.erb
+++ b/app/views/users/_tab_profile_admin.html.erb
@@ -227,7 +227,7 @@
             <% end %>
             <% if grantable_topics.any? %>
               <div class="dropdown d-inline-block ms-auto">
-                <button class="btn-link-add" type="button" data-bs-toggle="dropdown" aria-expanded="false">+ Grant can train</button>
+                <button class="btn-link-add" type="button" data-bs-toggle="dropdown" aria-expanded="false">+ Add Can Train</button>
                 <ul class="dropdown-menu dropdown-menu-end" style="max-height: 320px; overflow-y: auto;">
                   <% grantable_topics.each do |topic| %>
                     <li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -320,7 +320,7 @@
     <% elsif @active_tab == :incidents %>
       <%= render 'users/tab_incidents', user_incidents: @user_incidents, pagy: @pagy_incidents, user: @user %>
     <% elsif @active_tab == :parking %>
-      <%= render 'users/tab_parking', parking_notices: @parking_notices_list, show_actions: true %>
+      <%= render 'users/tab_parking', parking_notices: @parking_notices_list, actions: :admin %>
     <% elsif @active_tab == :journal %>
       <%= render 'users/tab_journal', journals: @journals, pagy: @pagy_journals, user: @user %>
     <% elsif @active_tab == :mail %>
@@ -402,7 +402,7 @@
     <% elsif @active_tab == :payments %>
       <%= render 'users/tab_payments', payments: @payments, pagy: @pagy_payments, user: @user, show_payment_links: false %>
     <% elsif @active_tab == :parking %>
-      <%= render 'users/tab_parking', parking_notices: @parking_notices_list, show_actions: false, member_close: true %>
+      <%= render 'users/tab_parking', parking_notices: @parking_notices_list, actions: :member %>
     <% elsif @active_tab == :messages %>
       <%= render 'users/tab_messages', messages: @messages, pagy: @pagy_messages, user: @user, show_send: false %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
   get '/training/record', to: 'trainings#record', as: :record_training
   post '/training/record', to: 'trainings#create_bulk'
   get '/training/:id',  to: 'training_catalog#show',  as: :training_catalog_topic, constraints: { id: /\d+/ }
-  resources :member_parking_permits, only: %i[new create] do
+  resources :member_parking_permits, only: %i[new create show edit update] do
     member do
       patch :close
     end

--- a/test/controllers/member_parking_permits_controller_test.rb
+++ b/test/controllers/member_parking_permits_controller_test.rb
@@ -95,7 +95,132 @@ class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'active', permit.reload.status
   end
 
+  test 'member cannot close an already-cleared permit' do
+    sign_in_as_member
+    permit = member_permit(status: 'cleared')
+
+    patch close_member_parking_permit_path(permit)
+
+    assert_redirected_to user_path(current_member, tab: :parking)
+    assert_equal 'cleared', permit.reload.status
+  end
+
+  test 'member can view own permit with edit and clear actions' do
+    sign_in_as_member
+    permit = member_permit
+
+    get member_parking_permit_path(permit)
+
+    assert_response :success
+    assert_select 'a[href=?]', edit_member_parking_permit_path(permit)
+    assert_select 'form[action=?]', close_member_parking_permit_path(permit)
+  end
+
+  test 'member can view own ticket but gets no edit or clear actions' do
+    sign_in_as_member
+    ticket = member_ticket
+
+    get member_parking_permit_path(ticket)
+
+    assert_response :success
+    assert_select 'a[href=?]', edit_member_parking_permit_path(ticket), false
+    assert_select 'form[action=?]', close_member_parking_permit_path(ticket), false
+  end
+
+  test 'member can open edit form for own permit' do
+    sign_in_as_member
+    permit = member_permit
+
+    get edit_member_parking_permit_path(permit)
+
+    assert_response :success
+    assert_match(/Edit Parking Permit/i, response.body)
+  end
+
+  test 'member cannot edit their own ticket' do
+    sign_in_as_member
+    ticket = member_ticket
+
+    get edit_member_parking_permit_path(ticket)
+
+    assert_redirected_to user_path(current_member, tab: :parking)
+  end
+
+  test 'member can update own permit' do
+    sign_in_as_member
+    permit = member_permit
+
+    patch member_parking_permit_path(permit), params: {
+      parking_notice: { description: 'Updated description', location: 'Metal Shop' }
+    }
+
+    assert_redirected_to user_path(current_member, tab: :parking)
+    permit.reload
+    assert_equal 'Updated description', permit.description
+    assert_equal 'Metal Shop', permit.location
+  end
+
+  test 'member cannot update their own ticket' do
+    sign_in_as_member
+    ticket = member_ticket
+
+    patch member_parking_permit_path(ticket), params: {
+      parking_notice: { description: 'Tampered' }
+    }
+
+    assert_redirected_to user_path(current_member, tab: :parking)
+    assert_not_equal 'Tampered', ticket.reload.description
+  end
+
+  test "member cannot view another member's notice" do
+    sign_in_as_member
+    other = parking_notices(:active_permit)
+
+    get member_parking_permit_path(other)
+
+    assert_redirected_to user_path(current_member, tab: :parking)
+  end
+
+  test "member cannot update another member's permit" do
+    sign_in_as_member
+    other = parking_notices(:active_permit)
+    original = other.description
+
+    patch member_parking_permit_path(other), params: {
+      parking_notice: { description: 'Hijacked' }
+    }
+
+    assert_redirected_to user_path(current_member, tab: :parking)
+    assert_equal original, other.reload.description
+  end
+
+  test 'anonymous user cannot view a permit' do
+    permit = parking_notices(:active_permit)
+
+    get member_parking_permit_path(permit)
+
+    assert_redirected_to login_path
+  end
+
   private
+
+  def current_member
+    User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
+  end
+
+  def member_permit(status: 'active')
+    current_member.parking_notices.create!(
+      notice_type: 'permit', status: status, issued_by: current_member,
+      expires_at: 3.days.from_now, description: 'My item', location: 'Woodshop'
+    )
+  end
+
+  def member_ticket
+    ParkingNotice.create!(
+      notice_type: 'ticket', status: 'active', user: current_member, issued_by: current_member,
+      expires_at: 3.days.from_now, description: 'Enforcement', location: 'Main Area'
+    )
+  end
 
   def sign_in_as_member
     post local_login_path, params: {


### PR DESCRIPTION
## Summary
- Members can now **view, edit, and clear their own parking permits** and **view their own tickets** from both the dashboard and profile parking tabs. Previously members reached parking via the dashboard tab, which had no actions, so the earlier self-close button never appeared.
- Admins get **view / edit / clear** actions on **every** permit and ticket row on a member's profile parking tab.
- Tickets are view-only for members (issued by staff); edit/update/close are guarded server-side and scoped to `current_user`.
- Also renames the profile "Grant can train" control to "Add Can Train".

## Changes
- `MemberParkingPermitsController`: add `show`, `edit`, `update` (plus existing `close`), all scoped to `current_user.parking_notices`. `edit/update/close` are restricted to permits; an active check guards `close`.
- New member-facing views: `show` (read-only, member-friendly), `edit`, and a shared `_form` partial (refactored `new` to use it).
- Rewrote `_tab_parking` to use a single role-aware `actions:` mode (`:admin` / `:member`) instead of `show_actions`/`member_close`; updated all three render call sites (admin profile, self profile, dashboard).
- Routes: add `show/edit/update` to `member_parking_permits`.

## Test plan
- [x] `member_parking_permits_controller_test` (17 tests): member view/edit/update/close of own permits; ticket view-only; cannot access others'; anonymous blocked.
- [x] `users_controller_test` + `dashboard_controller_test` (44 tests) pass — partial param change renders cleanly.
- [x] RuboCop clean on changed Ruby files.
- [ ] Manual: confirm member dashboard/profile parking tab shows correct buttons; admin profile shows view/edit/clear on all rows.

Made with [Cursor](https://cursor.com)