### PR TITLE
Parking: admin-clearance option for tickets + notice history

### DIFF
--- a/app/controllers/member_parking_permits_controller.rb
+++ b/app/controllers/member_parking_permits_controller.rb
@@ -1,6 +1,6 @@
 class MemberParkingPermitsController < AuthenticatedController
-  before_action :set_owned_notice, only: %i[show edit update close]
-  before_action :require_owned_permit, only: %i[edit update close]
+  before_action :set_owned_notice, only: %i[show edit update close request_clearance add_note]
+  before_action :require_owned_permit, only: %i[edit update]
 
   # Members may view their own permits and tickets.
   def show; end
@@ -30,6 +30,7 @@ class MemberParkingPermitsController < AuthenticatedController
   end
 
   def update
+    @parking_notice.event_actor = current_user
     if @parking_notice.update(member_parking_permit_params)
       redirect_to user_path(current_user, tab: :parking), notice: 'Parking permit updated.'
     else
@@ -37,16 +38,55 @@ class MemberParkingPermitsController < AuthenticatedController
     end
   end
 
-  # Members may close (clear) only their own active permits.
+  # Members may clear their own active notices unless admin clearance is required.
   def close
     unless @parking_notice.active?
-      redirect_to user_path(current_user, tab: :parking), alert: 'Only active permits can be closed.'
+      redirect_to user_path(current_user, tab: :parking), alert: 'Only active parking notices can be cleared.'
       return
     end
 
+    unless @parking_notice.clearable_by?(current_user)
+      redirect_to user_path(current_user, tab: :parking),
+                  alert: 'This parking notice must be cleared by an admin. You can request clearance instead.'
+      return
+    end
+
+    @parking_notice.event_actor = current_user
     @parking_notice.clear!(current_user)
     @parking_notice.record_journal_entry!('parking_notice_cleared', actor: current_user)
-    redirect_to user_path(current_user, tab: :parking), notice: 'Parking permit closed.'
+    redirect_to user_path(current_user, tab: :parking),
+                notice: "Parking #{@parking_notice.notice_type} cleared."
+  end
+
+  # Members ask an admin to clear a notice that requires admin clearance.
+  def request_clearance
+    unless @parking_notice.active? && @parking_notice.requires_admin_clearance?
+      redirect_to user_path(current_user, tab: :parking),
+                  alert: 'This parking notice does not need an admin clearance request.'
+      return
+    end
+
+    if @parking_notice.clearance_requested?
+      redirect_to user_path(current_user, tab: :parking), notice: 'Clearance has already been requested.'
+      return
+    end
+
+    @parking_notice.request_clearance!(current_user)
+    redirect_to user_path(current_user, tab: :parking),
+                notice: 'Clearance requested. An admin will review your request.'
+  end
+
+  # Members may add a note to the history of their own notice.
+  def add_note
+    note = params[:note].to_s.strip
+
+    if note.blank?
+      redirect_to member_parking_permit_path(@parking_notice), alert: 'Note cannot be blank.'
+      return
+    end
+
+    @parking_notice.log_event!('note', actor: current_user, note: note)
+    redirect_to member_parking_permit_path(@parking_notice), notice: 'Note added.'
   end
 
   private
@@ -57,12 +97,13 @@ class MemberParkingPermitsController < AuthenticatedController
     redirect_to user_path(current_user, tab: :parking), alert: 'That parking notice is not available.'
   end
 
-  # Tickets are issued by staff; members can view them but not edit, update, or clear.
+  # Tickets are issued by staff; members may view and clear them (subject to
+  # admin-clearance rules) but cannot edit their details.
   def require_owned_permit
     return if @parking_notice.permit?
 
     redirect_to user_path(current_user, tab: :parking),
-                alert: 'Parking tickets are issued by staff and can only be viewed.'
+                alert: 'Parking ticket details are managed by staff.'
   end
 
   def member_parking_permit_params

--- a/app/controllers/parking_notices_controller.rb
+++ b/app/controllers/parking_notices_controller.rb
@@ -2,7 +2,7 @@ class ParkingNoticesController < AdminController
   include Pagy::Method
 
   before_action :set_parking_notice,
-                only: %i[show edit update clear download_pdf print_notice remove_photo download_photo]
+                only: %i[show edit update clear add_note download_pdf print_notice remove_photo download_photo]
 
   def index
     @parking_notices = ParkingNotice.includes(:user, :issued_by).newest_first
@@ -40,6 +40,7 @@ class ParkingNoticesController < AdminController
   def create
     @parking_notice = ParkingNotice.new(parking_notice_params)
     @parking_notice.issued_by = current_user
+    @parking_notice.event_actor = current_user
 
     if @parking_notice.save
       template_key = @parking_notice.permit? ? 'parking_permit_issued' : 'parking_ticket_issued'
