### PR TITLE
Add ability to pause a member's RFID key access

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -501,6 +501,18 @@
 }
 .btn-link-add:hover { text-decoration: underline; }
 
+.btn-link-action {
+  background: none;
+  border: none;
+  color: var(--bs-secondary-color);
+  font-size: 11px;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  text-decoration: none;
+}
+.btn-link-action:hover { color: var(--bs-body-color); text-decoration: underline; }
+
 // Outline-secondary is the app's default action button, but Bootstrap's dark-mode
 // rendering (muted gray text + dim border) is low-contrast on our dark panels. Brighten the
 // label and border so actions are legible and stand out, without adding any color meaning.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < AuthenticatedController
                          unmark_sponsored destroy
                          sync_to_authentik sync_from_authentik
                          unlink_slack unlink_authentik unlink_sheet
-                         mark_help_seen]
+                         mark_help_seen pause_key_access resume_key_access]
   before_action :require_admin!, except: %i[show edit update mark_help_seen]
   before_action :authorize_profile_view, only: [:show]
   before_action :authorize_self_or_admin, only: %i[edit update]
@@ -37,6 +37,7 @@ class UsersController < AuthenticatedController
     @filter_params[:membership_plan_id] = params[:membership_plan_id] if params[:membership_plan_id].present?
     @filter_params[:missing] = params[:missing] if params[:missing].present?
     @filter_params[:account_type] = params[:account_type] if params[:account_type].present?
+    @filter_params[:key_access] = params[:key_access] if params[:key_access].present?
     if params[:emergency_active_override].present?
       @filter_params[:emergency_active_override] = params[:emergency_active_override]
     end
@@ -88,6 +89,8 @@ class UsersController < AuthenticatedController
       @users = @users.non_service_accounts.where("email IS NULL OR email = ''")
     end
 
+    @users = @users.non_service_accounts.where(key_access_paused: true) if params[:key_access] == 'paused'
+
     # Total count always from the full (non-legacy-adjusted) set for the "X of Y" message
     @user_count = default_users.count
 
@@ -125,6 +128,7 @@ class UsersController < AuthenticatedController
 
     @no_rfid_count = filtered_members.where.missing(:rfids).count
     @no_email_count = filtered_members.where("email IS NULL OR email = ''").count
+    @key_paused_count = filtered_members.where(key_access_paused: true).count
 
     @service_account_count = @users.service_accounts.count
     @member_account_count = @users.non_service_accounts.count
@@ -142,7 +146,7 @@ class UsersController < AuthenticatedController
                      params[:dues_status].present? || params[:active].present? ||
                      params[:missing].present? || params[:account_type].present? ||
                      params[:membership_plan_id].present? || params[:q].present? ||
-                     params[:emergency_active_override].present?
+                     params[:emergency_active_override].present? || params[:key_access].present?
     @filtered_count = @users.count if @filter_active || @include_legacy
 
     # Store filter/sort params for passing to user profile links
@@ -241,6 +245,7 @@ class UsersController < AuthenticatedController
       if params[:emergency_active_override] == '1'
         nav_query = nav_query.where(service_account: false, emergency_active_override: true)
       end
+      nav_query = nav_query.where(service_account: false, key_access_paused: true) if params[:key_access] == 'paused'
 
       # Apply sorting — use Arel nodes to avoid string interpolation (CodeQL SQL injection rule)
       sort_column = SORTABLE_COLUMNS.include?(params[:sort]) ? params[:sort] : 'full_name'
@@ -269,6 +274,7 @@ class UsersController < AuthenticatedController
       if params[:emergency_active_override].present?
         @nav_params[:emergency_active_override] = params[:emergency_active_override]
       end
+      @nav_params[:key_access] = params[:key_access] if params[:key_access].present?
       @nav_params[:sort] = params[:sort] if params[:sort].present?
       @nav_params[:direction] = params[:direction] if params[:direction].present?
     end
@@ -387,6 +393,30 @@ class UsersController < AuthenticatedController
     end
     @user.update!(active: false)
     redirect_to user_path(@user), notice: 'Account deactivated.'
