### PR TITLE
Increase font sizes on parking permit and ticket PDFs

### DIFF
--- a/app/services/parking_notice_pdf.rb
+++ b/app/services/parking_notice_pdf.rb
@@ -38,7 +38,7 @@ class ParkingNoticePdf
     move_down 10
     stroke_horizontal_rule
     move_down 10
-    text "Notice ##{@notice.id}", size: 10, color: '666666', align: :center
+    text "Notice ##{@notice.id}", size: 12, color: '666666', align: :center
   end
 
   def metadata_section
@@ -60,6 +60,7 @@ class ParkingNoticePdf
     table(data, column_widths: [100, 412]) do |t|
       t.cells.borders = []
       t.cells.padding = [4, 8]
+      t.cells.size = 14
       t.column(0).font_style = :bold
       t.column(0).text_color = '444444'
     end
@@ -68,7 +69,7 @@ class ParkingNoticePdf
   def description_section
     section_header('Description')
     move_down 8
-    text @notice.description, size: 11, leading: 4
+    text @notice.description, size: 14, leading: 4
   end
 
   def notes_section
@@ -77,11 +78,11 @@ class ParkingNoticePdf
 
     bounding_box([0, cursor], width: bounds.width) do
       fill_color 'FFF8E1'
-      fill_rectangle([0, cursor], bounds.width, height_of(@notice.notes, size: 11) + 20)
+      fill_rectangle([0, cursor], bounds.width, height_of(@notice.notes, size: 14) + 20)
       fill_color '000000'
       move_down 10
       indent(10) do
-        text @notice.notes, size: 11, leading: 4
+        text @notice.notes, size: 14, leading: 4
       end
     end
     move_down 10
@@ -130,7 +131,7 @@ class ParkingNoticePdf
   end
 
   def section_header(title)
-    text title, size: 14, style: :bold
+    text title, size: 16, style: :bold
     stroke_horizontal_rule
   end
 
@@ -141,7 +142,7 @@ class ParkingNoticePdf
       bounding_box([0, 30], width: bounds.width, height: 30) do
         stroke_horizontal_rule
         move_down 5
-        font_size 8 do
+        font_size 10 do
           text_box "#{org} — Generated: #{Time.current.strftime('%B %d, %Y at %I:%M %p')}",
                    at: [0, cursor],
                    width: bounds.width / 2,

--- a/app/services/parking_notice_receipt_pdf.rb
+++ b/app/services/parking_notice_receipt_pdf.rb
@@ -92,16 +92,16 @@ class ParkingNoticeReceiptPdf
     @theme ||= if thermal?
                  s = thermal_font_scale
                  {
-                   org: (8 * s).round, title: (18 * s).round, subhead: (10 * s).round,
-                   section: (8 * s).round, body: (9 * s).round,
-                   field: (8 * s).round,
-                   header_gap: 4, block_gap: 2, sep_pad: 4
+                   org: (11 * s).round, title: (18 * s).round, subhead: (10 * s).round,
+                   section: (11 * s).round, body: (12 * s).round,
+                   field: (11 * s).round,
+                   header_gap: 4, block_gap: 3, sep_pad: 4
                  }
                else
                  {
-                   org: 16, title: 48, subhead: 24, section: 14, body: 17,
-                   field: 17,
-                   header_gap: 14, block_gap: 6, sep_pad: 12
+                   org: 20, title: 48, subhead: 24, section: 18, body: 21,
+                   field: 21,
+                   header_gap: 14, block_gap: 8, sep_pad: 12
                  }
                end
   end


### PR DESCRIPTION
## Summary
- Bump smaller text in thermal and full-page receipt PDFs (metadata, description, location fields)
- Increase body and metadata font sizes in the downloadable parking notice PDF

## Test plan
- [ ] Re-print a parking permit on the thermal printer and confirm metadata/description text is legible
- [ ] Print a parking ticket on full-page layout and confirm readability
- [ ] Download a parking notice PDF and verify metadata and description sections are larger


Made with [Cursor](https://cursor.com)