@@ -68,6 +69,7 @@ class ParkingNoticesController < AdminController
   end
 
   def update
+    @parking_notice.event_actor = current_user
     if @parking_notice.update(parking_notice_params)
       redirect_to parking_notice_path(@parking_notice),
                   notice: "Parking #{@parking_notice.notice_type} updated successfully."
@@ -78,11 +80,24 @@ class ParkingNoticesController < AdminController
   end
 
   def clear
+    @parking_notice.event_actor = current_user
     @parking_notice.clear!(current_user)
     @parking_notice.record_journal_entry!('parking_notice_cleared', actor: current_user)
 
     redirect_to parking_notice_path(@parking_notice),
                 notice: "Parking #{@parking_notice.notice_type} marked as cleared."
+  end
+
+  def add_note
+    note = params[:note].to_s.strip
+
+    if note.blank?
+      redirect_to parking_notice_path(@parking_notice), alert: 'Note cannot be blank.'
+      return
+    end
+
+    @parking_notice.log_event!('note', actor: current_user, note: note)
+    redirect_to parking_notice_path(@parking_notice), notice: 'Note added.'
   end
 
   def download_pdf
@@ -165,7 +180,8 @@ class ParkingNoticesController < AdminController
   def parking_notice_params
     params.expect(
       parking_notice: [:notice_type, :user_id, :description, :location,
-                       :location_detail, :expires_at, :notes, { photos: [] }]
+                       :location_detail, :expires_at, :notes, :requires_admin_clearance,
+                       { photos: [] }]
     )
   end
 

--- a/app/models/parking_notice.rb
+++ b/app/models/parking_notice.rb
@@ -5,13 +5,21 @@ class ParkingNotice < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :issued_by, class_name: 'User'
   belongs_to :cleared_by, class_name: 'User', optional: true
+  belongs_to :clearance_requested_by, class_name: 'User', optional: true
 
+  has_many :events, class_name: 'ParkingNoticeEvent', dependent: :destroy
   has_many_attached :photos
+
+  # Set by controllers so history events can record who triggered the change.
+  attr_accessor :event_actor
 
   validates :notice_type, presence: true, inclusion: { in: NOTICE_TYPES }
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :expires_at, presence: true
   validates :user, presence: true, if: :permit?
+
+  after_create :log_opened_event
+  after_update :log_renewal_event, if: :renewal_logged?
 
   scope :permits, -> { where(notice_type: 'permit') }
   scope :tickets, -> { where(notice_type: 'ticket') }
@@ -75,16 +83,47 @@ class ParkingNotice < ApplicationRecord
     parts.join(' — ')
   end
 
-  def clear!(admin)
-    update!(
-      status: 'cleared',
-      cleared_at: Time.current,
-      cleared_by: admin
-    )
+  # A member may clear their own active notice unless it has been flagged as
+  # requiring admin clearance. Admins can always clear any active notice.
+  def clearable_by?(actor)
+    return false unless active?
+    return true if actor&.admin?
+    return false if requires_admin_clearance?
+
+    actor.present? && user_id == actor.id
+  end
+
+  def clearance_requested?
+    clearance_requested_at.present? && !cleared?
+  end
+
+  def clear!(actor)
+    transaction do
+      update!(
+        status: 'cleared',
+        cleared_at: Time.current,
+        cleared_by: actor
+      )
+      log_event!('cleared', actor: actor)
+    end
   end
 
   def expire!
-    update!(status: 'expired')
+    transaction do
+      update!(status: 'expired')
+      log_event!('expired')
+    end
+  end
+
+  def request_clearance!(member)
+    transaction do
+      update!(clearance_requested_at: Time.current, clearance_requested_by: member)
+      log_event!('clearance_requested', actor: member)
+    end
+  end
+
+  def log_event!(event_type, actor: nil, note: nil)
+    events.create!(event_type: event_type, actor: actor, note: note.presence)
   end
 
   def record_journal_entry!(action_name, actor: nil)
@@ -121,5 +160,21 @@ class ParkingNotice < ApplicationRecord
       expires_at: expires_at.strftime('%B %d, %Y'),
       notice_type: notice_type_display
     )
+  end
+
+  private
+
+  def log_opened_event
+    log_event!('opened', actor: event_actor || issued_by)
+  end
+
+  def log_renewal_event
+    log_event!('renewed', actor: event_actor)
+  end
+
+  # Treat an expiration change (without a status change) as a renewal so it lands
+  # in the history. clear!/expire! change status, so they don't trip this.
+  def renewal_logged?
+    saved_change_to_expires_at? && !saved_change_to_status?
   end
 end