+  end
+
+  def pause_key_access
+    if @user.key_access_paused?
+      redirect_to key_access_redirect_path, notice: "Key access is already paused for #{@user.display_name}."
+      return
+    end
+
+    @user.pause_key_access!
+    redirect_to key_access_redirect_path,
+                notice: "Key access paused for #{@user.display_name}. " \
+                        'Their keys are kept but will not be synced to the access controllers.'
+  end
+
+  def resume_key_access
+    unless @user.key_access_paused?
+      redirect_to key_access_redirect_path, notice: "Key access is not paused for #{@user.display_name}."
+      return
+    end
+
+    @user.resume_key_access!
+    redirect_to key_access_redirect_path,
+                notice: "Key access resumed for #{@user.display_name}. " \
+                        'Sync the access controllers to restore their access.'
   end
 
   def enable_emergency_active_override
@@ -557,6 +587,16 @@ class UsersController < AuthenticatedController
   end
 
   private
+
+  # Pause/resume can be triggered from the member profile or the Add Key Fob screen.
+  # Return to the originating screen so the toggled button stays in context.
+  def key_access_redirect_path
+    if params[:return_to] == 'add_key'
+      new_rfid_path(rfid: { user_id: @user.id })
+    else
+      user_path(@user, tab: :profile)
+    end
+  end
 
   def set_user_for_show
     @user = User.includes(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,6 +89,8 @@ class User < ApplicationRecord
   }
 
   scope :active, -> { where(active: true) }
+  scope :key_access_paused, -> { where(key_access_paused: true) }
+  scope :key_access_active, -> { where(key_access_paused: false) }
   scope :admin, -> { where(is_admin: true) }
   scope :service_accounts, -> { where(service_account: true) }
   scope :non_service_accounts, -> { where(service_account: false) }
@@ -130,6 +132,20 @@ class User < ApplicationRecord
 
   def active?
     active
+  end
+
+  # Pause this member's RFID key access without removing or deactivating their keys.
+  # Paused members are excluded from access controller syncs (see AccessControllerPayloadBuilder).
+  def pause_key_access!
+    return false if key_access_paused?
+
+    update!(key_access_paused: true, key_access_paused_at: Time.current)
+  end
+
+  def resume_key_access!
+    return false unless key_access_paused?
+
+    update!(key_access_paused: false, key_access_paused_at: nil)
   end
 
   def username

--- a/app/services/access_controller_payload_builder.rb
+++ b/app/services/access_controller_payload_builder.rb
@@ -26,7 +26,9 @@ class AccessControllerPayloadBuilder
 
   def base_users
     scope = sync_inactive_members? ? User.all : User.active
-    scope.includes(:rfids, trainings_as_trainee: :training_topic)
+    # Members with paused key access are never synced to access controllers,
+    # even when active and otherwise eligible.
+    scope.key_access_active.includes(:rfids, trainings_as_trainee: :training_topic)
   end
 
   def sync_inactive_members?

--- a/app/views/rfids/new.html.erb
+++ b/app/views/rfids/new.html.erb
@@ -37,6 +37,7 @@
                  data-user-name="<%= [user.display_name, user.email, user.username].compact.join(' ').downcase %>"
                  data-user-display="<%= user.display_name %>"
                  data-has-building-access="<%= @trained_user_ids.include?(user.id) %>"
+                 data-key-access-paused="<%= user.key_access_paused? %>"
                  style="cursor: pointer;">
               <div class="fw-semibold"><%= user.display_name %></div>
               <% if user.email.present? %>
@@ -104,6 +105,28 @@
         <%= link_to "Cancel", root_path, class: "btn btn-outline-secondary" %>
       </div>
     <% end %>
+
+    <div id="key_access_controls" class="border-top pt-3 mt-3" style="display: none;">
+      <div class="text-muted small mb-2">
+        Need to suspend access without adding a key? Pausing keeps the member's existing keys but stops
+        syncing them to the access controllers.
+      </div>
+      <div id="pause_access_wrapper">
+        <%= button_to pause_key_access_user_path('__USER_ID__', return_to: 'add_key'),
+            method: :post, class: "btn btn-outline-warning",
+            form: { id: "pause_access_form", data: { turbo: false } } do %>
+          <i class="bi bi-pause-circle me-1"></i>Pause key access (no key added)
+        <% end %>
+      </div>
+      <div id="resume_access_wrapper" style="display: none;">
+        <span class="badge text-bg-warning-subtle me-2"><i class="bi bi-pause-circle me-1"></i>Access paused</span>
+        <%= button_to resume_key_access_user_path('__USER_ID__', return_to: 'add_key'),
+            method: :post, class: "btn btn-outline-secondary",
+            form: { id: "resume_access_form", data: { turbo: false } } do %>
+          <i class="bi bi-play-circle me-1"></i>Resume key access
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -128,6 +151,32 @@
       // Prevent double-init
       if (memberSearch.dataset.initialized === 'true') return;
       memberSearch.dataset.initialized = 'true';
