### PR TITLE
Retry pending application AI feedback every 30 minutes

### DIFF
--- a/app/jobs/membership_application_ai_feedback_retry_job.rb
+++ b/app/jobs/membership_application_ai_feedback_retry_job.rb
@@ -1,0 +1,9 @@
+class MembershipApplicationAiFeedbackRetryJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    MembershipApplication.ai_feedback_unprocessed.order(:id).find_each do |application|
+      MembershipApplications::ProcessAiFeedback.call(application: application)
+    end
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -102,6 +102,14 @@ Sidekiq.configure_server do |config|
     active_job: true
   )
 
+  # Membership Application AI Feedback Retry - Every 30 minutes
+  Sidekiq::Cron::Job.create(
+    name: 'Membership Application AI Feedback Retry - Every 30 minutes',
+    cron: '*/30 * * * *',
+    class: 'MembershipApplicationAiFeedbackRetryJob',
+    active_job: true
+  )
+
   # Message Trash Cleanup - Daily at 5am
   Sidekiq::Cron::Job.create(
     name: 'Message Trash Cleanup - Daily at 5am',

--- a/test/jobs/membership_application_ai_feedback_retry_job_test.rb
+++ b/test/jobs/membership_application_ai_feedback_retry_job_test.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+
+class MembershipApplicationAiFeedbackRetryJobTest < ActiveJob::TestCase
+  setup do
+    @profile = ai_ollama_profiles(:application_status)
+    @profile.update!(
+      enabled: true,
+      base_url: 'http://ollama.test:11434',
+      model: 'test-model',
+      prompt: 'You review applications.'
+    )
+    ai_ollama_profiles(:default).update!(base_url: '', model: '')
+  end
+
+  test 'processes submitted applications with missing AI feedback' do
+    app = MembershipApplication.create!(email: 'retry-ai@example.com', status: 'submitted', submitted_at: Time.current)
+    app.update_columns(ai_feedback_last_error: 'timeout', updated_at: Time.current)
+
+    payload = {
+      'score' => 2,
+      'score_rationale' => 'Looks good.',
+      'recommendation' => 'accept',
+      'questions' => [],
+      'garbage' => false,
+      'garbage_reason' => nil
+    }
+    stub_result = Ollama::ChatCompletion::Result.new(true, JSON.generate(payload), nil)
+
+    with_chat_completion_stub(stub_result) do
+      MembershipApplicationAiFeedbackRetryJob.perform_now
+    end
+
+    app.reload
+    assert app.ai_feedback_processed?
+    assert_equal 2, app.ai_feedback_score
+    assert_nil app.ai_feedback_last_error
+  end
+
+  test 'skips applications that already have AI feedback' do
+    app = MembershipApplication.create!(
+      email: 'already-processed@example.com',
+      status: 'submitted',
+      submitted_at: Time.current,
+      ai_feedback_processed_at: Time.current,
+      ai_feedback_score: 1,
+      ai_feedback_questions: []
+    )
+
+    called = false
+    with_chat_completion_stub(lambda { |**|
+      called = true
+      Ollama::ChatCompletion::Result.new(true, '{}', nil)
+    }) do
+      MembershipApplicationAiFeedbackRetryJob.perform_now
+    end
+
+    assert_not called
+    assert_equal 1, app.reload.ai_feedback_score
+  end
+
+  test 'skips draft applications' do
+    app = MembershipApplication.create!(email: 'draft-skip@example.com', status: 'draft')
+
+    called = false
+    with_chat_completion_stub(lambda { |**|
+      called = true
+      Ollama::ChatCompletion::Result.new(true, '{}', nil)
+    }) do
+      MembershipApplicationAiFeedbackRetryJob.perform_now
+    end
+
+    assert_not called
+    assert_nil app.reload.ai_feedback_processed_at
+  end
+
+  private
+
+  def with_chat_completion_stub(result_or_callable)
+    original_call = Ollama::ChatCompletion.method(:call)
+    replacement = result_or_callable.respond_to?(:call) ? result_or_callable : ->(**) { result_or_callable }
+    Ollama::ChatCompletion.define_singleton_method(:call) do |**kwargs|
+      replacement.call(**kwargs)
+    end
+    yield
+  ensure
+    Ollama::ChatCompletion.define_singleton_method(:call, original_call)
+  end
+end


### PR DESCRIPTION
## Summary
- Add `MembershipApplicationAiFeedbackRetryJob` to scan `ai_feedback_unprocessed` applications and run `ProcessAiFeedback` for each
- Schedule the job via sidekiq-cron every 30 minutes so applications that failed AI review at submit time are retried when Ollama comes back
- Add job tests covering retry after failure, skipping processed apps, and skipping drafts

## Test plan
- [x] `docker compose -f docker-compose.test.yml run --rm test bin/rails test test/jobs/membership_application_ai_feedback_retry_job_test.rb`
- [ ] Submit an application while Ollama is down; confirm it shows AI error
- [ ] Restore Ollama; confirm feedback appears within ~30 minutes without running the rake task


Made with [Cursor](https://cursor.com)