--- a/app/models/parking_notice_event.rb
+++ b/app/models/parking_notice_event.rb
@@ -1,0 +1,36 @@
+class ParkingNoticeEvent < ApplicationRecord
+  EVENT_TYPES = %w[opened renewed cleared expired clearance_requested note].freeze
+
+  belongs_to :parking_notice
+  belongs_to :actor, class_name: 'User', optional: true
+
+  validates :event_type, presence: true, inclusion: { in: EVENT_TYPES }
+  validates :note, presence: true, if: -> { event_type == 'note' }
+
+  scope :chronological, -> { order(created_at: :asc, id: :asc) }
+  scope :recent_first, -> { order(created_at: :desc, id: :desc) }
+
+  def label
+    case event_type
+    when 'opened' then 'Opened'
+    when 'renewed' then 'Renewed'
+    when 'cleared' then 'Cleared'
+    when 'expired' then 'Expired'
+    when 'clearance_requested' then 'Clearance requested'
+    when 'note' then 'Note'
+    else event_type.humanize
+    end
+  end
+
+  def icon
+    case event_type
+    when 'opened' then 'bi-plus-circle'
+    when 'renewed' then 'bi-arrow-repeat'
+    when 'cleared' then 'bi-check-circle'
+    when 'expired' then 'bi-clock-history'
+    when 'clearance_requested' then 'bi-hand-index'
+    when 'note' then 'bi-chat-left-text'
+    else 'bi-dot'
+    end
+  end
+end

--- a/app/views/member_parking_permits/show.html.erb
+++ b/app/views/member_parking_permits/show.html.erb
@@ -4,15 +4,22 @@
     <span class="badge bg-<%= @parking_notice.status_badge_color %>"><%= @parking_notice.status_display %></span>
   </h1>
   <div class="d-flex gap-2">
-    <% if @parking_notice.permit? && !@parking_notice.cleared? %>
-      <%= link_to edit_member_parking_permit_path(@parking_notice), class: 'btn btn-outline-secondary' do %>
-        <i class="bi bi-pencil me-1"></i> Edit
+    <% unless @parking_notice.cleared? %>
+      <% if @parking_notice.permit? %>
+        <%= link_to edit_member_parking_permit_path(@parking_notice), class: 'btn btn-outline-secondary' do %>
+          <i class="bi bi-pencil me-1"></i> Edit
+        <% end %>
       <% end %>
-      <% if @parking_notice.active? %>
+      <% if @parking_notice.clearable_by?(current_user) %>
         <%= button_to close_member_parking_permit_path(@parking_notice), method: :patch,
             class: 'btn btn-outline-secondary',
-            form: { data: { turbo_confirm: "Clear this parking permit? This frees the spot and can't be undone." } } do %>
+            form: { data: { turbo_confirm: "Clear this parking notice? This frees the spot and can't be undone." } } do %>
           <i class="bi bi-check-circle me-1"></i> Clear
+        <% end %>
+      <% elsif @parking_notice.active? && @parking_notice.requires_admin_clearance? && !@parking_notice.clearance_requested? %>
+        <%= button_to request_clearance_member_parking_permit_path(@parking_notice), method: :post,
+            class: 'btn btn-outline-secondary' do %>
+          <i class="bi bi-hand-index me-1"></i> Request clearance
         <% end %>
       <% end %>
     <% end %>
@@ -24,6 +31,15 @@
 
 <% if @parking_notice.ticket? %>
   <p class="text-secondary mb-3">This parking ticket was issued by staff. Contact a member of the team if you have questions.</p>
+<% end %>
+
+<% if @parking_notice.clearance_requested? %>
+  <div class="alert alert-warning" role="alert">
+    <i class="bi bi-hand-index me-1"></i>
+    You've requested that an admin clear this notice. They'll review it soon.
+  </div>
+<% elsif @parking_notice.active? && @parking_notice.requires_admin_clearance? %>
+  <p class="text-secondary mb-3">This notice must be cleared by an admin. Use "Request clearance" to ask the team to clear it.</p>
 <% end %>
 
 <div class="card shadow-sm border-0 mb-4">
@@ -61,3 +77,7 @@
     </div>
   </div>
 <% end %>
+
+<%= render 'parking_notices/history',
+    events: @parking_notice.events.includes(:actor).chronological,
+    note_url: add_note_member_parking_permit_path(@parking_notice) %>

--- a/app/views/parking_notices/_form.html.erb
+++ b/app/views/parking_notices/_form.html.erb
@@ -74,6 +74,18 @@
         <%= f.text_area :notes, class: 'form-control', rows: 2,
             placeholder: 'Internal notes (not shown to members)...' %>
       </div>
