### PR TITLE
Hide member linking for open and under-review applications.

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -66,15 +66,12 @@ class MembershipApplicationsController < ApplicationController
 
     @pagy, @applications = pagy(@applications, limit: 25)
 
-    name_q_scope = ApplicationFormQuestion.joins(:application_form_page)
-    @applicant_name_question_id = name_q_scope.where(application_form_pages: { position: 1 }, label: 'Name').pick(:id)
-
-    @users_for_application_link = User.non_service_accounts.ordered_by_display_name.to_a
+    load_applications_index_metadata
   end
 
   def show
     @pages_with_answers = @application.answers_by_page
-    @users_for_application_link = User.non_service_accounts.ordered_by_display_name.to_a
+    @users_for_application_link = linkable_users_for_show
     vote = @application.ai_feedback_votes.detect { |v| v.user_id == current_user.id }
     @current_ai_feedback_vote = vote || @application.ai_feedback_votes.build(user: current_user)
     tf = @application.tour_feedbacks.detect { |f| f.user_id == current_user.id }
@@ -88,6 +85,12 @@ class MembershipApplicationsController < ApplicationController
   end
 
   def link_user
+    unless @application.linkable_to_member?
+      redirect_to membership_application_path(@application),
+                  alert: 'Open and under-review applications cannot be linked to member accounts.'
+      return
+    end
+
     user = User.non_service_accounts.find(params[:user_id])
     @application.update!(user: user)
     redirect_to membership_application_path(@application),
@@ -227,6 +230,24 @@ class MembershipApplicationsController < ApplicationController
                                        .where('LOWER(delivery_to) IN (?)', emails.presence || [''])
                                        .newest_first
                                        .group_by { |entry| entry.delivery_to.downcase }
+  end
+
+  def load_applications_index_metadata
+    name_q_scope = ApplicationFormQuestion.joins(:application_form_page)
+    @applicant_name_question_id = name_q_scope.where(application_form_pages: { position: 1 }, label: 'Name').pick(:id)
+    @users_for_application_link = linkable_users_for_index
+  end
+
+  def linkable_users_for_index
+    return [] if %w[submitted under_review].include?(@current_status)
+
+    User.non_service_accounts.ordered_by_display_name.to_a
+  end
+
+  def linkable_users_for_show
+    return [] unless @application.linkable_to_member?
+
+    User.non_service_accounts.ordered_by_display_name.to_a
   end
 
   def review_parking!(method, notice)

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -130,6 +130,10 @@ class MembershipApplication < ApplicationRecord
     submitted? || in_review?
   end
 
+  def linkable_to_member?
+    user.nil? && !pending?
+  end
+
   def submit!
     update!(status: 'submitted', submitted_at: Time.current)
     Journal.record_application_event!(application: self, action: 'application_submitted')

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -205,6 +205,7 @@
     </div>
   <% end %>
 <% elsif @applications.any? %>
+  <% show_link_actions = @applications.any?(&:linkable_to_member?) %>
   <div class="card shadow-sm border-0">
     <div class="table-responsive">
       <table class="table table-hover mb-0">
@@ -217,7 +218,9 @@
             <th>Admin votes</th>
             <th>Reviewed by</th>
             <th>Linked member</th>
-            <th class="text-end">Actions</th>
+            <% if show_link_actions %>
+              <th class="text-end">Actions</th>
+            <% end %>
           </tr>
         </thead>
         <tbody>
@@ -266,16 +269,18 @@
                   <span class="text-muted">—</span>
                 <% end %>
               </td>
