### PR TITLE
Fix initiated tab actions to target awaiting applications only.

### DIFF
--- a/app/controllers/concerns/initiated_application_actions.rb
+++ b/app/controllers/concerns/initiated_application_actions.rb
@@ -3,6 +3,8 @@ module InitiatedApplicationActions
 
   def extend_initiated_application
     verification = ApplicationVerification.find(params[:id])
+    return if reject_initiated_action_when_application_received!(verification)
+
     duration = initiated_application_extension_duration
 
     if duration.nil?
@@ -16,11 +18,7 @@ module InitiatedApplicationActions
 
   def resend_initiated_application
     verification = ApplicationVerification.find(params[:id])
-
-    if verification.verified?
-      redirect_to_initiated_applications alert: 'This application is already open; no confirmation email is needed.'
-      return
-    end
+    return if reject_initiated_action_when_application_received!(verification)
 
     verification.deliver_verification_email!
     redirect_to_initiated_applications notice: "Re-sent the confirmation link to #{verification.email}."
@@ -37,5 +35,12 @@ module InitiatedApplicationActions
     when 'day' then 1.day
     when 'week' then 1.week
     end
+  end
+
+  def reject_initiated_action_when_application_received!(verification)
+    return false if verification.awaiting_application?
+
+    redirect_to_initiated_applications alert: 'An application has already been received for this email.'
+    true
   end
 end

--- a/app/models/application_verification.rb
+++ b/app/models/application_verification.rb
@@ -33,6 +33,15 @@ class ApplicationVerification < ApplicationRecord
     update!(expires_at: [expires_at, Time.current].max + duration)
   end
 
+  def received_application?
+    MembershipApplication.where.not(status: 'draft')
+                         .exists?(['LOWER(email) = ?', email.downcase])
+  end
+
+  def awaiting_application?
+    !received_application?
+  end
+
   def deliver_verification_email!
     url_options = Rails.application.config.action_mailer.default_url_options
     verification_url = Rails.application.routes.url_helpers.apply_verify_email_url(

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -170,7 +170,7 @@
                   <% end %>
                 </td>
                 <td class="text-end text-nowrap">
-                  <% unless verification.verified? %>
+                  <% if verification.awaiting_application? %>
                     <%= button_to "Re-send",
                         resend_initiated_membership_applications_path(verification),
                         method: :post,

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -686,29 +686,46 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_match 'Re-sent the confirmation link', flash[:notice]
   end
 
-  test 'resend initiated application rejects verified open applications' do
-    verification = ApplicationVerification.create!(email: 'open@example.com')
-    verification.verify_email!
+  test 'resend initiated application rejects when application already received' do
+    verification = ApplicationVerification.create!(email: 'received@example.com')
+    MembershipApplication.create!(
+      email: verification.email,
+      status: 'submitted',
+      submitted_at: Time.current
+    )
 
     assert_no_enqueued_emails do
       post resend_initiated_membership_applications_path(verification)
     end
 
     assert_redirected_to membership_applications_path(status: 'initiated')
-    assert_match 'already open', flash[:alert]
+    assert_match 'already been received', flash[:alert]
   end
 
-  test 'index initiated tab hides actions for verified open applications' do
-    ApplicationVerification.create!(email: 'pending@example.com')
-    open_verification = ApplicationVerification.create!(email: 'open@example.com')
-    open_verification.verify_email!
+  test 'index initiated tab hides actions when application already received' do
+    awaiting_verification = ApplicationVerification.create!(email: 'awaiting@example.com')
+    received_verification = ApplicationVerification.create!(email: 'received@example.com')
+    MembershipApplication.create!(
+      email: received_verification.email,
+      status: 'submitted',
+      submitted_at: Time.current
+    )
 
     get membership_applications_path(status: 'initiated')
 
     assert_response :success
-    pending_verification = ApplicationVerification.find_by!(email: 'pending@example.com')
-    assert_select 'form[action=?]', resend_initiated_membership_applications_path(pending_verification)
-    assert_select 'form[action=?]', resend_initiated_membership_applications_path(open_verification), count: 0
+    assert_select 'form[action=?]', resend_initiated_membership_applications_path(awaiting_verification)
+    assert_select 'form[action=?]', resend_initiated_membership_applications_path(received_verification), count: 0
+  end
+
+  test 'index initiated tab shows actions for verified email without received application' do
+    verification = ApplicationVerification.create!(email: 'verified-awaiting@example.com')
+    verification.verify_email!
+
+    get membership_applications_path(status: 'initiated')
+
+    assert_response :success
+    assert_select 'form[action=?]', resend_initiated_membership_applications_path(verification)
   end
 
   private


### PR DESCRIPTION
Show re-send and extend controls when no application has been received yet, including after email verification, and hide them once a submitted application exists.