+
+      <% if parking_notice.ticket? %>
+        <%# Require admin clearance %>
+        <div class="form-check mb-3">
+          <%= f.check_box :requires_admin_clearance, class: 'form-check-input' %>
+          <%= f.label :requires_admin_clearance, 'Require an admin to clear this ticket',
+              class: 'form-check-label' %>
+          <div class="form-text">
+            When enabled, the member can request clearance but cannot clear the ticket themselves.
+          </div>
+        </div>
+      <% end %>
     </div>
 
     <div class="col-md-6">

--- a/app/views/parking_notices/_history.html.erb
+++ b/app/views/parking_notices/_history.html.erb
@@ -1,0 +1,43 @@
+<%# locals: events, note_url %>
+<div class="card shadow-sm border-0 mb-4">
+  <div class="card-header bg-transparent">
+    <span class="h-section-label">History</span>
+  </div>
+  <div class="card-body">
+    <% if events.any? %>
+      <ul class="list-unstyled mb-0">
+        <% events.each_with_index do |event, index| %>
+          <li class="d-flex gap-2 py-2 <%= 'border-bottom' unless index == events.size - 1 %>">
+            <i class="bi <%= event.icon %> text-secondary mt-1"></i>
+            <div class="flex-grow-1">
+              <div class="d-flex justify-content-between align-items-start gap-2">
+                <span class="fw-medium"><%= event.label %></span>
+                <span class="text-12 text-secondary text-nowrap"
+                      title="<%= event.created_at.strftime('%B %d, %Y at %l:%M %p') %>">
+                  <%= event.created_at.strftime('%b %d, %Y') %>
+                </span>
+              </div>
+              <% if event.note.present? %>
+                <div class="text-13"><%= simple_format(event.note, {}, wrapper_tag: 'span') %></div>
+              <% end %>
+              <% if event.actor.present? %>
+                <div class="text-12 text-secondary">by <%= event.actor.display_name %></div>
+              <% end %>
+            </div>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-secondary text-13 mb-0">No history yet.</p>
+    <% end %>
+
+    <% if local_assigns[:note_url].present? %>
+      <%= form_with url: note_url, method: :post, local: true, class: 'mt-3' do %>
+        <div class="input-group">
+          <%= text_field_tag :note, nil, class: 'form-control', placeholder: 'Add a note to the history…' %>
+          <button type="submit" class="btn btn-outline-secondary">Add note</button>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/parking_notices/show.html.erb
+++ b/app/views/parking_notices/show.html.erb
@@ -63,6 +63,24 @@
   </p>
 <% end %>
 
+<% if @parking_notice.clearance_requested? %>
+  <div class="alert alert-warning d-flex justify-content-between align-items-center" role="alert">
+    <div>
+      <i class="bi bi-hand-index me-1"></i>
+      <span class="fw-medium">Clearance requested</span>
+      <% if @parking_notice.clearance_requested_by.present? %>
+        by <%= link_to @parking_notice.clearance_requested_by.display_name, user_path(@parking_notice.clearance_requested_by) %>
+      <% end %>
+      <span class="text-secondary">
+        on <%= @parking_notice.clearance_requested_at.strftime('%B %d, %Y at %l:%M %p') %>
+      </span>
+    </div>
+    <%= button_to 'Clear now', clear_parking_notice_path(@parking_notice), method: :post,
+        class: 'btn btn-sm btn-outline-secondary',
+        form: { data: { turbo_confirm: 'Mark this parking notice as cleared?' } } %>
+  </div>
+<% end %>
+
 <div class="card shadow-sm border-<%= @parking_notice.badge_color %> mb-4">
   <div class="card-body">
     <div class="row">
@@ -86,6 +104,18 @@
           <% if @parking_notice.notes.present? %>
             <dt>Admin Notes</dt>
             <dd><%= simple_format(@parking_notice.notes) %></dd>
+          <% end %>
+
+          <% if @parking_notice.ticket? %>
+            <dt>Admin clearance</dt>
+            <dd>
+              <% if @parking_notice.requires_admin_clearance? %>
+                <span class="badge text-bg-warning-subtle">Required</span>
+                <span class="text-12 text-secondary">Member cannot clear this ticket themselves.</span>
+              <% else %>
+                <span class="text-secondary">Not required</span>
+              <% end %>
+            </dd>
           <% end %>
         </dl>
       </div>
@@ -157,3 +187,7 @@
     </div>
   </div>
 <% end %>
+
+<%= render 'parking_notices/history',
+    events: @parking_notice.events.includes(:actor).chronological,
+    note_url: add_note_parking_notice_path(@parking_notice) %>

--- a/app/views/users/_tab_parking.html.erb
+++ b/app/views/users/_tab_parking.html.erb
@@ -37,7 +37,10 @@
               </td>
               <% if show_actions_column %>
                 <td class="text-end">