+
+      function updateKeyAccessControls(userId, paused) {
+        const controls = document.getElementById('key_access_controls');
+        const pauseWrapper = document.getElementById('pause_access_wrapper');
+        const resumeWrapper = document.getElementById('resume_access_wrapper');
+        const pauseForm = document.getElementById('pause_access_form');
+        const resumeForm = document.getElementById('resume_access_form');
+        if (!controls || !pauseForm || !resumeForm) return;
+
+        pauseForm.action = '/users/' + userId + '/pause_key_access?return_to=add_key';
+        resumeForm.action = '/users/' + userId + '/resume_key_access?return_to=add_key';
+
+        controls.style.display = '';
+        if (paused === 'true') {
+          pauseWrapper.style.display = 'none';
+          resumeWrapper.style.display = '';
+        } else {
+          pauseWrapper.style.display = '';
+          resumeWrapper.style.display = 'none';
+        }
+      }
+
+      function hideKeyAccessControls() {
+        const controls = document.getElementById('key_access_controls');
+        if (controls) controls.style.display = 'none';
+      }
 
       function filterMembers() {
         const searchTerm = memberSearch.value.toLowerCase().trim();
@@ -159,7 +208,7 @@
         }
       }
 
-      function selectMember(userId, displayName, hasBuildingAccess) {
+      function selectMember(userId, displayName, hasBuildingAccess, keyAccessPaused) {
         userIdInput.value = userId;
         selectedMemberName.textContent = displayName;
         selectedMember.style.display = 'block';
@@ -177,6 +226,7 @@
           hasTrainingNote.style.display = 'none';
         }
         addTrainingInput.value = '0';
+        updateKeyAccessControls(userId, keyAccessPaused);
       }
 
       function clearSelection() {
@@ -190,6 +240,7 @@
         buttonsWithoutTraining.style.display = 'flex';
         addTrainingInput.value = '0';
         hasTrainingNote.style.display = 'none';
+        hideKeyAccessControls();
       }
 
       memberSearch.addEventListener('input', filterMembers);
@@ -201,7 +252,8 @@
           const userId = this.getAttribute('data-user-id');
           const displayName = this.getAttribute('data-user-display');
           const hasBuildingAccess = this.getAttribute('data-has-building-access');
