### PR TITLE
Normalize access controller user text to ASCII

### DIFF
--- a/app/jobs/access_controller_verb_job.rb
+++ b/app/jobs/access_controller_verb_job.rb
@@ -88,12 +88,20 @@ class AccessControllerVerbJob < ApplicationJob
       user = User.find_by(id: user_id)
       if user
         env['MM_USER_ID'] = user.id.to_s
-        env['MM_USER_NAME'] = user.full_name.presence || user.display_name
+        if (name = normalize_user_text(user.full_name.presence || user.display_name))
+          env['MM_USER_NAME'] = name
+        end
         env['MM_USER_EMAIL'] = user.email if user.email.present?
-        env['MM_USER_USERNAME'] = user.username if user.username.present?
+        if (username = normalize_user_text(user.username))
+          env['MM_USER_USERNAME'] = username
+        end
       end
     end
 
     env
+  end
+
+  def normalize_user_text(value)
+    AccessControllerTextNormalizer.call(value).presence
   end
 end

--- a/app/services/access_controller_payload_builder.rb
+++ b/app/services/access_controller_payload_builder.rb
@@ -43,11 +43,15 @@ class AccessControllerPayloadBuilder
 
   def user_entry(user)
     {
-      name: user.full_name.presence || user.display_name,
+      name: normalize_text(user.full_name.presence || user.display_name),
       uid: user.authentik_id.presence || user.id,
-      greeting_name: user.greeting_name,
+      greeting_name: normalize_text(user.greeting_name),
       rfids: user.rfids.map(&:rfid),
-      permissions: user.trainings_as_trainee.map { |t| t.training_topic&.name }.compact.uniq
+      permissions: user.trainings_as_trainee.filter_map { |t| normalize_text(t.training_topic&.name) }.uniq
     }
+  end
+
+  def normalize_text(value)
+    AccessControllerTextNormalizer.call(value).presence
   end
 end

--- a/app/services/access_controller_text_normalizer.rb
+++ b/app/services/access_controller_text_normalizer.rb
@@ -1,0 +1,17 @@
+# Converts user-facing strings to ASCII for access controller scripts and env vars.
+# Non-ASCII characters are transliterated when possible; anything else is dropped.
+class AccessControllerTextNormalizer
+  def self.call(value)
+    new(value).call
+  end
+
+  def initialize(value)
+    @value = value
+  end
+
+  def call
+    return nil if @value.nil?
+
+    ActiveSupport::Inflector.transliterate(@value.to_s, '').strip
+  end
+end

--- a/test/jobs/access_controller_verb_job_test.rb
+++ b/test/jobs/access_controller_verb_job_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class AccessControllerVerbJobTest < ActiveSupport::TestCase
+  setup do
+    @access_controller = AccessController.create!(
+      name: 'Laser 1',
+      hostname: 'laser1.local',
+      access_controller_type: access_controller_types(:laser_controller)
+    )
+    @user = users(:one)
+  end
+
+  test 'build_env converts user name and username to ASCII' do
+    @user.update!(full_name: 'José García', username: 'josé')
+
+    env = AccessControllerVerbJob.new.send(:build_env, @access_controller, @user.id)
+
+    assert_equal 'Jose Garcia', env['MM_USER_NAME']
+    assert_equal 'jose', env['MM_USER_USERNAME']
+  end
+
+  test 'build_env omits username when it cannot be represented in ASCII' do
+    @user.update!(username: '用户')
+
+    env = AccessControllerVerbJob.new.send(:build_env, @access_controller, @user.id)
+
+    assert_not env.key?('MM_USER_USERNAME')
+  end
+end

--- a/test/services/access_controller_payload_builder_test.rb
+++ b/test/services/access_controller_payload_builder_test.rb
@@ -143,6 +143,32 @@ class AccessControllerPayloadBuilderTest < ActiveSupport::TestCase
     assert_includes user_entry['permissions'], 'Woodworking'
   end
 