-                  <div class="d-flex gap-1 justify-content-end">
+                  <div class="d-flex gap-1 justify-content-end align-items-center">
+                    <% if notice.clearance_requested? %>
+                      <span class="badge text-bg-warning-subtle">Clearance requested</span>
+                    <% end %>
                     <% if actions == :admin %>
                       <%= link_to "View", parking_notice_path(notice), class: "btn btn-sm btn-outline-secondary" %>
                       <% unless notice.cleared? %>
@@ -48,12 +51,17 @@
                       <% end %>
                     <% elsif actions == :member %>
                       <%= link_to "View", member_parking_permit_path(notice), class: "btn btn-sm btn-outline-secondary" %>
-                      <% if notice.permit? && !notice.cleared? %>
-                        <%= link_to "Edit", edit_member_parking_permit_path(notice), class: "btn btn-sm btn-outline-secondary" %>
-                        <% if notice.active? %>
+                      <% unless notice.cleared? %>
+                        <% if notice.permit? %>
+                          <%= link_to "Edit", edit_member_parking_permit_path(notice), class: "btn btn-sm btn-outline-secondary" %>
+                        <% end %>
+                        <% if notice.clearable_by?(current_user) %>
                           <%= button_to "Clear", close_member_parking_permit_path(notice), method: :patch,
                               class: "btn btn-sm btn-outline-secondary",
-                              form: { data: { turbo_confirm: "Clear this parking permit? This frees the spot and can't be undone." } } %>
+                              form: { data: { turbo_confirm: "Clear this parking notice? This frees the spot and can't be undone." } } %>
+                        <% elsif notice.active? && notice.requires_admin_clearance? && !notice.clearance_requested? %>
+                          <%= button_to "Request clearance", request_clearance_member_parking_permit_path(notice), method: :post,
+                              class: "btn btn-sm btn-outline-secondary" %>
                         <% end %>
                       <% end %>
                     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,8 @@ Rails.application.routes.draw do
   resources :member_parking_permits, only: %i[new create show edit update] do
     member do
       patch :close
+      post :request_clearance
+      post :add_note
     end
   end
 
@@ -411,6 +413,7 @@ Rails.application.routes.draw do
   resources :parking_notices do
     member do
       post :clear
+      post :add_note
       get :download_pdf
       post :print_notice
       delete 'photos/:photo_id', action: :remove_photo, as: :remove_photo

--- a/db/migrate/20260612100000_add_clearance_fields_to_parking_notices.rb
+++ b/db/migrate/20260612100000_add_clearance_fields_to_parking_notices.rb
@@ -1,0 +1,11 @@
+class AddClearanceFieldsToParkingNotices < ActiveRecord::Migration[8.1]
+  def change
+    add_column :parking_notices, :requires_admin_clearance, :boolean, null: false, default: false
+    add_column :parking_notices, :clearance_requested_at, :datetime
+    add_reference :parking_notices, :clearance_requested_by,
+                  null: true, foreign_key: { to_table: :users }
+
+    add_index :parking_notices, :requires_admin_clearance
+    add_index :parking_notices, :clearance_requested_at
+  end
+end

--- a/db/migrate/20260612100100_create_parking_notice_events.rb
+++ b/db/migrate/20260612100100_create_parking_notice_events.rb
@@ -1,0 +1,14 @@
+class CreateParkingNoticeEvents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :parking_notice_events do |t|
+      t.references :parking_notice, null: false, foreign_key: true
+      t.references :actor, null: true, foreign_key: { to_table: :users }
+      t.string :event_type, null: false
+      t.text :note
+      t.timestamps
+    end
+
+    add_index :parking_notice_events, %i[parking_notice_id created_at]
+    add_index :parking_notice_events, :event_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_10_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_100100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -618,7 +618,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_120000) do
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 
+  create_table "parking_notice_events", force: :cascade do |t|
+    t.bigint "actor_id"
+    t.datetime "created_at", null: false
+    t.string "event_type", null: false
+    t.text "note"
+    t.bigint "parking_notice_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_id"], name: "index_parking_notice_events_on_actor_id"
+    t.index ["event_type"], name: "index_parking_notice_events_on_event_type"
+    t.index ["parking_notice_id", "created_at"], name: "idx_on_parking_notice_id_created_at_1c4803fe34"
+    t.index ["parking_notice_id"], name: "index_parking_notice_events_on_parking_notice_id"
+  end
+
   create_table "parking_notices", force: :cascade do |t|
+    t.datetime "clearance_requested_at"
+    t.bigint "clearance_requested_by_id"
     t.datetime "cleared_at"
     t.bigint "cleared_by_id"
     t.datetime "created_at", null: false
@@ -629,13 +644,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_120000) do
     t.string "location_detail"
     t.text "notes"
     t.string "notice_type", null: false
+    t.boolean "requires_admin_clearance", default: false, null: false
     t.string "status", default: "active", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.index ["clearance_requested_at"], name: "index_parking_notices_on_clearance_requested_at"
