### PR TITLE
Add re-send action for initiated membership applications

### DIFF
--- a/app/controllers/application_verifications_controller.rb
+++ b/app/controllers/application_verifications_controller.rb
@@ -97,14 +97,7 @@ class ApplicationVerificationsController < ApplicationController
     )
   end
 
-  def deliver_verification_mailer(email, verification)
-    verification_url = apply_verify_email_url(token: verification.token)
-    expiry_hours = MembershipSetting.application_verification_expiry_hours
-
-    MemberMailer.application_email_verification(
-      email,
-      verification_url: verification_url,
-      expires_in: "#{expiry_hours} #{'hour'.pluralize(expiry_hours)}"
-    ).deliver_later
+  def deliver_verification_mailer(_email, verification)
+    verification.deliver_verification_email!
   end
 end

--- a/app/controllers/concerns/initiated_application_actions.rb
+++ b/app/controllers/concerns/initiated_application_actions.rb
@@ -1,0 +1,41 @@
+module InitiatedApplicationActions
+  extend ActiveSupport::Concern
+
+  def extend_initiated_application
+    verification = ApplicationVerification.find(params[:id])
+    duration = initiated_application_extension_duration
+
+    if duration.nil?
+      redirect_to_initiated_applications alert: 'Choose one day or one week.'
+      return
+    end
+
+    verification.extend_expiration_by!(duration)
+    redirect_to_initiated_applications notice: "Extended #{verification.email}'s verification link."
+  end
+
+  def resend_initiated_application
+    verification = ApplicationVerification.find(params[:id])
+
+    if verification.verified?
+      redirect_to_initiated_applications alert: 'This application is already open; no confirmation email is needed.'
+      return
+    end
+
+    verification.deliver_verification_email!
+    redirect_to_initiated_applications notice: "Re-sent the confirmation link to #{verification.email}."
+  end
+
+  private
+
+  def redirect_to_initiated_applications(flash)
+    redirect_to membership_applications_path(status: 'initiated'), flash
+  end
+
+  def initiated_application_extension_duration
+    case params[:duration]
+    when 'day' then 1.day
+    when 'week' then 1.week
+    end
+  end
+end

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -4,10 +4,11 @@ class MembershipApplicationsController < ApplicationController
   include Pagy::Method
   include MembershipApplicationWizard
   include MembershipApplicationWizard::Actions