+  test 'payload converts user names to ASCII' do
+    ensure_user_one_in_payload!
+    @user_one.update!(full_name: 'José García', username: 'josé', greeting_name: 'José',
+                      use_full_name_for_greeting: false, use_username_for_greeting: false)
+    Training.create!(trainee: @user_one, training_topic: @laser_topic, trained_at: 1.day.ago)
+
+    payload = parse_payload
+    user_entry = payload.find { |u| u['uid'] == @user_one.authentik_id }
+
+    assert user_entry, 'Expected user_one in payload'
+    assert_equal 'Jose Garcia', user_entry['name']
+    assert_equal 'Jose', user_entry['greeting_name']
+  end
+
+  test 'payload omits greeting_name when it cannot be represented in ASCII' do
+    ensure_user_one_in_payload!
+    @user_one.update!(full_name: 'Example User One', greeting_name: '用户', use_full_name_for_greeting: false,
+                      use_username_for_greeting: false)
+
+    payload = parse_payload
+    user_entry = payload.find { |u| u['uid'] == @user_one.authentik_id }
+
+    assert user_entry, 'Expected user_one in payload'
+    assert_nil user_entry['greeting_name']
+  end
+
   # --- Model method tests ---
 
   test 'user_meets_training_requirements? returns true when no topics required' do
@@ -159,6 +185,19 @@ class AccessControllerPayloadBuilderTest < ActiveSupport::TestCase
   end
 
   private
+
+  def ensure_user_one_in_payload!
+    DefaultSetting.instance.update!(sync_inactive_members: false)
+    @user_one.update_columns(
+      active: true,
+      key_access_paused: false,
+      membership_status: 'paying',
+      dues_status: 'current'
+    )
+    return if @user_one.rfids.exists?
+
+    @user_one.rfids.create!(rfid: 'RFID001')
+  end
 
   def parse_payload(access_controller_type: nil)
     json = AccessControllerPayloadBuilder.call(access_controller_type: access_controller_type)

--- a/test/services/access_controller_text_normalizer_test.rb
+++ b/test/services/access_controller_text_normalizer_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class AccessControllerTextNormalizerTest < ActiveSupport::TestCase
+  test 'returns nil for nil input' do
+    assert_nil AccessControllerTextNormalizer.call(nil)
+  end
+
+  test 'passes through plain ASCII text' do
+    assert_equal 'exampleuser', AccessControllerTextNormalizer.call('exampleuser')
+    assert_equal 'Laser Cutting', AccessControllerTextNormalizer.call('Laser Cutting')
+  end
+
+  test 'transliterates accented characters to ASCII' do
+    assert_equal 'Jose', AccessControllerTextNormalizer.call('José')
+    assert_equal 'Muller', AccessControllerTextNormalizer.call('Müller')
+  end
+
+  test 'drops characters that cannot be represented in ASCII' do
+    assert_equal '', AccessControllerTextNormalizer.call('用户')
+    assert_equal 'hello', AccessControllerTextNormalizer.call('hello用户')
+    assert_equal 'cafe', AccessControllerTextNormalizer.call('café ☕')
+  end
+end


### PR DESCRIPTION
## Summary
- Add `AccessControllerTextNormalizer` to transliterate user-facing strings to ASCII and drop non-representable characters
- Apply normalization to sync payload fields (`name`, `greeting_name`, `permissions`) and verb job env vars (`MM_USER_NAME`, `MM_USER_USERNAME`)
- Add unit and integration tests covering accented names, dropped Unicode, and env var behavior

## Test plan
- [x] `docker compose -f docker-compose.test.yml run --rm test bin/rails test test/services/access_controller_text_normalizer_test.rb test/services/access_controller_payload_builder_test.rb test/jobs/access_controller_verb_job_test.rb`
- [x] RuboCop on changed files


Made with [Cursor](https://cursor.com)