### PR TITLE
Allow Executive Director to park applications as needs review

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -6,21 +6,20 @@ class MembershipApplicationsController < ApplicationController
   include MembershipApplicationWizard::Actions
 
   ADMIN_ACTIONS = %i[
-    index show import approve reject delay_for_review link_user unlink_user vote_ai_feedback
+    index show import approve reject delay_for_review mark_needs_review link_user unlink_user vote_ai_feedback
     save_tour_feedback vote_acceptance extend_initiated_application
   ].freeze
   APPLICATION_MEMBER_ACTIONS = %i[
-    show approve reject delay_for_review link_user unlink_user vote_ai_feedback
+    show approve reject delay_for_review mark_needs_review link_user unlink_user vote_ai_feedback
     save_tour_feedback vote_acceptance
   ].freeze
 
   before_action :require_admin!, only: ADMIN_ACTIONS
   before_action :set_application_admin, only: APPLICATION_MEMBER_ACTIONS
-  before_action :require_executive_director_for_final_decision!, only: %i[approve reject delay_for_review]
-  before_action :require_submitted_for_delay!, only: :delay_for_review
+  before_action :require_executive_director_for_final_decision!,
+                only: %i[approve reject delay_for_review mark_needs_review]
+  before_action :require_submitted_for_review_parking!, only: %i[delay_for_review mark_needs_review]
   before_action :require_pending_application_for_acceptance_vote!, only: :vote_acceptance
-
-  # --- Admin actions ---
 
   def import
     if params[:file].blank?
@@ -56,11 +55,12 @@ class MembershipApplicationsController < ApplicationController
                       @applications
                     when 'unlinked'
                       @applications.where(user_id: nil).where(status: 'approved')
+                    when 'under_review'
+                      @applications.where(status: MembershipApplication::IN_REVIEW_STATUSES)
                     else
                       @applications.where(status: @current_status)
                     end
     @applications = @applications.admin_search(params[:q])
-    # Ensure stable newest-first order after search/includes (PostgreSQL + AR can otherwise return arbitrary order).
     @applications = @applications.newest_first
 
     @pagy, @applications = pagy(@applications, limit: 25)
@@ -93,8 +93,7 @@ class MembershipApplicationsController < ApplicationController
     tf = @application.tour_feedbacks.detect { |f| f.user_id == current_user.id }
     @current_tour_feedback = tf || @application.tour_feedbacks.build(user: current_user)
     av = @application.acceptance_votes.detect { |v| v.user_id == current_user.id }
-    # Use `new` not `build` so we do not add a blank vote to the association (nil decision
-    # was shown as "Reject" in the tally list and could confuse the form).
+    # Use `new` not `build` — a blank vote was shown as "Reject" in the tally list.
     @current_acceptance_vote = av || MembershipApplicationAcceptanceVote.new(
       membership_application: @application,
       user: current_user
@@ -188,12 +187,9 @@ class MembershipApplicationsController < ApplicationController
     end
   end
 
-  def delay_for_review
-    notes = params[:admin_notes]
-    @application.delay_for_review!(current_user, notes: notes)
-    redirect_to membership_application_path(@application),
-                notice: 'Application marked as under review.'
-  end
+  def delay_for_review = review_parking!(:delay_for_review!, 'Application marked as under review.')
+
+  def mark_needs_review = review_parking!(:mark_needs_review!, 'Application marked as needs review.')
 
   def vote_ai_feedback
     unless @application.ai_feedback_processed?
@@ -253,18 +249,23 @@ class MembershipApplicationsController < ApplicationController
     end
   end
 
+  def review_parking!(method, notice)
+    @application.public_send(method, current_user, notes: params[:admin_notes])
+    redirect_to membership_application_path(@application), notice: notice
+  end
+
   def require_executive_director_for_final_decision!
     return if true_user&.can_finalize_membership_application?
 
     redirect_to membership_application_path(@application),
-                alert: 'Only members trained as Executive Director may approve, reject, or delay applications.'
+                alert: 'Only members trained as Executive Director may approve, reject, or park applications.'
   end
 
-  def require_submitted_for_delay!
+  def require_submitted_for_review_parking!
     return if @application.submitted?
 
     redirect_to membership_application_path(@application),
-                alert: 'Only open applications can be marked for delayed review.'
+                alert: 'Only open applications can be parked for review.'
   end
 
   def require_pending_application_for_acceptance_vote!

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -33,6 +33,7 @@ class Journal < ApplicationRecord
     application_approved
     application_rejected
     application_delayed_for_review
+    application_marked_needs_review
   ].freeze
 
   # Fields whose changes should trigger a highlight

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -1,5 +1,7 @@
 class MembershipApplication < ApplicationRecord