+    t.index ["clearance_requested_by_id"], name: "index_parking_notices_on_clearance_requested_by_id"
     t.index ["cleared_by_id"], name: "index_parking_notices_on_cleared_by_id"
     t.index ["expires_at"], name: "index_parking_notices_on_expires_at"
     t.index ["issued_by_id"], name: "index_parking_notices_on_issued_by_id"
     t.index ["notice_type", "status"], name: "index_parking_notices_on_notice_type_and_status"
+    t.index ["requires_admin_clearance"], name: "index_parking_notices_on_requires_admin_clearance"
     t.index ["status"], name: "index_parking_notices_on_status"
     t.index ["user_id"], name: "index_parking_notices_on_user_id"
   end
@@ -1087,7 +1106,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_120000) do
   add_foreign_key "membership_plans", "users"
   add_foreign_key "messages", "users", column: "recipient_id"
   add_foreign_key "messages", "users", column: "sender_id"
+  add_foreign_key "parking_notice_events", "parking_notices"
+  add_foreign_key "parking_notice_events", "users", column: "actor_id"
   add_foreign_key "parking_notices", "users"
+  add_foreign_key "parking_notices", "users", column: "clearance_requested_by_id"
   add_foreign_key "parking_notices", "users", column: "cleared_by_id"
   add_foreign_key "parking_notices", "users", column: "issued_by_id"
   add_foreign_key "payment_events", "cash_payments"

--- a/test/controllers/member_parking_permits_controller_test.rb
+++ b/test/controllers/member_parking_permits_controller_test.rb
@@ -63,18 +63,75 @@ class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
     assert_equal member.id, permit.cleared_by_id
   end
 
-  test 'member cannot close their own ticket' do
+  test 'member can close their own ticket when admin clearance is not required' do
     sign_in_as_member
-    member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
-    ticket = ParkingNotice.create!(
-      notice_type: 'ticket', status: 'active', user: member, issued_by: member,
-      expires_at: 3.days.from_now, description: 'Enforcement', location: 'Main Area'
-    )
+    ticket = member_ticket
 
     patch close_member_parking_permit_path(ticket)
 
-    assert_redirected_to user_path(member, tab: :parking)
+    assert_redirected_to user_path(current_member, tab: :parking)
+    assert_equal 'cleared', ticket.reload.status
+    assert_equal current_member.id, ticket.cleared_by_id
+  end
+
+  test 'member cannot close a ticket that requires admin clearance' do
+    sign_in_as_member
+    ticket = member_ticket
+    ticket.update!(requires_admin_clearance: true)
+
+    patch close_member_parking_permit_path(ticket)
+
+    assert_redirected_to user_path(current_member, tab: :parking)
     assert_equal 'active', ticket.reload.status
+  end
+
+  test 'member can request clearance for a ticket that requires admin clearance' do
+    sign_in_as_member
+    ticket = member_ticket
+    ticket.update!(requires_admin_clearance: true)
+
+    assert_difference -> { ticket.events.count }, 1 do
+      post request_clearance_member_parking_permit_path(ticket)
+    end
+
+    assert_redirected_to user_path(current_member, tab: :parking)
+    assert ticket.reload.clearance_requested?
+    assert_equal current_member.id, ticket.clearance_requested_by_id
+  end
+
+  test 'member cannot request clearance when it is not required' do
+    sign_in_as_member
+    ticket = member_ticket
+
+    post request_clearance_member_parking_permit_path(ticket)
+
+    assert_redirected_to user_path(current_member, tab: :parking)
+    assert_not ticket.reload.clearance_requested?
+  end
+
+  test 'member can add a note to the history of their own notice' do
+    sign_in_as_member
+    permit = member_permit
+
+    assert_difference -> { permit.events.count }, 1 do
+      post add_note_member_parking_permit_path(permit), params: { note: 'Picked up tomorrow' }
+    end
+
+    assert_redirected_to member_parking_permit_path(permit)
+    event = permit.events.last
+    assert_equal 'note', event.event_type
+    assert_equal 'Picked up tomorrow', event.note
+  end
+
+  test 'member cannot add a blank note' do
+    sign_in_as_member
+    permit = member_permit
+
+    assert_no_difference -> { permit.events.count } do
+      post add_note_member_parking_permit_path(permit), params: { note: '   ' }
+    end
+
+    assert_redirected_to member_parking_permit_path(permit)
   end
 
   test "member cannot close another member's permit" do
@@ -116,7 +173,7 @@ class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'form[action=?]', close_member_parking_permit_path(permit)
   end
 
-  test 'member can view own ticket but gets no edit or clear actions' do
+  test 'member can view own ticket with a clear action but no edit action' do
     sign_in_as_member
     ticket = member_ticket
 