-              <td class="text-end text-nowrap">
-                <% if app.user.nil? %>
-                  <button type="button" class="btn btn-sm btn-primary"
-                          data-bs-toggle="modal" data-bs-target="#maLinkMemberModal"
-                          data-ma-link-action="<%= link_user_membership_application_path(app) %>"
-                          data-application-email="<%= h(app.email) %>">
-                    Link member
-                  </button>
-                <% end %>
-              </td>
+              <% if show_link_actions %>
+                <td class="text-end text-nowrap">
+                  <% if app.linkable_to_member? %>
+                    <button type="button" class="btn btn-sm btn-primary"
+                            data-bs-toggle="modal" data-bs-target="#maLinkMemberModal"
+                            data-ma-link-action="<%= link_user_membership_application_path(app) %>"
+                            data-application-email="<%= h(app.email) %>">
+                      Link member
+                    </button>
+                  <% end %>
+                </td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/membership_applications/show.html.erb
+++ b/app/views/membership_applications/show.html.erb
@@ -60,7 +60,7 @@
                               form: { data: { turbo_confirm: 'Remove the member link from this application?' } } %>
               <% else %>
                 <span class="text-muted">Not linked</span>
-                <% if @users_for_application_link.any? %>
+                <% if @application.linkable_to_member? && @users_for_application_link.any? %>
                   <button type="button" class="btn btn-sm btn-primary"
                           data-bs-toggle="modal" data-bs-target="#maLinkMemberModal">
                     Link member
@@ -104,7 +104,7 @@
   <%= render 'tour_feedback_card', application: @application, current_tour_feedback: @current_tour_feedback %>
 <% end %>
 
-<% if @application.user.nil? && @users_for_application_link.any? %>
+<% if @application.linkable_to_member? && @users_for_application_link.any? %>
   <%= render 'link_member_modal',
              users: @users_for_application_link,
              form_url: link_user_membership_application_path(@application),

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -63,8 +63,9 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
   test 'link_user associates member with application' do
     app = MembershipApplication.create!(
       email: 'link-app-test@example.com',
-      status: 'submitted',
-      submitted_at: Time.current
+      status: 'approved',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
     )
     member = users(:member_with_local_account)
 
@@ -73,6 +74,62 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to membership_application_path(app)
     assert_match(/linked/i, flash[:notice])
     assert_equal member.id, app.reload.user_id
+  end
+
+  test 'link_user rejects open and under-review applications' do
+    app = MembershipApplication.create!(
+      email: 'link-pending@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    member = users(:member_with_local_account)
+
+    post link_user_membership_application_path(app), params: { user_id: member.id }
+
+    assert_redirected_to membership_application_path(app)
+    assert_match(/cannot be linked/i, flash[:alert])
+    assert_nil app.reload.user_id
+  end
+
+  test 'index open tab does not offer link member action' do
+    MembershipApplication.create!(
+      email: 'open-no-link@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+
+    get membership_applications_path(status: 'submitted')
+
+    assert_response :success
+    assert_select 'button', text: 'Link member', count: 0
+  end
+
+  test 'index under review tab does not offer link member action' do
+    MembershipApplication.create!(
+      email: 'review-no-link@example.com',
+      status: 'under_review',
+      submitted_at: Time.current
+    )
+
+    get membership_applications_path(status: 'under_review')
+
+    assert_response :success
+    assert_select 'button', text: 'Link member', count: 0
+  end
+
+  test 'index unlinked tab offers link member action' do
+    app = MembershipApplication.create!(
+      email: 'unlinked-linkable@example.com',
+      status: 'approved',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+
+    get membership_applications_path(status: 'unlinked')
+
+    assert_response :success
+    assert_select 'button', text: 'Link member'
+    assert_select 'button[data-ma-link-action=?]', link_user_membership_application_path(app)
   end
 
   test 'index search filters by query param' do
@@ -442,7 +499,7 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
 
     get membership_applications_path(status: 'under_review')
     assert_response :success
-    assert_includes response.body, app.email
+    assert_select 'a[href=?]', membership_application_path(app)
     assert_includes response.body, 'Needs review'
   end
 


### PR DESCRIPTION
Applicants still in review have no member account to link; restrict the list and detail UI plus the link action to approved or rejected applications only.