### PR TITLE
Add optional comments to admin acceptance votes

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -280,7 +280,7 @@ class MembershipApplicationsController < ApplicationController
   end
 
   def acceptance_vote_params
-    params.expect(acceptance_vote: [:decision])
+    params.expect(acceptance_vote: %i[decision comment])
   end
 
   def ai_feedback_vote_params

--- a/app/views/membership_applications/_acceptance_votes_card.html.erb
+++ b/app/views/membership_applications/_acceptance_votes_card.html.erb
@@ -42,6 +42,14 @@
                 <%= av.label :decision, 'Reject', value: 'reject', class: 'form-check-label' %>
               </div>
             </div>
+            <div class="mt-3">
+              <%= av.label :comment, 'Explain your vote', class: 'form-label' %>
+              <span class="text-muted small">(optional)</span>
+              <%= av.text_area :comment,
+                               class: 'form-control',
+                               rows: 3,
+                               placeholder: 'Why accept or reject this applicant?' %>
+            </div>
           </fieldset>
         <% end %>
         <%= submit_tag 'Save vote', class: 'btn btn-outline-primary mt-3' %>
@@ -56,14 +64,21 @@
       <h6 class="small text-uppercase text-muted fw-semibold mb-2">Votes</h6>
       <ul class="list-unstyled small mb-0">
         <% persisted_votes.sort_by { |v| [v.user.display_name, v.id] }.each do |v| %>
-          <li class="mb-1">
-            <%= link_to v.user.display_name, user_path(v.user), class: 'text-decoration-none' %>:
-            <% if v.decision == 'accept' %>
-              <span class="badge bg-success">Accept</span>
-            <% elsif v.decision == 'reject' %>
-              <span class="badge bg-danger">Reject</span>
+          <li class="mb-3 pb-3 border-bottom border-secondary-subtle">
+            <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
+              <%= link_to v.user.display_name, user_path(v.user), class: 'fw-semibold text-decoration-none' %>
+              <% if v.decision == 'accept' %>
+                <span class="badge bg-success">Accept</span>
+              <% elsif v.decision == 'reject' %>
+                <span class="badge bg-danger">Reject</span>
+              <% else %>
+                <span class="badge bg-secondary">—</span>
+              <% end %>
+            </div>
+            <% if v.comment.present? %>
+              <div class="text-body-secondary"><%= simple_format v.comment, class: 'mb-0' %></div>
             <% else %>
-              <span class="badge bg-secondary">—</span>
+              <p class="text-muted fst-italic mb-0">No explanation given</p>
             <% end %>
           </li>
         <% end %>

--- a/db/migrate/20260613120000_add_comment_to_membership_application_acceptance_votes.rb
+++ b/db/migrate/20260613120000_add_comment_to_membership_application_acceptance_votes.rb
@@ -1,0 +1,5 @@
+class AddCommentToMembershipApplicationAcceptanceVotes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :membership_application_acceptance_votes, :comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_13_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -503,6 +503,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_120000) do
   end
 
   create_table "membership_application_acceptance_votes", force: :cascade do |t|
+    t.text "comment"
     t.datetime "created_at", null: false
     t.string "decision", null: false
     t.bigint "membership_application_id", null: false

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -504,10 +504,36 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
       submitted_at: Time.current
     )
     post vote_acceptance_membership_application_path(app), params: {
-      acceptance_vote: { decision: 'accept' }
+      acceptance_vote: { decision: 'accept', comment: 'Strong fit for the shop' }
     }
     assert_redirected_to membership_application_path(app)
     assert_equal({ 'accept' => 1 }, app.reload.acceptance_vote_counts)
+    vote = app.acceptance_votes.sole
+    assert_equal 'Strong fit for the shop', vote.comment
+  end
+
+  test 'vote_acceptance updates existing vote and comment for same admin' do
+    sign_in_as_admin
+    admin = User.find(session[:user_id])
+    app = MembershipApplication.create!(
+      email: 'vote-accept-update@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    MembershipApplicationAcceptanceVote.create!(
+      membership_application: app,
+      user: admin,
+      decision: 'accept',
+      comment: 'First take'
+    )
+    assert_no_difference -> { app.reload.acceptance_votes.count } do
+      post vote_acceptance_membership_application_path(app), params: {
+        acceptance_vote: { decision: 'reject', comment: 'Changed after tour' }
+      }
+    end
+    vote = app.reload.acceptance_votes.sole
+    assert_equal 'reject', vote.decision
+    assert_equal 'Changed after tour', vote.comment
   end
 
   test 'vote_acceptance rejected when application finalized' do

--- a/test/models/membership_application_acceptance_vote_test.rb
+++ b/test/models/membership_application_acceptance_vote_test.rb
@@ -16,10 +16,23 @@ class MembershipApplicationAcceptanceVoteTest < ActiveSupport::TestCase
     v = MembershipApplicationAcceptanceVote.new(
       membership_application: @app,
       user: @user,
-      decision: 'accept'
+      decision: 'accept',
+      comment: 'Great energy on the tour'
     )
     assert v.valid?
     assert v.save
+    assert_equal 'Great energy on the tour', v.comment
+  end
+
+  test 'comment is optional' do
+    v = MembershipApplicationAcceptanceVote.new(
+      membership_application: @app,
+      user: @user,
+      decision: 'reject'
+    )
+    assert v.valid?
+    assert v.save
+    assert_nil v.comment
   end
 
   test 'one vote per user per application' do


### PR DESCRIPTION
## Summary
- Adds an optional `comment` field to admin acceptance votes on membership applications
- Admins can explain accept/reject votes when casting or updating their vote on the application detail page
- Vote list shows each admin's explanation (or "No explanation given" when blank)

## Test plan
- [x] Model tests for saving votes with and without comments
- [x] Controller tests for creating and updating votes with comments
- [x] Full test suite passes (`docker compose -f docker-compose.test.yml run --rm test`)
- [x] RuboCop clean (`docker compose -f docker-compose.lint.yml run --rm rubocop`)
- [ ] Manually vote on a pending application and confirm comment appears in the votes list


Made with [Cursor](https://cursor.com)