@@ -124,6 +181,18 @@ class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select 'a[href=?]', edit_member_parking_permit_path(ticket), false
+    assert_select 'form[action=?]', close_member_parking_permit_path(ticket)
+  end
+
+  test 'member sees a request-clearance action for a ticket needing admin clearance' do
+    sign_in_as_member
+    ticket = member_ticket
+    ticket.update!(requires_admin_clearance: true)
+
+    get member_parking_permit_path(ticket)
+
+    assert_response :success
+    assert_select 'form[action=?]', request_clearance_member_parking_permit_path(ticket)
     assert_select 'form[action=?]', close_member_parking_permit_path(ticket), false
   end
 

--- a/test/controllers/parking_notices_controller_test.rb
+++ b/test/controllers/parking_notices_controller_test.rb
@@ -321,12 +321,53 @@ class ParkingNoticesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'application/pdf', response.content_type
   end
 
+  test 'create saves a ticket that requires admin clearance' do
+    assert_difference 'ParkingNotice.count', 1 do
+      post parking_notices_url, params: {
+        parking_notice: {
+          notice_type: 'ticket',
+          description: 'Needs staff sign-off',
+          location: 'Main Area',
+          expires_at: 3.days.from_now,
+          requires_admin_clearance: '1'
+        }
+      }
+    end
+    assert ParkingNotice.last.requires_admin_clearance?
+  end
+
   # --- Clear ---
 
   test 'clear marks notice as cleared' do
     post clear_parking_notice_url(@active_permit)
     assert_redirected_to parking_notice_path(@active_permit)
     assert @active_permit.reload.cleared?
+  end
+
+  test 'clear logs a cleared history event' do
+    assert_difference -> { @active_permit.events.count }, 1 do
+      post clear_parking_notice_url(@active_permit)
+    end
+    assert_equal 'cleared', @active_permit.events.recent_first.first.event_type
+  end
+
+  # --- Notes / history ---
+
+  test 'add_note records a history note' do
+    assert_difference -> { @active_permit.events.count }, 1 do
+      post add_note_parking_notice_url(@active_permit), params: { note: 'Called the member' }
+    end
+    assert_redirected_to parking_notice_path(@active_permit)
+    event = @active_permit.events.recent_first.first
+    assert_equal 'note', event.event_type
+    assert_equal 'Called the member', event.note
+  end
+
+  test 'add_note rejects a blank note' do
+    assert_no_difference -> { @active_permit.events.count } do
+      post add_note_parking_notice_url(@active_permit), params: { note: '  ' }
+    end
+    assert_redirected_to parking_notice_path(@active_permit)
   end
 
   private

--- a/test/models/parking_notice_event_test.rb
+++ b/test/models/parking_notice_event_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class ParkingNoticeEventTest < ActiveSupport::TestCase
+  setup do
+    @notice = parking_notices(:active_permit)
+  end
+
+  test 'requires a valid event_type' do
+    event = ParkingNoticeEvent.new(parking_notice: @notice, event_type: 'bogus')
+    assert_not event.valid?
+    assert_includes event.errors[:event_type], 'is not included in the list'
+  end
+
+  test 'note event requires a note' do
+    event = ParkingNoticeEvent.new(parking_notice: @notice, event_type: 'note')
+    assert_not event.valid?
+
+    event.note = 'A note'
+    assert event.valid?
+  end
+
+  test 'non-note events do not require a note' do
+    event = ParkingNoticeEvent.new(parking_notice: @notice, event_type: 'opened')
+    assert event.valid?
+  end
+
+  test 'label and icon return display strings' do
+    event = ParkingNoticeEvent.new(parking_notice: @notice, event_type: 'cleared')
+    assert_equal 'Cleared', event.label
+    assert_equal 'bi-check-circle', event.icon
+  end
+
+  test 'chronological orders oldest first' do
+    @notice.log_event!('opened')
+    @notice.log_event!('renewed')
+
+    assert_equal %w[opened renewed], @notice.events.chronological.pluck(:event_type)
+  end
+end

--- a/test/models/parking_notice_test.rb
+++ b/test/models/parking_notice_test.rb
@@ -171,4 +171,110 @@ class ParkingNoticeTest < ActiveSupport::TestCase
       notice.record_journal_entry!('parking_ticket_issued')
     end
   end