-          selectMember(userId, displayName, hasBuildingAccess);
+          const keyAccessPaused = this.getAttribute('data-key-access-paused');
+          selectMember(userId, displayName, hasBuildingAccess, keyAccessPaused);
         });
 
         result.addEventListener('mouseenter', function() {
@@ -245,6 +297,7 @@
         if (results[i].getAttribute('data-user-id') === userId) {
           const displayName = results[i].getAttribute('data-user-display');
           const hasBuildingAccess = results[i].getAttribute('data-has-building-access');
+          const keyAccessPaused = results[i].getAttribute('data-key-access-paused');
 
           var selectedMember = document.getElementById('selected_member');
           var selectedMemberName = document.getElementById('selected_member_name');
@@ -265,6 +318,24 @@
             buttonsWithTraining.style.display = 'flex';
             buttonsWithoutTraining.style.display = 'none';
             hasTrainingNote.style.display = 'none';
+          }
+
+          var keyAccessControls = document.getElementById('key_access_controls');
+          var pauseWrapper = document.getElementById('pause_access_wrapper');
+          var resumeWrapper = document.getElementById('resume_access_wrapper');
+          var pauseForm = document.getElementById('pause_access_form');
+          var resumeForm = document.getElementById('resume_access_form');
+          if (keyAccessControls && pauseForm && resumeForm) {
+            pauseForm.action = '/users/' + userId + '/pause_key_access?return_to=add_key';
+            resumeForm.action = '/users/' + userId + '/resume_key_access?return_to=add_key';
+            keyAccessControls.style.display = '';
+            if (keyAccessPaused === 'true') {
+              pauseWrapper.style.display = 'none';
+              resumeWrapper.style.display = '';
+            } else {
+              pauseWrapper.style.display = '';
+              resumeWrapper.style.display = 'none';
+            }
           }
           break;
         }

--- a/app/views/users/_tab_profile_admin.html.erb
+++ b/app/views/users/_tab_profile_admin.html.erb
@@ -273,7 +273,23 @@
             <% else %>
               <span class="profile-field-value empty">None</span>
             <% end %>
-            <%= link_to "+ Add key", new_rfid_path(rfid: { user_id: user.id }), class: "btn-link-add ms-auto" %>
+            <% if user.key_access_paused? %>
+              <span class="badge text-bg-warning-subtle" title="<%= user.key_access_paused_at&.strftime('Paused %b %-d, %Y at %-l:%M %p') %>">
+                <i class="bi bi-pause-circle me-1"></i>Access paused
+              </span>
+            <% end %>
+            <span class="d-inline-flex align-items-center gap-3 ms-auto">
+              <%= link_to "+ Add key", new_rfid_path(rfid: { user_id: user.id }), class: "btn-link-add" %>
+              <% if user.key_access_paused? %>
+                <%= button_to "Resume access", resume_key_access_user_path(user), method: :post,
+                    class: "btn-link-action", form: { class: "d-inline" },
+                    data: { turbo: false } %>
+              <% else %>
+                <%= button_to "Pause access", pause_key_access_user_path(user), method: :post,
+                    class: "btn-link-action", form: { class: "d-inline" },
+                    data: { turbo: false, turbo_confirm: "Pause RFID key access for #{user.display_name}? Their keys are kept but stop syncing to the access controllers." } %>
+              <% end %>
+            </span>
           </div>
         </div>
       </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -47,6 +47,7 @@
     filter_labels << (params[:active] == 'true' ? 'Active only' : 'Inactive only') if params[:active].present?
     filter_labels << 'Active override' if params[:emergency_active_override] == '1'
     filter_labels << "Missing: #{params[:missing] == 'rfid' ? 'No RFID' : 'No Email'}" if params[:missing].present?
+    filter_labels << 'Key access paused' if params[:key_access] == 'paused'
     if params[:account_type].present?
       filter_labels << (params[:account_type] == 'service' ? 'Service Accounts' : 'Members Only')
     end
@@ -176,6 +177,9 @@
       <% end %>
       <%= link_to stacking_filter_path(:emergency_active_override, '1'), class: "badge text-bg-warning text-decoration-none #{'border border-dark border-2' if params[:emergency_active_override] == '1'}" do %>
         <i class="bi bi-lightning-charge me-1"></i>Active override: <strong><%= @emergency_active_override_count %></strong>
+      <% end %>
+      <%= link_to stacking_filter_path(:key_access, 'paused'), class: "badge text-bg-warning text-decoration-none #{'border border-dark border-2' if params[:key_access] == 'paused'}" do %>
+        <i class="bi bi-pause-circle me-1"></i>Key paused: <strong><%= @key_paused_count %></strong>
       <% end %>
     </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,8 @@ Rails.application.routes.draw do
       post :unlink_authentik
       post :unlink_sheet
       post :mark_help_seen
+      post :pause_key_access
+      post :resume_key_access
     end
     collection do
       post :sync

--- a/db/migrate/20260612120000_add_key_access_paused_to_users.rb
+++ b/db/migrate/20260612120000_add_key_access_paused_to_users.rb
@@ -1,0 +1,7 @@
+class AddKeyAccessPausedToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :key_access_paused, :boolean, default: false, null: false
+    add_column :users, :key_access_paused_at, :datetime
+    add_index :users, :key_access_paused
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_100100) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -1017,6 +1017,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_100100) do
     t.string "greeting_name"
     t.boolean "is_admin", default: false, null: false
     t.boolean "is_sponsored", default: false, null: false
+    t.boolean "key_access_paused", default: false, null: false
+    t.datetime "key_access_paused_at"
     t.datetime "last_login_at"
     t.date "last_payment_date"
     t.datetime "last_synced_at"
@@ -1053,6 +1055,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_100100) do
     t.index ["authentik_id"], name: "index_users_on_authentik_id", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
     t.index ["is_sponsored"], name: "index_users_on_is_sponsored"
+    t.index ["key_access_paused"], name: "index_users_on_key_access_paused"
     t.index ["legacy"], name: "index_users_on_legacy"
     t.index ["login_token"], name: "index_users_on_login_token", unique: true
     t.index ["membership_plan_id"], name: "index_users_on_membership_plan_id"

--- a/test/controllers/rfids_controller_test.rb
+++ b/test/controllers/rfids_controller_test.rb
@@ -20,6 +20,24 @@ class RfidsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'input[name=?][value=?]', 'rfid[rfid]', '127,'
   end
 
