### PR TITLE
Show private notice in place instead of redirecting

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -163,6 +163,7 @@ class UsersController < AuthenticatedController
     # Determine view level based on viewer and profile settings
     @natural_view_level = determine_view_level
     @view_level = determine_effective_view_level
+    @profile_hidden = profile_hidden_for_view?(@view_level)
 
     # Set up view preview options for admins and profile owners
     setup_view_preview_options
@@ -638,20 +639,26 @@ class UsersController < AuthenticatedController
     return if user_signed_in? && @user == current_user
 
     # Check profile visibility settings
+    # Anyone can view a public profile. For members-only and private profiles,
+    # only anonymous visitors are redirected to sign in. Signed-in members fall
+    # through to the show action, which renders the profile or, for a private
+    # profile, a "this profile is private" notice at the same URL.
+    return if @user.profile_visibility == 'public'
+
+    redirect_to login_path, alert: 'Please sign in to view this profile.' unless user_signed_in?
+  end
+
+  # Whether the profile body should be replaced with a "not available" notice
+  # for the given view level, based on the profile's visibility setting.
+  # Admin and self view levels always see the full profile.
+  def profile_hidden_for_view?(view_level)
     case @user.profile_visibility
-    when 'public'
-      # Anyone can view
-      true
     when 'members'
-      # Must be logged in
-      redirect_to login_path, alert: 'Please sign in to view this profile.' unless user_signed_in?
+      view_level == :public
     when 'private'
-      # Only admin or self (already checked above)
-      if user_signed_in?
-        redirect_to user_path(current_user), alert: 'This profile is private.'
-      else
-        redirect_to login_path, alert: 'Please sign in to view this profile.'
-      end
+      view_level.in?(%i[public members])
+    else
+      false
     end
   end
 

--- a/app/views/users/_profile_hidden.html.erb
+++ b/app/views/users/_profile_hidden.html.erb
@@ -1,0 +1,11 @@
+<div class="text-center py-5">
+  <i class="bi bi-lock text-secondary" style="font-size: 2rem;" aria-hidden="true"></i>
+  <h1 class="h4 mt-3 mb-1"><%= user.display_name %></h1>
+  <p class="text-secondary mb-0">
+    <% if view_level == :public %>
+      This profile is not available to the public.
+    <% else %>
+      This profile is private.
+    <% end %>
+  </p>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -59,6 +59,9 @@
   </div>
 <% end %>
 
+<% if @profile_hidden %>
+  <%= render 'users/profile_hidden', user: @user, view_level: @view_level %>
+<% else %>
 <% if @view_level == :admin && @user.emergency_active_override? %>
   <div class="override-banner mb-3">
     <div class="d-flex align-items-center gap-2 small">
@@ -414,15 +417,8 @@
 
 <% else %>
   <%# ===== PUBLIC VIEW - NO TABS ===== %>
-  <% if @user.profile_visibility != 'public' %>
-    <div class="text-center py-5">
-      <h1 class="display-6 fw-bold text-muted">404</h1>
-      <p class="lead text-muted mb-1">Page not found</p>
-      <p class="text-muted small">This profile is not visible to the public.</p>
-    </div>
-  <% else %>
-    <%= render 'users/tab_profile_public', user: @user %>
-  <% end %>
+  <%= render 'users/tab_profile_public', user: @user %>
+<% end %>
 <% end %>
 
 <%# Member Help Modal - only for profile owner %>

--- a/test/controllers/user_profile_visibility_test.rb
+++ b/test/controllers/user_profile_visibility_test.rb
@@ -68,11 +68,18 @@ class UserProfileVisibilityTest < ActionDispatch::IntegrationTest
     assert_match @public_user.display_name, response.body
   end
 
-  test 'logged in member cannot view private profile of another user' do
+  test 'logged in member sees a private notice on a private profile at its own URL' do
     sign_in_as_member
     get user_path(@private_user)
-    # Should redirect to their own profile
-    assert_redirected_to user_path(@member_with_account)
+
+    # Stays on the private profile's URL (no redirect) and shows the notice
+    assert_response :success
+    assert_match(/This profile is private/i, response.body)
+
+    # Must not leak the hidden profile's contents
+    assert_no_match(@private_user.bio, response.body) if @private_user.bio.present?
+    assert_no_match(/Trained on/i, response.body)
+    assert_no_match(/nav-tabs/, response.body)
   end
 
   test 'logged in member sees training info but not status panel on other profiles' do
@@ -335,6 +342,42 @@ class UserProfileVisibilityTest < ActionDispatch::IntegrationTest
 
     # Should not see preview selector (they're not admin or owner)
     assert_no_match(/View as:/i, response.body)
+  end
+
+  test 'owner previewing own private profile as other members sees the private notice' do
+    @member_with_account.update!(profile_visibility: 'private')
+
+    sign_in_as_member
+    get user_path(@member_with_account, view_as: :members)
+    assert_response :success
+
+    # Preview controls remain so the owner can switch back
+    assert_match(/View as:/i, response.body)
+    assert_match(/This profile is private/i, response.body)
+
+    # The owner's own profile contents are hidden in this preview
+    assert_no_match(@member_with_account.bio, response.body) if @member_with_account.bio.present?
+  end
+
+  test 'owner viewing own private profile normally sees their full profile' do
+    @member_with_account.update!(profile_visibility: 'private')
+
+    sign_in_as_member
+    get user_path(@member_with_account)
+    assert_response :success
+
+    # Self view is never hidden by the visibility setting
+    assert_no_match(/This profile is private/i, response.body)
+    assert_match(/nav-tabs/, response.body)
+  end
+
+  test 'admin viewing a private profile sees the full profile, not the private notice' do
+    sign_in_as_admin
+    get user_path(@private_user)
+    assert_response :success
+
+    assert_no_match(/This profile is private/i, response.body)
+    assert_match @private_user.display_name, response.body
   end
 
   private


### PR DESCRIPTION
Previously, when a signed-in member opened the URL of a profile whose owner had set visibility to private, they were redirected to their own profile with a "This profile is private." flash. The banner appeared on the viewer's own profile, which was confusing, and previewing a private profile as another member still showed the full profile.

Now the viewer stays on the requested profile's URL and sees a calm "This profile is private." notice with no profile contents leaked. Owners and admins previewing as other members see the same notice, while self and admin views are unaffected. Anonymous visitors are still asked to sign in.