-  STATUSES = %w[draft submitted under_review approved rejected].freeze
+  STATUSES = %w[draft submitted under_review needs_review approved rejected].freeze
+  IN_REVIEW_STATUSES = %w[under_review needs_review].freeze
+  NAGGABLE_PENDING_STATUSES = %w[submitted under_review].freeze
 
   # Training topic name (TrainingTopic.name) — viewers with this training see applicant PII without masking.
   EXECUTIVE_DIRECTOR_TRAINING_TOPIC_NAME = 'Executive Director'.freeze
@@ -41,13 +43,14 @@ class MembershipApplication < ApplicationRecord
     where.not(status: 'draft').where(ai_feedback_processed_at: nil)
   }
   scope :submitted_apps, -> { where(status: 'submitted') }
-  scope :under_review_apps, -> { where(status: 'under_review') }
+  scope :under_review_apps, -> { where(status: IN_REVIEW_STATUSES) }
   scope :approved, -> { where(status: 'approved') }
   scope :rejected, -> { where(status: 'rejected') }
-  # Applications awaiting a final decision (Open or Under Review).
-  scope :pending, -> { where(status: %w[submitted under_review]) }
+  # Applications awaiting a final decision (Open, Under Review, or parked Needs Review).
+  scope :pending, -> { where(status: %w[submitted] + IN_REVIEW_STATUSES) }
+  scope :naggable_pending, -> { where(status: NAGGABLE_PENDING_STATUSES) }
   scope :stale_pending, lambda { |stale_cutoff = 1.week.ago|
-    pending
+    naggable_pending
       .where('COALESCE(membership_applications.submitted_at, membership_applications.created_at) <= ?', stale_cutoff)
   }
   scope :awaiting_admin_nag, lambda { |stale_cutoff = 1.week.ago, repeat_cutoff = 3.days.ago|
@@ -107,6 +110,14 @@ class MembershipApplication < ApplicationRecord
     status == 'under_review'
   end
 
+  def needs_review?
+    status == 'needs_review'
+  end
+
+  def in_review?
+    under_review? || needs_review?
+  end
+
   def approved?
     status == 'approved'
   end
@@ -116,7 +127,7 @@ class MembershipApplication < ApplicationRecord
   end
 
   def pending?
-    submitted? || under_review?
+    submitted? || in_review?
   end
 
   def submit!
@@ -168,10 +179,23 @@ class MembershipApplication < ApplicationRecord
     Journal.record_application_event!(application: self, action: 'application_delayed_for_review', actor: admin)
   end
 
+  # Parks the application indefinitely: no staff nags, no acceptance votes, no applicant email.
+  def mark_needs_review!(admin, notes: nil)
+    raise ArgumentError, 'Only open applications can be marked needs review' unless submitted?
+
+    update!(
+      status: 'needs_review',
+      reviewed_by: admin,
+      reviewed_at: Time.current,
+      admin_notes: notes
+    )
+    Journal.record_application_event!(application: self, action: 'application_marked_needs_review', actor: admin)
+  end
+
   def status_display
     return 'Open' if submitted?
-
-    return 'Under Review' if under_review?
+    return 'Under review' if under_review?
+    return 'Needs review' if needs_review?
 
     status&.titleize
   end
@@ -179,7 +203,7 @@ class MembershipApplication < ApplicationRecord
   def status_badge_color
     case status
     when 'submitted' then 'primary'
-    when 'under_review' then 'warning'
+    when 'under_review', 'needs_review' then 'warning'
     when 'approved' then 'success'
     when 'rejected' then 'danger'
     else 'secondary'
@@ -244,7 +268,7 @@ class MembershipApplication < ApplicationRecord
   end
 
   def acceptance_vote_open?
-    !approved? && !rejected?
+    !approved? && !rejected? && !needs_review?
   end
 
   AI_FEEDBACK_REC_BADGES = {

--- a/app/services/membership_applications/csv_importer.rb
+++ b/app/services/membership_applications/csv_importer.rb
@@ -92,7 +92,7 @@ module MembershipApplications
       # Blank Timestamp leaves submitted_at unchanged (nil does not overwrite).
       attrs[:submitted_at] = submitted_at if submitted_at.present?
 
-      if app.submitted? || app.under_review?
+      if app.submitted? || app.in_review?
         attrs[:status] = status
         if status.in?(%w[approved rejected])
           attrs[:reviewed_at] = reviewed_at

--- a/app/services/membership_applications/notify_directors_of_stale_applications.rb
+++ b/app/services/membership_applications/notify_directors_of_stale_applications.rb
@@ -41,7 +41,7 @@ module MembershipApplications
     end
 
     def naggable?(application)
-      application.pending? &&
+      application.status.in?(MembershipApplication::NAGGABLE_PENDING_STATUSES) &&
         application_age_start(application) <= @now - INITIAL_DELAY &&
         next_nag_due?(application)
     end

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -55,7 +55,7 @@
                                when 'application_submitted' then 'text-bg-info'
                                when 'application_approved' then 'text-bg-success'
                                when 'application_rejected' then 'text-bg-danger'
-                               when 'application_delayed_for_review' then 'text-bg-warning'
+                               when 'application_delayed_for_review', 'application_marked_needs_review' then 'text-bg-warning'
                                else 'text-bg-secondary'
                                end %>
               <span class="badge <%= badge_class %>"><%= j.action.humanize %></span>

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -223,7 +223,7 @@
                             data: { turbo_frame: '_top' } %>
               </td>
               <td>
-                <span class="badge bg-<%= app.status_badge_color %><%= ' text-dark' if app.under_review? %>"><%= app.status_display %></span>
+                <span class="badge bg-<%= app.status_badge_color %><%= ' text-dark' if app.in_review? %>"><%= app.status_display %></span>
               </td>
               <td><%= app.submitted_at&.strftime('%b %d, %Y') || '—' %></td>
               <td class="text-nowrap">

--- a/app/views/membership_applications/show.html.erb
+++ b/app/views/membership_applications/show.html.erb
@@ -16,7 +16,7 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
   <h1 class="h3 mb-0">
     Application #<%= @application.id %>
-    <span class="badge bg-<%= @application.status_badge_color %><%= ' text-dark' if @application.under_review? %>"><%= @application.status_display %></span>
+    <span class="badge bg-<%= @application.status_badge_color %><%= ' text-dark' if @application.in_review? %>"><%= @application.status_display %></span>
   </h1>
   <div>
     <%= link_to membership_applications_path, class: "btn btn-outline-secondary" do %>
@@ -41,7 +41,7 @@
 
           <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
             <dt>Status</dt>
-            <dd class="mb-0"><span class="badge bg-<%= @application.status_badge_color %><%= ' text-dark' if @application.under_review? %>"><%= @application.status_display %></span></dd>
+            <dd class="mb-0"><span class="badge bg-<%= @application.status_badge_color %><%= ' text-dark' if @application.in_review? %>"><%= @application.status_display %></span></dd>
           </div>
 
           <div class="rounded border border-secondary-subtle bg-body-tertiary p-3 mb-2">
@@ -147,7 +147,7 @@
   </div>
 <% end %>
 
-<% unless @application.draft? %>
+<% unless @application.draft? || @application.needs_review? %>
   <%= render 'acceptance_votes_card', application: @application, current_acceptance_vote: @current_acceptance_vote %>
 <% end %>
 
@@ -186,11 +186,23 @@
                 <i class="bi bi-hourglass-split me-1"></i> Delay for review
               </button>
             <% end %>
+            <%= form_with url: mark_needs_review_membership_application_path(@application), method: :post, local: true do %>
+              <input type="hidden" name="admin_notes" id="needs_review_admin_notes" value="">
+              <button type="submit" class="btn btn-outline-secondary review-btn"
+                      data-turbo-confirm="Park this application as needs review? It will not trigger reminders or acceptance votes.">
+                <i class="bi bi-pause-circle me-1"></i> Needs review
+              </button>
+            <% end %>
           <% end %>
         </div>
+        <% if @application.needs_review? %>
+          <p class="text-muted small mb-0 mt-3">
+            Parked as needs review. This application will not appear in stale reminders or acceptance votes until you approve or reject it.
+          </p>
+        <% end %>
       <% else %>
         <p class="text-muted mb-0">
-          Only members trained as <strong>Executive Director</strong> may approve, reject, or delay applications.
+          Only members trained as <strong>Executive Director</strong> may approve, reject, or park applications.
           Use admin acceptance votes above to record your recommendation.
         </p>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -442,6 +442,7 @@ Rails.application.routes.draw do
       post :approve
       post :reject
       post :delay_for_review
+      post :mark_needs_review
       post :link_user
       post :unlink_user
       post :vote_ai_feedback

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -380,6 +380,69 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/open applications/i, flash[:alert].to_s)
   end
 
+  test 'mark_needs_review blocked when executive director topic exists and admin lacks training' do
+    TrainingTopic.create!(name: 'Executive Director')
+    app = MembershipApplication.create!(
+      email: 'needs-review-gate@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    assert_no_changes -> { app.reload.status } do
+      post mark_needs_review_membership_application_path(app), params: { admin_notes: 'Later' }
+    end
+    assert_redirected_to membership_application_path(app)
+    assert_match(/Executive Director/i, flash[:alert].to_s)
+  end
+
+  test 'mark_needs_review sets needs_review when executive director' do
+    topic = TrainingTopic.create!(name: 'Executive Director')
+    admin = User.find(session[:user_id])
+    Training.create!(trainee: admin, training_topic: topic, trained_at: Time.current)
+    app = MembershipApplication.create!(
+      email: 'needs-review-ok@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+
+    assert_difference -> { Journal.where(action: 'application_marked_needs_review').count }, 1 do
+      post mark_needs_review_membership_application_path(app), params: { admin_notes: 'Parked' }
+    end
+    assert_redirected_to membership_application_path(app)
+    assert_match(/needs review/i, flash[:notice].to_s)
+    assert_equal 'needs_review', app.reload.status
+    assert_equal 'Parked', app.admin_notes
+  end
+
+  test 'mark_needs_review redirects when application already parked' do
+    topic = TrainingTopic.create!(name: 'Executive Director')
+    admin = User.find(session[:user_id])
+    Training.create!(trainee: admin, training_topic: topic, trained_at: Time.current)
+    app = MembershipApplication.create!(
+      email: 'needs-review-twice@example.com',
+      status: 'needs_review',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+
+    post mark_needs_review_membership_application_path(app), params: { admin_notes: 'x' }
+    assert_redirected_to membership_application_path(app)
+    assert_match(/open applications/i, flash[:alert].to_s)
+  end
+
+  test 'under review tab includes needs_review applications' do
+    app = MembershipApplication.create!(
+      email: 'needs-review-index@example.com',
+      status: 'needs_review',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+
+    get membership_applications_path(status: 'under_review')
+    assert_response :success
+    assert_includes response.body, app.email
+    assert_includes response.body, 'Needs review'
+  end
+
   test 'reject redirects to edit queued mail when executive director' do
     topic = TrainingTopic.create!(name: 'Executive Director')
     admin = User.find(session[:user_id])

--- a/test/models/membership_application_test.rb
+++ b/test/models/membership_application_test.rb
@@ -53,6 +53,57 @@ class MembershipApplicationTest < ActiveSupport::TestCase
     end
   end
 
+  test 'mark_needs_review! moves open application to needs_review and journals' do
+    app = MembershipApplication.create!(email: 'needs-review@example.com', status: 'submitted')
+    admin = users(:one)
+
+    assert_difference -> { Journal.where(action: 'application_marked_needs_review').count }, 1 do
+      app.mark_needs_review!(admin, notes: 'Not now')
+    end
+
+    app.reload
+    assert_equal 'needs_review', app.status
+    assert_equal admin, app.reviewed_by
+    assert app.reviewed_at.present?
+    assert_equal 'Not now', app.admin_notes
+    assert_not app.acceptance_vote_open?
+  end
+
+  test 'mark_needs_review! raises when not open' do
+    app = MembershipApplication.create!(email: 'needs-review-bad@example.com', status: 'approved',
+                                        submitted_at: Time.current, reviewed_at: Time.current)
+
+    assert_raises(ArgumentError) do
+      app.mark_needs_review!(users(:one))
+    end
+  end
+
+  test 'stale_pending excludes needs_review applications' do
+    travel_to Time.zone.local(2026, 5, 28, 12, 0, 0) do
+      parked = MembershipApplication.create!(
+        email: 'parked-needs-review@example.com',
+        status: 'needs_review',
+        submitted_at: 8.days.ago,
+        created_at: 8.days.ago,
+        reviewed_at: Time.current
+      )
+
+      ids = MembershipApplication.stale_pending.pluck(:id)
+      assert_not_includes ids, parked.id
+    end
+  end
+
+  test 'under_review_apps includes needs_review status' do
+    parked = MembershipApplication.create!(
+      email: 'in-review-tab@example.com',
+      status: 'needs_review',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+
+    assert_includes MembershipApplication.under_review_apps.pluck(:id), parked.id
+  end
+
   test 'reject! creates pending queued rejection mail' do
     app = MembershipApplication.create!(email: 'reject-mail-test@example.com', status: 'submitted')
     admin = users(:one)

--- a/test/services/membership_applications/notify_directors_of_stale_applications_test.rb
+++ b/test/services/membership_applications/notify_directors_of_stale_applications_test.rb
@@ -159,6 +159,26 @@ module MembershipApplications
       assert_nil application.reload.application_nag_sent_at
     end
 
+    test 'does not email applications parked as needs review' do
+      now = Time.zone.local(2026, 5, 1, 9, 0, 0)
+      train_staff(users(:one), MembershipApplication::EXECUTIVE_DIRECTOR_TRAINING_TOPIC_NAME)
+      application = stale_application(
+        now: now,
+        email: 'parked-needs-review@example.com',
+        status: 'needs_review'
+      )
+
+      travel_to now do
+        assert_no_difference 'ActionMailer::Base.deliveries.size' do
+          perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+            NotifyDirectorsOfStaleApplications.call(now: now)
+          end
+        end
+      end
+
+      assert_nil application.reload.application_nag_sent_at
+    end
+
     private
 
     def stale_application(now:, email:, status: 'submitted', application_nag_sent_at: nil)


### PR DESCRIPTION
## Summary
- Adds a **Needs review** action for Executive Directors to park open applications indefinitely
- Parked applications appear in the Under Review tab but are excluded from stale staff nags and acceptance votes
- ED can still approve or reject a parked application when ready

## Test plan
- [x] Model, controller, and nag service tests pass (`docker compose -f docker-compose.test.yml run --rm test`)
- [ ] As ED, mark an open application **Needs review** and confirm it moves to the Under Review tab with the correct badge
- [ ] Confirm parked applications do not appear in dashboard stale counts or trigger staff nag emails
- [ ] Confirm acceptance votes are hidden and ED can still approve/reject

Made with [Cursor](https://cursor.com)