+  test 'new key fob form includes pause and resume key access controls' do
+    get new_rfid_url
+
+    assert_response :success
+    assert_select '#key_access_controls'
+    assert_select 'form#pause_access_form'
+    assert_select 'form#resume_access_form'
+  end
+
+  test 'new key fob form marks members with paused key access' do
+    users(:one).pause_key_access!
+
+    get new_rfid_url
+
+    assert_response :success
+    assert_select ".member-result[data-user-id=?][data-key-access-paused='true']", users(:one).id.to_s
+  end
+
   private
 
   def sign_in_as_admin

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -493,6 +493,57 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_match target.full_name, response.body
   end
 
+  test 'pause_key_access pauses the member and redirects to profile' do
+    assert_not @user.key_access_paused?
+
+    post pause_key_access_user_path(@user)
+
+    assert_redirected_to user_path(@user, tab: :profile)
+    assert @user.reload.key_access_paused?
+    follow_redirect!
+    assert_match(/Key access paused/i, response.body)
+  end
+
+  test 'resume_key_access resumes the member and redirects to profile' do
+    @user.pause_key_access!
+
+    post resume_key_access_user_path(@user)
+
+    assert_redirected_to user_path(@user, tab: :profile)
+    assert_not @user.reload.key_access_paused?
+    follow_redirect!
+    assert_match(/Key access resumed/i, response.body)
+  end
+
+  test 'pause_key_access redirects to the add key screen when return_to=add_key' do
+    post pause_key_access_user_path(@user, return_to: 'add_key')
+
+    assert_redirected_to new_rfid_path(rfid: { user_id: @user.id })
+    assert @user.reload.key_access_paused?
+  end
+
+  test 'pause_key_access is idempotent when already paused' do
+    @user.pause_key_access!
+
+    post pause_key_access_user_path(@user)
+
+    assert_redirected_to user_path(@user, tab: :profile)
+    follow_redirect!
+    assert_match(/already paused/i, response.body)
+  end
+
+  test 'admin profile shows pause access button and paused state' do
+    get user_path(@user, tab: :profile)
+    assert_response :success
+    assert_select 'form[action=?]', pause_key_access_user_path(@user)
+
+    @user.pause_key_access!
+    get user_path(@user, tab: :profile)
+    assert_response :success
+    assert_select 'form[action=?]', resume_key_access_user_path(@user)
+    assert_match(/Access paused/i, response.body)
+  end
+
   private
 
   def sign_in_as_local_admin

--- a/test/controllers/users_index_filters_test.rb
+++ b/test/controllers/users_index_filters_test.rb
@@ -139,6 +139,31 @@ class UsersIndexFiltersTest < ActionDispatch::IntegrationTest
     assert_match users(:one).display_name, response.body
   end
 