+  include InitiatedApplicationActions
 
   ADMIN_ACTIONS = %i[
     index show import approve reject delay_for_review mark_needs_review link_user unlink_user vote_ai_feedback
-    save_tour_feedback vote_acceptance extend_initiated_application
+    save_tour_feedback vote_acceptance extend_initiated_application resend_initiated_application
   ].freeze
   APPLICATION_MEMBER_ACTIONS = %i[
     show approve reject delay_for_review mark_needs_review link_user unlink_user vote_ai_feedback
@@ -69,20 +70,6 @@ class MembershipApplicationsController < ApplicationController
     @applicant_name_question_id = name_q_scope.where(application_form_pages: { position: 1 }, label: 'Name').pick(:id)
 
     @users_for_application_link = User.non_service_accounts.ordered_by_display_name.to_a
-  end
-
-  def extend_initiated_application
-    verification = ApplicationVerification.find(params[:id])
-    duration = initiated_application_extension_duration
-
-    if duration.nil?
-      redirect_to membership_applications_path(status: 'initiated'), alert: 'Choose one day or one week.'
-      return
-    end
-
-    verification.extend_expiration_by!(duration)
-    redirect_to membership_applications_path(status: 'initiated'),
-                notice: "Extended #{verification.email}'s verification link."
   end
 
   def show
@@ -240,13 +227,6 @@ class MembershipApplicationsController < ApplicationController
                                        .where('LOWER(delivery_to) IN (?)', emails.presence || [''])
                                        .newest_first
                                        .group_by { |entry| entry.delivery_to.downcase }
-  end
-
-  def initiated_application_extension_duration
-    case params[:duration]
-    when 'day' then 1.day
-    when 'week' then 1.week
-    end
   end
 
   def review_parking!(method, notice)

--- a/app/models/application_verification.rb
+++ b/app/models/application_verification.rb
@@ -33,6 +33,21 @@ class ApplicationVerification < ApplicationRecord
     update!(expires_at: [expires_at, Time.current].max + duration)
   end
 
+  def deliver_verification_email!
+    url_options = Rails.application.config.action_mailer.default_url_options
+    verification_url = Rails.application.routes.url_helpers.apply_verify_email_url(
+      token: token,
+      **url_options
+    )
+    expiry_hours = MembershipSetting.application_verification_expiry_hours
+
+    MemberMailer.application_email_verification(
+      email,
+      verification_url: verification_url,
+      expires_in: "#{expiry_hours} #{'hour'.pluralize(expiry_hours)}"
+    ).deliver_later
+  end
+
   def status_display
     return 'Expired' if expired?
     return 'Verified' if email_verified?

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -170,16 +170,23 @@
                   <% end %>
                 </td>
                 <td class="text-end text-nowrap">
-                  <%= button_to "+1 day",
-                      extend_initiated_membership_applications_path(verification, duration: 'day'),
-                      method: :post,
-                      class: "btn btn-sm btn-outline-secondary",
-                      form: { class: 'd-inline-block' } %>
-                  <%= button_to "+1 week",
-                      extend_initiated_membership_applications_path(verification, duration: 'week'),
-                      method: :post,
-                      class: "btn btn-sm btn-outline-secondary",
-                      form: { class: 'd-inline-block' } %>
+                  <% unless verification.verified? %>
+                    <%= button_to "Re-send",
+                        resend_initiated_membership_applications_path(verification),
+                        method: :post,
+                        class: "btn btn-sm btn-outline-secondary",
+                        form: { class: 'd-inline-block' } %>
+                    <%= button_to "+1 day",
+                        extend_initiated_membership_applications_path(verification, duration: 'day'),
+                        method: :post,
+                        class: "btn btn-sm btn-outline-secondary",
+                        form: { class: 'd-inline-block' } %>
+                    <%= button_to "+1 week",
+                        extend_initiated_membership_applications_path(verification, duration: 'week'),
+                        method: :post,
+                        class: "btn btn-sm btn-outline-secondary",
+                        form: { class: 'd-inline-block' } %>
+                  <% end %>
                 </td>
               </tr>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -437,6 +437,8 @@ Rails.application.routes.draw do
       post :import
       post 'initiated/:id/extend/:duration', to: 'membership_applications#extend_initiated_application',
                                              as: :extend_initiated
+      post 'initiated/:id/resend', to: 'membership_applications#resend_initiated_application',
+                                   as: :resend_initiated
     end
     member do
       post :approve

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -2,8 +2,11 @@
 
 # Also see MembershipApplicationTest for admin_search scope tests and index?q tests below.
 require 'test_helper'
+require 'active_job/test_helper'
 
 class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   setup do
     @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
     Rails.application.config.x.local_auth.enabled = true
@@ -613,6 +616,42 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to membership_applications_path(status: 'initiated')
     assert_in_delta original_expiry + 1.week, verification.reload.expires_at, 1.second
+  end
+
+  test 'resend initiated application confirmation link' do
+    verification = ApplicationVerification.create!(email: 'resend@example.com')
+
+    assert_enqueued_emails 1 do
+      post resend_initiated_membership_applications_path(verification)
+    end
+
+    assert_redirected_to membership_applications_path(status: 'initiated')
+    assert_match 'Re-sent the confirmation link', flash[:notice]
+  end
+
+  test 'resend initiated application rejects verified open applications' do
+    verification = ApplicationVerification.create!(email: 'open@example.com')
+    verification.verify_email!
+
+    assert_no_enqueued_emails do
+      post resend_initiated_membership_applications_path(verification)
+    end
+
+    assert_redirected_to membership_applications_path(status: 'initiated')
+    assert_match 'already open', flash[:alert]
+  end
+
+  test 'index initiated tab hides actions for verified open applications' do
+    ApplicationVerification.create!(email: 'pending@example.com')
+    open_verification = ApplicationVerification.create!(email: 'open@example.com')
+    open_verification.verify_email!
+
+    get membership_applications_path(status: 'initiated')
+
+    assert_response :success
+    pending_verification = ApplicationVerification.find_by!(email: 'pending@example.com')
+    assert_select 'form[action=?]', resend_initiated_membership_applications_path(pending_verification)
+    assert_select 'form[action=?]', resend_initiated_membership_applications_path(open_verification), count: 0
   end
 
   private


### PR DESCRIPTION
## Summary
- Adds a **Re-send** button on Applications → Initiated to resend the email confirmation link
- Hides all action buttons (Re-send, +1 day, +1 week) once the applicant has verified their email and the application is open
- Extracts verification email delivery to `ApplicationVerification#deliver_verification_email!` for reuse by apply flow and admin re-send
- Removes **Link member** from Open and Under Review lists (and detail pages) since applicants in those stages have no member account yet; linking remains available for approved/rejected applications

## Test plan
- [x] Full test suite passes (1288 tests)
- [x] RuboCop clean
- [ ] On Initiated tab, pending verification shows Re-send / extend buttons
- [ ] Verified (open) row shows no action buttons
- [ ] Re-send enqueues confirmation email and shows success notice
- [ ] Open and Under Review tabs show no Link member buttons
- [ ] Unlinked tab still offers Link member for approved applications