+
+  # --- Admin-clearance permissions ---
+
+  test 'clearable_by? lets the owner clear their own active notice' do
+    assert parking_notices(:active_permit).clearable_by?(@user)
+  end
+
+  test 'clearable_by? blocks a non-owner who is not an admin' do
+    other = users(:two)
+    assert_not parking_notices(:active_permit).clearable_by?(other)
+  end
+
+  test 'clearable_by? blocks the owner when admin clearance is required' do
+    notice = parking_notices(:active_permit)
+    notice.update!(requires_admin_clearance: true)
+    assert_not notice.clearable_by?(@user)
+  end
+
+  test 'clearable_by? always lets an admin clear, even when admin clearance is required' do
+    admin = users(:two)
+    admin.update!(is_admin: true)
+    notice = parking_notices(:active_permit)
+    notice.update!(requires_admin_clearance: true)
+    assert notice.clearable_by?(admin)
+  end
+
+  test 'clearable_by? blocks clearing a notice that is not active' do
+    assert_not parking_notices(:cleared_permit).clearable_by?(@user)
+  end
+
+  # --- History events ---
+
+  test 'creating a notice logs an opened event' do
+    notice = nil
+    assert_difference 'ParkingNoticeEvent.count', 1 do
+      notice = ParkingNotice.create!(
+        notice_type: 'permit', user: @user, issued_by: @admin, expires_at: 7.days.from_now
+      )
+    end
+    event = notice.events.last
+    assert_equal 'opened', event.event_type
+    assert_equal @admin, event.actor
+  end
+
+  test 'clear! logs a cleared event' do
+    notice = parking_notices(:active_permit)
+    assert_difference 'ParkingNoticeEvent.count', 1 do
+      notice.clear!(@admin)
+    end
+    assert_equal 'cleared', notice.events.last.event_type
+  end
+
+  test 'expire! logs an expired event' do
+    notice = parking_notices(:active_permit)
+    assert_difference 'ParkingNoticeEvent.count', 1 do
+      notice.expire!
+    end
+    assert_equal 'expired', notice.events.last.event_type
+  end
+
+  test 'changing the expiration logs a renewed event' do
+    notice = parking_notices(:active_permit)
+    assert_difference 'ParkingNoticeEvent.count', 1 do
+      notice.update!(expires_at: 30.days.from_now)
+    end
+    assert_equal 'renewed', notice.events.last.event_type
+  end
+
+  test 'updating without changing expiration does not log a renewed event' do
+    notice = parking_notices(:active_permit)
+    assert_no_difference 'ParkingNoticeEvent.count' do
+      notice.update!(description: 'Tweaked description')
+    end
+  end
+
+  test 'log_event! records a note with its text' do
+    notice = parking_notices(:active_permit)
+    notice.log_event!('note', actor: @admin, note: 'Spoke with the member')
+    event = notice.events.last
+    assert_equal 'note', event.event_type
+    assert_equal 'Spoke with the member', event.note
+    assert_equal @admin, event.actor
+  end
+
+  # --- Clearance requests ---
+
+  test 'request_clearance! records the request and logs an event' do
+    notice = parking_notices(:active_permit)
+    notice.update!(requires_admin_clearance: true)
+
+    assert_difference 'ParkingNoticeEvent.count', 1 do
+      notice.request_clearance!(@user)
+    end
+
+    assert notice.clearance_requested?
+    assert_equal @user, notice.clearance_requested_by
+    assert_equal 'clearance_requested', notice.events.last.event_type
+  end
+
+  test 'clearance_requested? is false once the notice is cleared' do
+    notice = parking_notices(:active_permit)
+    notice.update!(requires_admin_clearance: true)
+    notice.request_clearance!(@user)
+    notice.clear!(@admin)
+    assert_not notice.clearance_requested?
+  end
 end


### PR DESCRIPTION
## Summary
- Tickets can be flagged to **require admin clearance**. When set, the member can request clearance but cannot clear the ticket themselves; admins can always clear any notice. By default, members may now clear their own tickets (previously view-only).
- Parking permits and tickets keep a **history** (`parking_notice_events`): opened, renewed (expiration changed), cleared, expired, and clearance-requested events, plus free-text notes added by members or admins.
- History timelines and a note-add form are shown on both the member and admin detail pages. The admin detail page surfaces a clearance-request banner and a "Require admin to clear" checkbox on the ticket form; the member views gain Clear / Request-clearance actions driven by the new permission rules.

## Changes
- Migrations: `requires_admin_clearance`, `clearance_requested_at`, `clearance_requested_by_id` on `parking_notices`; new `parking_notice_events` table.
- `ParkingNotice`: `clearable_by?`, `request_clearance!`, `clearance_requested?`, event logging on create/clear/expire/renew, `log_event!`.
- New `ParkingNoticeEvent` model + shared `_history` partial.
- Member + admin controllers/routes: `request_clearance` and `add_note` actions; permission-aware `close`.

## Test plan
- [x] `bin/rails test` (full suite) — 1234 runs, 0 failures
- [x] RuboCop — no offenses
- [ ] Manual: admin sets "require admin clearance" on a ticket; member sees Request-clearance only and admin sees the request banner
- [ ] Manual: member clears a normal ticket/permit; history records opened/cleared and notes

Made with [Cursor](https://cursor.com)