+  # ─── Key access paused filtering ───────────────────────────────────
+
+  test 'index shows key paused filter badge' do
+    get users_path
+    assert_response :success
+    assert_match(/Key paused/i, response.body)
+    assert_select 'a[href*="key_access=paused"]'
+  end
+
+  test 'filtering by key_access=paused returns only paused members' do
+    users(:one).pause_key_access!
+    users(:two).resume_key_access!
+
+    get users_path(key_access: 'paused')
+    assert_response :success
+    assert_match users(:one).display_name, response.body
+    assert_no_match(/#{Regexp.escape(users(:two).display_name)}/, response.body)
+  end
+
+  test 'key access paused filter shows in the active filter summary' do
+    get users_path(key_access: 'paused')
+    assert_response :success
+    assert_match 'Key access paused', response.body
+  end
+
   # ─── Combined / stacking filters ──────────────────────────────────
 
   test 'clear all filters link is shown when filter active' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -38,6 +38,66 @@ class UserTest < ActiveSupport::TestCase
     assert_equal ['user1@example.com'], results.pluck(:email)
   end
 
+  test 'pause_key_access! sets the flag and timestamp' do
+    user = users(:one)
+    assert_not user.key_access_paused?
+
+    freeze_time do
+      assert user.pause_key_access!
+      assert user.reload.key_access_paused?
+      assert_equal Time.current, user.key_access_paused_at
+    end
+  end
+
+  test 'pause_key_access! is a no-op when already paused' do
+    user = users(:one)
+    user.pause_key_access!
+    original_time = user.key_access_paused_at
+
+    travel 1.hour do
+      assert_not user.pause_key_access!
+      assert_equal original_time.to_i, user.reload.key_access_paused_at.to_i
+    end
+  end
+
+  test 'resume_key_access! clears the flag and timestamp' do
+    user = users(:one)
+    user.pause_key_access!
+
+    assert user.resume_key_access!
+    user.reload
+    assert_not user.key_access_paused?
+    assert_nil user.key_access_paused_at
+  end
+
+  test 'resume_key_access! is a no-op when not paused' do
+    user = users(:one)
+    assert_not user.resume_key_access!
+  end
+
+  test 'key_access_paused and key_access_active scopes' do
+    paused = users(:one)
+    active = users(:two)
+    paused.pause_key_access!
+    active.resume_key_access!
+
+    assert_includes User.key_access_paused, paused
+    assert_not_includes User.key_access_paused, active
+    assert_includes User.key_access_active, active
+    assert_not_includes User.key_access_active, paused
+  end
+
+  test 'pausing key access does not mark the user dirty for authentik sync' do
+    # cash_payer is paying + current, so its computed active status stays stable across saves
+    user = users(:cash_payer)
+    user.update!(authentik_dirty: false)
+    assert_not user.reload.authentik_dirty?
+
+    user.pause_key_access!
+
+    assert_not user.reload.authentik_dirty?
+  end
+
   test 'by_name_or_alias matches single-word full_name exactly' do
     user = User.create!(
       authentik_id: 'single-word-test',

--- a/test/services/access_controller_payload_builder_test.rb
+++ b/test/services/access_controller_payload_builder_test.rb
@@ -48,6 +48,38 @@ class AccessControllerPayloadBuilderTest < ActiveSupport::TestCase
     assert_not_includes uids, @user_one.authentik_id
   end
 
+  # --- Paused key access filtering ---
+
+  test 'excludes members with paused key access even when active with RFIDs' do
+    @user_one.pause_key_access!
+
+    payload = parse_payload
+    uids = payload.pluck('uid')
+    assert_not_includes uids, @user_one.authentik_id
+    assert_includes uids, @user_two.authentik_id
+  end
+
+  test 'excludes paused members even when sync_inactive_members is enabled' do
+    DefaultSetting.instance.update!(sync_inactive_members: true)
+    @user_one.pause_key_access!
+
+    payload = parse_payload
+    uids = payload.pluck('uid')
+    assert_not_includes uids, @user_one.authentik_id
+  end
+
+  test 'includes a member again after their key access is resumed' do
+    # Keep the member eligible regardless of computed active status so the test
+    # isolates the pause/resume behavior.
+    DefaultSetting.instance.update!(sync_inactive_members: true)
+
+    @user_one.pause_key_access!
+    assert_not_includes parse_payload.pluck('uid'), @user_one.authentik_id
+
+    @user_one.resume_key_access!
+    assert_includes parse_payload.pluck('uid'), @user_one.authentik_id
+  end
+
   # --- Per-type training topic filtering ---
 
   test 'includes all users when no training topics required' do


### PR DESCRIPTION
## Summary

Adds the ability for admins to **pause** a member's RFID key access without deleting their keys or deactivating their account. Paused members are excluded from access controller syncs, so their data is never sent to the access controller scripts.

### What changed
- **Data model:** new `key_access_paused` / `key_access_paused_at` columns on `users`, with `key_access_paused` / `key_access_active` scopes and `pause_key_access!` / `resume_key_access!` helpers on `User`.
- **Access controller sync:** `AccessControllerPayloadBuilder` excludes members with paused key access (even when active and otherwise eligible). The button toggles to **Resume** once paused.
- **Member profile:** Pause / Resume button next to the RFID keys, plus an "Access paused" badge.
- **Add Key Fob screen:** a control that pauses the selected member's access *without adding a key*; toggles to Resume when the member is already paused.
- **Members list:** a "Key paused" filter that stacks with the existing filters.

### Notes
- Pausing/resuming is journaled via the existing `User` update journal, and does not trigger an Authentik sync (the columns are not Authentik-syncable).
- After resuming, an access controller sync is still required to restore access — the flash message says so.

## Test plan
- [x] `AccessControllerPayloadBuilder` excludes paused members (active, inactive-sync, resume re-includes)
- [x] `User` pause/resume methods + scopes
- [x] Controller pause/resume endpoints (profile + add-key redirect, idempotency)
- [x] Members list "Key paused" filter
- [x] Add Key Fob screen renders pause/resume controls and marks paused members
- [x] Full suite green (`1253 runs, 0 failures`) and RuboCop clean

Made with [Cursor](https://cursor.com)