### PR TITLE
Limit self-service parking permits to 2 weeks

### DIFF
--- a/app/controllers/member_parking_permits_controller.rb
+++ b/app/controllers/member_parking_permits_controller.rb
@@ -1,4 +1,6 @@
 class MemberParkingPermitsController < AuthenticatedController
+  MAX_MEMBER_PERMIT_DURATION = 2.weeks
+
   before_action :set_owned_notice, only: %i[show edit update close request_clearance add_note]
   before_action :require_owned_permit, only: %i[edit update]
 
@@ -20,8 +22,9 @@ class MemberParkingPermitsController < AuthenticatedController
     @parking_notice.notice_type = 'permit'
     @parking_notice.issued_by = current_user
     @parking_notice.status = 'active'
+    validate_member_permit_duration
 
-    if @parking_notice.save
+    if @parking_notice.errors.empty? && @parking_notice.save
       @parking_notice.record_journal_entry!('parking_permit_issued', actor: current_user)
       redirect_to user_path(current_user, tab: :parking), notice: 'Parking permit created successfully.'
     else
@@ -31,7 +34,10 @@ class MemberParkingPermitsController < AuthenticatedController
 
   def update
     @parking_notice.event_actor = current_user
-    if @parking_notice.update(member_parking_permit_params)
+    @parking_notice.assign_attributes(member_parking_permit_params)
+    validate_member_permit_duration
+
+    if @parking_notice.errors.empty? && @parking_notice.save
       redirect_to user_path(current_user, tab: :parking), notice: 'Parking permit updated.'
     else
       render :edit, status: :unprocessable_content
@@ -110,5 +116,14 @@ class MemberParkingPermitsController < AuthenticatedController
     params.expect(
       parking_notice: %i[description location location_detail expires_at]
     )
+  end
+
+  def validate_member_permit_duration
+    return if @parking_notice.expires_at.blank?
+
+    max_expires_at = Time.current + MAX_MEMBER_PERMIT_DURATION
+    return if @parking_notice.expires_at <= max_expires_at
+
+    @parking_notice.errors.add(:expires_at, 'must be within 2 weeks')
   end
 end

--- a/app/views/member_parking_permits/_expiration_quick_buttons.html.erb
+++ b/app/views/member_parking_permits/_expiration_quick_buttons.html.erb
@@ -1,0 +1,6 @@
+<div class="d-flex flex-wrap gap-2 mb-2">
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="1">1 day</button>
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="3">3 days</button>
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="7">1 week</button>
+  <button type="button" class="btn btn-sm btn-outline-secondary quick-expire" data-days="14">2 weeks</button>
+</div>

--- a/app/views/member_parking_permits/_form.html.erb
+++ b/app/views/member_parking_permits/_form.html.erb
@@ -28,12 +28,15 @@
     </div>
   </div>
 
+  <% max_expires_at = MemberParkingPermitsController::MAX_MEMBER_PERMIT_DURATION.from_now %>
   <div class="mt-3 mb-4">
     <%= f.label :expires_at, 'Expiration', class: 'form-label' %>
-    <%= render 'parking_notices/expiration_quick_buttons' %>
+    <div class="text-12 text-secondary mb-2">Self-service permits cannot exceed 2 weeks.</div>
+    <%= render 'expiration_quick_buttons' %>
     <%= f.datetime_local_field :expires_at,
                                class: 'form-control',
                                required: true,
+                               max: max_expires_at.strftime('%Y-%m-%dT%H:%M'),
                                value: parking_notice.expires_at&.strftime('%Y-%m-%dT%H:%M') %>
   </div>
 

--- a/test/controllers/member_parking_permits_controller_test.rb
+++ b/test/controllers/member_parking_permits_controller_test.rb
@@ -42,6 +42,57 @@ class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to user_path(member, tab: :parking)
   end
 
+  test 'member can create permit expiring in exactly 2 weeks' do
+    sign_in_as_member
+
+    assert_difference 'ParkingNotice.count', 1 do
+      post member_parking_permits_path, params: {
+        parking_notice: {
+          description: 'Two week project',
+          location: 'Woodshop',
+          expires_at: 2.weeks.from_now.strftime('%Y-%m-%dT%H:%M')
+        }
+      }
+    end
+
+    assert_redirected_to user_path(current_member, tab: :parking)
+  end
+
+  test 'member cannot create permit longer than 2 weeks' do
+    sign_in_as_member
+
+    assert_no_difference 'ParkingNotice.count' do
+      post member_parking_permits_path, params: {
+        parking_notice: {
+          description: 'Long project',
+          location: 'Woodshop',
+          expires_at: 3.weeks.from_now.strftime('%Y-%m-%dT%H:%M')
+        }
+      }
+    end
+
+    assert_response :unprocessable_content
+    assert_match(/must be within 2 weeks/i, response.body)
+  end
+
+  test 'member cannot extend permit beyond 2 weeks' do
+    sign_in_as_member
+    permit = member_permit
+
+    assert_no_changes -> { permit.reload.expires_at } do
+      patch member_parking_permit_path(permit), params: {
+        parking_notice: {
+          description: permit.description,
+          location: permit.location,
+          expires_at: 1.month.from_now.strftime('%Y-%m-%dT%H:%M')
+        }
+      }
+    end
+
+    assert_response :unprocessable_content
+    assert_match(/must be within 2 weeks/i, response.body)
+  end
+
   test 'anonymous user cannot access member permit form' do
     get new_member_parking_permit_path
     assert_redirected_to login_path
@@ -298,13 +349,11 @@ class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def assert_expiration_quick_buttons
-    assert_select '.quick-expire', 7
+    assert_select '.quick-expire', 4
     assert_select '.quick-expire[data-days="1"]', text: '1 day'
     assert_select '.quick-expire[data-days="3"]', text: '3 days'
     assert_select '.quick-expire[data-days="7"]', text: '1 week'
     assert_select '.quick-expire[data-days="14"]', text: '2 weeks'
-    assert_select '.quick-expire[data-days="30"]', text: '30 days'
-    assert_select '.quick-expire[data-days="180"]', text: '180 days'
-    assert_select '.quick-expire[data-years="1"]', text: '1 year'
+    assert_select 'input[name="parking_notice[expires_at]"][max]'
   end
 end


### PR DESCRIPTION
## Summary
- Enforce a 2-week maximum expiration on member-created parking permits in `MemberParkingPermitsController` (create and update).
- Limit the member permit form to quick-expiration options through 2 weeks and set a `max` on the datetime field with helper text.
- Add controller tests for the boundary and rejection cases.

## Test plan
- [x] `docker compose -f docker-compose.test.yml run --rm test bin/rails test test/controllers/member_parking_permits_controller_test.rb`
- [x] RuboCop on changed Ruby files
- [ ] Create a permit as a member and confirm only 1 day–2 week quick buttons appear
- [ ] Confirm submitting a date beyond 2 weeks shows a validation error
- [ ] Confirm admin parking notice forms still allow longer durations


Made with [Cursor](https://cursor.com)