### PR TITLE
Applicant status page and application processing insights

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -15,6 +15,14 @@
 .text-11            { font-size: 11px; }
 .fw-medium          { font-weight: 500; }
 
+.application-status-progress-track {
+  height: 8px;
+}
+
+.application-status-outcome-email p:last-child {
+  margin-bottom: 0;
+}
+
 /* Bootstrap has subtle color variables but not text-bg-*-subtle utilities. */
 .text-bg-primary-subtle { color: var(--bs-primary-text-emphasis); background-color: var(--bs-primary-bg-subtle); }
 .text-bg-secondary-subtle { color: var(--bs-secondary-text-emphasis); background-color: var(--bs-secondary-bg-subtle); }

--- a/app/controllers/application_verifications_controller.rb
+++ b/app/controllers/application_verifications_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationVerificationsController < ApplicationController
-  before_action :redirect_builtin_only_requests_when_external, only: %i[send_verification verify_email check_email]
+  before_action :redirect_builtin_only_requests_when_external,
+                only: %i[send_verification verify_email check_email status]
 
   def gate
     unless MembershipSetting.use_builtin_membership_application?
@@ -37,10 +38,13 @@ class ApplicationVerificationsController < ApplicationController
   end
 
   def verify_email
-    verification = ApplicationVerification.find_by(token: params[:token])
+    verification = find_verification_for_token
+    return unless verification
 
-    if verification.nil?
-      redirect_to apply_new_path, alert: 'Invalid verification link.'
+    application = verification.submitted_application
+    if application
+      verification.verify_email! unless verification.email_verified?
+      redirect_to apply_application_status_path(token: verification.token)
       return
     end
 
@@ -53,6 +57,22 @@ class ApplicationVerificationsController < ApplicationController
     session[:verified_application_token] = verification.token
 
     redirect_to apply_start_path
+  end
+
+  def status
+    verification = find_verification_for_token
+    return unless verification
+
+    @application = verification.submitted_application
+    unless @application
+      redirect_to apply_new_path, alert: 'No submitted application was found for this link.'
+      return
+    end
+
+    verification.verify_email! unless verification.email_verified?
+    @status = @application.applicant_status
+    @outcome_email = MembershipApplications::OutcomeEmailRecorder.for_display(@application)
+    @timing = MembershipApplications::ApplicantStatusTiming.for(@application)
   end
 
   def check_email; end
@@ -99,5 +119,15 @@ class ApplicationVerificationsController < ApplicationController
 
   def deliver_verification_mailer(_email, verification)
     verification.deliver_verification_email!
+  end
+
+  def find_verification_for_token
+    verification = ApplicationVerification.find_by(token: params[:token])
+    if verification.nil?
+      redirect_to apply_new_path, alert: 'Invalid verification link.'
+      return nil
+    end
+
+    verification
   end
 end

--- a/app/controllers/concerns/membership_application_wizard/actions.rb
+++ b/app/controllers/concerns/membership_application_wizard/actions.rb
@@ -27,11 +27,9 @@ module MembershipApplicationWizard
       end
 
       return unless @email
+      return unless MembershipApplication.where(email: @email).where.not(status: 'draft').exists?
 
-      @existing_application = MembershipApplication.where(email: @email)
-                                                   .where.not(status: 'draft')
-                                                   .newest_first
-                                                   .first
+      redirect_to apply_application_status_path(token: @verification.token)
     end
 
     def save_page

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -43,6 +43,7 @@ class MembershipApplicationsController < ApplicationController
   def index
     @current_status = params[:status].presence || 'submitted'
     @status_counts = membership_application_status_counts
+    @processing_time_stats = MembershipApplications::ProcessingTimeStats.call
 
     if @current_status == 'initiated'
       load_initiated_applications

--- a/app/controllers/text_fragments_controller.rb
+++ b/app/controllers/text_fragments_controller.rb
@@ -235,6 +235,8 @@ class TextFragmentsController < AdminController
       HTML
     )
 
+    TextFragments::ApplicationFlowSeeds.seed!
+
     TextFragment.ensure_exists!(
       key: 'invite_already_accepted',
       title: 'Invitation: Already Accepted',

--- a/app/helpers/membership_applications_helper.rb
+++ b/app/helpers/membership_applications_helper.rb
@@ -1,0 +1,6 @@
+module MembershipApplicationsHelper
+  def membership_application_applicant_status_path(application)
+    verification = application.status_page_verification
+    apply_application_status_path(token: verification.token) if verification
+  end
+end

--- a/app/models/application_verification.rb
+++ b/app/models/application_verification.rb
@@ -42,6 +42,17 @@ class ApplicationVerification < ApplicationRecord
     !received_application?
   end
 
+  def submitted_application
+    MembershipApplication.where.not(status: 'draft')
+                         .where('LOWER(email) = ?', email.downcase)
+                         .newest_first
+                         .first
+  end
+
+  def status_link?
+    submitted_application.present?
+  end
+
   def deliver_verification_email!
     url_options = Rails.application.config.action_mailer.default_url_options
     verification_url = Rails.application.routes.url_helpers.apply_verify_email_url(

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -25,6 +25,7 @@ class MembershipApplication < ApplicationRecord
 
   belongs_to :reviewed_by, class_name: 'User', optional: true
   belongs_to :user, optional: true
+  belongs_to :outcome_queued_mail, class_name: 'QueuedMail', optional: true
   has_many :application_answers, dependent: :destroy
   has_many :ai_feedback_votes, -> { order(created_at: :asc) },
            class_name: 'MembershipApplicationAiFeedbackVote', dependent: :destroy
@@ -46,6 +47,7 @@ class MembershipApplication < ApplicationRecord
   scope :under_review_apps, -> { where(status: IN_REVIEW_STATUSES) }
   scope :approved, -> { where(status: 'approved') }
   scope :rejected, -> { where(status: 'rejected') }
+  scope :finalized, -> { where(status: %w[approved rejected]) }
   # Applications awaiting a final decision (Open, Under Review, or parked Needs Review).
   scope :pending, -> { where(status: %w[submitted] + IN_REVIEW_STATUSES) }
   scope :naggable_pending, -> { where(status: NAGGABLE_PENDING_STATUSES) }
@@ -166,6 +168,7 @@ class MembershipApplication < ApplicationRecord
       )
       Journal.record_application_event!(application: self, action: 'application_rejected', actor: admin)
       queued_mail = QueuedMail.enqueue_application_rejected(self, reason: notes.presence)
+      MembershipApplications::OutcomeEmailRecorder.assign!(self, queued_mail)
     end
     queued_mail
   end
@@ -285,6 +288,16 @@ class MembershipApplication < ApplicationRecord
   def ai_feedback_recommendation_badge_color
     key = ai_feedback_recommendation.to_s.downcase.strip.tr(' ', '_')
     AI_FEEDBACK_REC_BADGES.fetch(key, 'secondary')
+  end
+
+  def applicant_status
+    MembershipApplications::ApplicantStatus.for(self)
+  end
+
+  def status_page_verification
+    return nil if draft?
+
+    ApplicationVerification.where('LOWER(email) = ?', email.downcase).newest_first.first
   end
 
   private

--- a/app/models/queued_mail.rb
+++ b/app/models/queued_mail.rb
@@ -3,7 +3,7 @@ class QueuedMail < ApplicationRecord
 
   # Stand-in for +MemberMailer.build_template_variables+ when the applicant has no User yet
   ApplicantMailRecipient = Data.define(:display_name, :email, :username)
-  ImmediateDelivery = Data.define(:to, :subject, :email_template)
+  ImmediateDelivery = Data.define(:to, :subject, :body_html, :body_text, :email_template)
 
   belongs_to :email_template, optional: true
   belongs_to :recipient, class_name: 'User', optional: true
@@ -123,7 +123,13 @@ class QueuedMail < ApplicationRecord
       body_text: rendered[:body_text] || ''
     ).deliver_now
 
-    ImmediateDelivery.new(to: dest, subject: rendered[:subject], email_template: template)
+    ImmediateDelivery.new(
+      to: dest,
+      subject: rendered[:subject],
+      body_html: rendered[:body_html],
+      body_text: rendered[:body_text] || '',
+      email_template: template
+    )
   end
 
   def self.queued_mail_attrs(dest, reason, recipient, action, args)

--- a/app/services/membership_applications/applicant_status.rb
+++ b/app/services/membership_applications/applicant_status.rb
@@ -1,0 +1,77 @@
+module MembershipApplications
+  class ApplicantStatus
+    STAGES = {
+      submitted: 1,
+      review_begun: 2,
+      complete: 3
+    }.freeze
+
+    STEP_LABELS = [
+      { key: :submitted, label: 'Application submitted', step: '1/3' },
+      { key: :review_begun, label: 'Review process begun', step: '2/3' },
+      { key: :complete, label: 'Application process complete', step: '3/3' }
+    ].freeze
+
+    def self.for(application)
+      new(application)
+    end
+
+    def initialize(application)
+      @application = application
+    end
+
+    def stage
+      return :complete if @application.approved? || @application.rejected?
+      return :review_begun if review_process_begun?
+
+      :submitted
+    end
+
+    def step_number
+      STAGES.fetch(stage)
+    end
+
+    def progress_percent
+      (step_number / 3.0 * 100).round
+    end
+
+    def complete?
+      stage == :complete
+    end
+
+    def headline
+      case stage
+      when :submitted
+        'Your application is in the queue for review.'
+      when :review_begun
+        'Your application is being reviewed.'
+      when :complete
+        if @application.approved?
+          'Your application has been approved.'
+        else
+          'Your application has been reviewed.'
+        end
+      end
+    end
+
+    def step_labels
+      STEP_LABELS
+    end
+
+    def step_active?(step_key)
+      STAGES.fetch(step_key) <= step_number
+    end
+
+    def step_current?(step_key)
+      stage == step_key
+    end
+
+    private
+
+    def review_process_begun?
+      @application.in_review? ||
+        @application.acceptance_votes.exists? ||
+        @application.tour_feedbacks.exists?
+    end
+  end
+end

--- a/app/services/membership_applications/applicant_status_timing.rb
+++ b/app/services/membership_applications/applicant_status_timing.rb
@@ -1,0 +1,48 @@
+module MembershipApplications
+  class ApplicantStatusTiming
+    OVERDUE_APOLOGY_FRAGMENT_KEY = 'application_status_overdue_apology'.freeze
+
+    def self.for(application, now: Time.current)
+      new(application, now: now).call
+    end
+
+    def initialize(application, now: Time.current)
+      @application = application
+      @now = now
+    end
+
+    def call
+      estimate = ProcessingTimeStats.applicant_estimate
+      waiting_seconds = waiting_duration_seconds
+      average_seconds = estimate[:average_seconds]
+      overdue = pending? && average_seconds && waiting_seconds && waiting_seconds > average_seconds
+
+      {
+        estimate: estimate,
+        waiting_seconds: waiting_seconds,
+        waiting_label: waiting_seconds ? ProcessingTimeStats.format_duration(waiting_seconds) : nil,
+        show_apology: overdue,
+        apology_content: overdue ? apology_content : nil
+      }
+    end
+
+    private
+
+    attr_reader :application, :now
+
+    def pending?
+      !application.approved? && !application.rejected?
+    end
+
+    def waiting_duration_seconds
+      opened_at = application.submitted_at || application.created_at
+      return nil unless opened_at
+
+      [now - opened_at, 0].max
+    end
+
+    def apology_content
+      TextFragment.content_for(OVERDUE_APOLOGY_FRAGMENT_KEY).presence
+    end
+  end
+end

--- a/app/services/membership_applications/backfill_outcome_emails.rb
+++ b/app/services/membership_applications/backfill_outcome_emails.rb
@@ -1,0 +1,144 @@
+module MembershipApplications
+  class BackfillOutcomeEmails
+    OUTCOME_MAILER_ACTIONS = {
+      'approved' => 'application_approved',
+      'rejected' => 'application_rejected'
+    }.freeze
+
+    Result = Struct.new(:linked_queued_mail, :linked_snapshot, :unmatched)
+
+    def self.call(dry_run: false)
+      new(dry_run: dry_run).call
+    end
+
+    def initialize(dry_run: false)
+      @dry_run = dry_run
+      @linked_queued_mail = 0
+      @linked_snapshot = 0
+      @unmatched = 0
+    end
+
+    def call
+      excluded_queued_mail_ids = Set.new(
+        MembershipApplication.where.not(outcome_queued_mail_id: nil).pluck(:outcome_queued_mail_id)
+      )
+
+      scope.find_each do |application|
+        process_application!(application, excluded_queued_mail_ids)
+      end
+
+      Result.new(@linked_queued_mail, @linked_snapshot, @unmatched)
+    end
+
+    private
+
+    attr_reader :dry_run
+
+    def scope
+      MembershipApplication.finalized
+                           .where(outcome_queued_mail_id: nil, outcome_email_subject: nil)
+                           .order(:id)
+    end
+
+    def process_application!(application, excluded_queued_mail_ids)
+      queued_mail = find_queued_mail(application, excluded_queued_mail_ids: excluded_queued_mail_ids)
+      if queued_mail
+        assign_queued_mail!(application, queued_mail)
+        excluded_queued_mail_ids << queued_mail.id
+        @linked_queued_mail += 1
+        log_line(application, "queued mail ##{queued_mail.id} (#{queued_mail.mailer_action})")
+        return
+      end
+
+      mail_log_entry = find_direct_mail_log_entry(application)
+      if mail_log_entry
+        assign_mail_log_snapshot!(application, mail_log_entry)
+        @linked_snapshot += 1
+        log_line(application, "mail log entry ##{mail_log_entry.id} (#{mail_log_entry.delivery_action})")
+        return
+      end
+
+      @unmatched += 1
+      log_line(application, 'no matching sent outcome email found')
+    end
+
+    def assign_queued_mail!(application, queued_mail)
+      return if dry_run
+
+      OutcomeEmailRecorder.assign!(application, queued_mail)
+    end
+
+    def assign_mail_log_snapshot!(application, entry)
+      return if dry_run
+
+      application.update!(
+        outcome_email_subject: entry.delivery_subject,
+        outcome_email_body_html: entry.delivery_body_html
+      )
+    end
+
+    def log_line(application, message)
+      prefix = dry_run ? '[DRY RUN] ' : ''
+      # rubocop:disable Rails/Output
+      puts "#{prefix}Application #{application.id} (#{application.email}, #{application.status}): #{message}"
+      # rubocop:enable Rails/Output
+    end
+
+    def find_queued_mail(application, excluded_queued_mail_ids:)
+      action = OUTCOME_MAILER_ACTIONS[application.status]
+      return nil unless action
+
+      dest_emails = destination_emails(application)
+      return nil if dest_emails.empty?
+
+      candidates = QueuedMail
+                   .where(mailer_action: action)
+                   .where.not(sent_at: nil)
+      candidates = candidates.where.not(id: excluded_queued_mail_ids.to_a) if excluded_queued_mail_ids.any?
+
+      candidates = candidates.where(
+        <<~SQL.squish,
+          LOWER(TRIM("to")) IN (:emails)
+          OR (recipient_id IS NOT NULL AND recipient_id = :recipient_id)
+        SQL
+        emails: dest_emails,
+        recipient_id: application.user_id
+      )
+
+      pick_closest_to_review(candidates.to_a, application.reviewed_at) { |record| record.sent_at || record.created_at }
+    end
+
+    def find_direct_mail_log_entry(application)
+      action = OUTCOME_MAILER_ACTIONS[application.status]
+      return nil unless action
+
+      dest_emails = destination_emails(application)
+      return nil if dest_emails.empty?
+
+      candidates = MailLogEntry
+                   .where(event: 'sent', delivery_action: action)
+                   .where('LOWER(TRIM(delivery_to)) IN (?)', dest_emails)
+                   .order(created_at: :desc)
+                   .to_a
+
+      pick_closest_to_review(candidates, application.reviewed_at, &:created_at)
+    end
+
+    def pick_closest_to_review(records, reviewed_at, &anchor_time)
+      return records.first if records.size <= 1
+      return records.first if reviewed_at.blank?
+
+      records.min_by do |record|
+        anchor = anchor_time ? anchor_time.call(record) : record.created_at
+        (anchor - reviewed_at).abs
+      end
+    end
+
+    def destination_emails(application)
+      [application.email, application.user&.email].filter_map do |email|
+        normalized = email.to_s.strip.downcase
+        normalized.presence
+      end.uniq
+    end
+  end
+end

--- a/app/services/membership_applications/finalize_approval.rb
+++ b/app/services/membership_applications/finalize_approval.rb
@@ -64,6 +64,7 @@ module MembershipApplications
         user = resolve_recipient_user!
         approve_application!(user)
         queued_mail = queue_approval_mail_for(user)
+        MembershipApplications::OutcomeEmailRecorder.assign!(@application, queued_mail)
       end
 
       success_result(user: user, queued_mail: queued_mail)

--- a/app/services/membership_applications/outcome_email_recorder.rb
+++ b/app/services/membership_applications/outcome_email_recorder.rb
@@ -1,0 +1,31 @@
+module MembershipApplications
+  class OutcomeEmailRecorder
+    def self.assign!(application, delivery)
+      return if delivery.nil?
+
+      case delivery
+      when QueuedMail
+        application.update!(outcome_queued_mail: delivery)
+      when QueuedMail::ImmediateDelivery
+        application.update!(
+          outcome_email_subject: delivery.subject,
+          outcome_email_body_html: delivery.body_html
+        )
+      end
+    end
+
+    def self.for_display(application)
+      if application.outcome_queued_mail
+        {
+          subject: application.outcome_queued_mail.subject,
+          body_html: application.outcome_queued_mail.body_html
+        }
+      elsif application.outcome_email_subject.present?
+        {
+          subject: application.outcome_email_subject,
+          body_html: application.outcome_email_body_html.to_s
+        }
+      end
+    end
+  end
+end

--- a/app/services/membership_applications/processing_time_stats.rb
+++ b/app/services/membership_applications/processing_time_stats.rb
@@ -1,0 +1,73 @@
+module MembershipApplications
+  class ProcessingTimeStats
+    APPLICANT_ESTIMATE_MULTIPLIER = 1.25
+
+    def self.call(since: 2.months.ago)
+      new(since: since).call
+    end
+
+    def self.format_duration(seconds)
+      return nil if seconds.nil?
+
+      seconds = seconds.round
+      if seconds < 60
+        'less than a minute'
+      elsif seconds < 3600
+        minutes = (seconds / 60.0).round
+        "#{minutes} #{'minute'.pluralize(minutes)}"
+      elsif seconds < 86_400
+        hours = (seconds / 3600.0).round
+        "#{hours} #{'hour'.pluralize(hours)}"
+      else
+        days = (seconds / 86_400.0).round
+        "#{days} #{'day'.pluralize(days)}"
+      end
+    end
+
+    def self.applicant_estimate(since: 2.months.ago, multiplier: APPLICANT_ESTIMATE_MULTIPLIER)
+      stats = call(since: since)
+      average_seconds = stats[:average_seconds]
+      return stats.merge(estimated_seconds: nil, estimated_label: nil) unless average_seconds
+
+      estimated_seconds = average_seconds * multiplier
+      stats.merge(
+        estimated_seconds: estimated_seconds,
+        estimated_label: format_duration(estimated_seconds)
+      )
+    end
+
+    def initialize(since:)
+      @since = since
+    end
+
+    def call
+      count, average_seconds = finalized_scope.pick(
+        Arel.sql('COUNT(*)'),
+        Arel.sql("AVG(EXTRACT(EPOCH FROM (reviewed_at - #{opened_at_sql})))")
+      )
+
+      count = count.to_i
+      average_seconds = average_seconds&.to_f
+      {
+        count: count,
+        average_seconds: average_seconds,
+        average_label: count.positive? ? self.class.format_duration(average_seconds) : nil
+      }
+    end
+
+    private
+
+    attr_reader :since
+
+    def opened_at_sql
+      @opened_at_sql ||= 'COALESCE(membership_applications.submitted_at, membership_applications.created_at)'
+    end
+
+    def finalized_scope
+      MembershipApplication.finalized
+                           .where(reviewed_at: since..)
+                           .where("#{opened_at_sql} IS NOT NULL")
+                           .where("reviewed_at >= #{opened_at_sql}")
+    end
+  end
+end

--- a/app/services/text_fragments/application_flow_seeds.rb
+++ b/app/services/text_fragments/application_flow_seeds.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module TextFragments
+  module ApplicationFlowSeeds
+    module_function
+
+    def seed!
+      seed_check_email!
+      seed_gate_intro!
+      seed_overdue_apology!
+    end
+
+    def seed_check_email!
+      TextFragment.ensure_exists!(
+        key: 'application_verification_check_email',
+        title: 'Application Verification: Check Email',
+        content: <<~HTML
+          <h2 class="h4 mb-3">Check Your Email</h2>
+          <p class="mb-4">
+            We've sent a verification link to the email address you provided.
+            Please check your inbox and click the link to begin your membership application.
+          </p>
+        HTML
+      )
+    end
+
+    def seed_gate_intro!
+      TextFragment.ensure_exists!(
+        key: 'application_verification_gate_intro',
+        title: 'Application Verification: Gate Introduction',
+        content: <<~HTML
+          <p>
+            Thank you for your interest in joining! Before you begin your application, please
+            confirm the following and provide your email address.
+          </p>
+        HTML
+      )
+    end
+
+    def seed_overdue_apology!
+      TextFragment.ensure_exists!(
+        key: 'application_status_overdue_apology',
+        title: 'Application Status: Overdue Apology',
+        content: <<~HTML
+          <p>
+            We're sorry your application is taking longer than usual. PDX Hackerspace is run entirely
+            by volunteers, and sometimes review can take longer than we'd like. Thank you for your patience
+            while our team catches up.
+          </p>
+        HTML
+      )
+    end
+  end
+end

--- a/app/views/application_form_pages/index.html.erb
+++ b/app/views/application_form_pages/index.html.erb
@@ -32,6 +32,27 @@
           shown on the public <%= link_to 'apply page', apply_path, class: 'text-decoration-none' %> when the external option is selected (built-in redirects <code>/apply</code> to the wizard).
         </p>
       <% end %>
+      <% check_email_frag = TextFragment.find_by(key: 'application_verification_check_email') %>
+      <% if check_email_frag %>
+        <p class="text-muted small mb-3">
+          <%= link_to 'Edit check-email text', edit_text_fragment_path(check_email_frag), class: 'text-decoration-none' %>:
+          shown after someone submits their email on the built-in apply flow.
+        </p>
+      <% end %>
+      <% gate_intro_frag = TextFragment.find_by(key: 'application_verification_gate_intro') %>
+      <% if gate_intro_frag %>
+        <p class="text-muted small mb-3">
+          <%= link_to 'Edit apply gate intro', edit_text_fragment_path(gate_intro_frag), class: 'text-decoration-none' %>:
+          shown at the top of the built-in <%= link_to 'apply gate', apply_new_path, class: 'text-decoration-none' %> before confirmations.
+        </p>
+      <% end %>
+      <% overdue_apology_frag = TextFragment.find_by(key: 'application_status_overdue_apology') %>
+      <% if overdue_apology_frag %>
+        <p class="text-muted small mb-3">
+          <%= link_to 'Edit overdue status apology', edit_text_fragment_path(overdue_apology_frag), class: 'text-decoration-none' %>:
+          shown on the applicant status page when review is taking longer than recent averages.
+        </p>
+      <% end %>
       <%= submit_tag 'Save application flow', class: 'btn btn-primary' %>
     <% end %>
   </div>

--- a/app/views/application_verifications/_application_status_progress.html.erb
+++ b/app/views/application_verifications/_application_status_progress.html.erb
@@ -1,0 +1,25 @@
+<%# locals: (status:) %>
+<div class="application-status-progress mb-4">
+  <div class="progress application-status-progress-track" role="progressbar"
+       aria-valuenow="<%= status.progress_percent %>"
+       aria-valuemin="0"
+       aria-valuemax="100"
+       aria-label="Application progress">
+    <div class="progress-bar bg-success" style="width: <%= status.progress_percent %>%"></div>
+    <% remaining = 100 - status.progress_percent %>
+    <% if remaining.positive? %>
+      <div class="progress-bar bg-warning" style="width: <%= remaining %>%"></div>
+    <% end %>
+  </div>
+  <div class="d-flex text-12 mt-2 gap-1">
+    <% status.step_labels.each_with_index do |step, index| %>
+      <% align_class = index.zero? ? 'text-start' : (index == status.step_labels.length - 1 ? 'text-end' : 'text-center') %>
+      <div class="flex-fill <%= align_class %>">
+        <span class="<%= status.step_active?(step[:key]) ? 'text-body fw-medium' : 'text-secondary' %>">
+          <%= step[:label] %>
+        </span>
+        <span class="text-secondary"> (<%= step[:step] %>)</span>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/application_verifications/check_email.html.erb
+++ b/app/views/application_verifications/check_email.html.erb
@@ -5,11 +5,16 @@
         <div class="display-4 text-primary mb-4">
           <i class="bi bi-envelope-check"></i>
         </div>
-        <h2 class="h4 mb-3">Check Your Email</h2>
-        <p class="mb-4">
-          We've sent a verification link to the email address you provided.
-          Please check your inbox and click the link to begin your membership application.
-        </p>
+        <% check_email_content = TextFragment.content_for('application_verification_check_email') %>
+        <% if check_email_content.present? %>
+          <%= sanitize(check_email_content) %>
+        <% else %>
+          <h2 class="h4 mb-3">Check Your Email</h2>
+          <p class="mb-4">
+            We've sent a verification link to the email address you provided.
+            Please check your inbox and click the link to begin your membership application.
+          </p>
+        <% end %>
         <div class="alert alert-info text-start">
           <i class="bi bi-info-circle me-2"></i>
           <strong>Didn't receive it?</strong> Check your spam folder. The link expires in

--- a/app/views/application_verifications/gate.html.erb
+++ b/app/views/application_verifications/gate.html.erb
@@ -3,10 +3,15 @@
     <div class="card shadow-sm border-0 mb-4">
       <div class="card-body p-4 p-md-5">
         <h2 class="h4 mb-3">Membership Application</h2>
-        <p>
-          Thank you for your interest in joining! Before you begin your application, please
-          confirm the following and provide your email address.
-        </p>
+        <% gate_intro_content = TextFragment.content_for('application_verification_gate_intro') %>
+        <% if gate_intro_content.present? %>
+          <%= sanitize(gate_intro_content) %>
+        <% else %>
+          <p>
+            Thank you for your interest in joining! Before you begin your application, please
+            confirm the following and provide your email address.
+          </p>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/application_verifications/status.html.erb
+++ b/app/views/application_verifications/status.html.erb
@@ -1,0 +1,63 @@
+<div class="row justify-content-center py-5">
+  <div class="col-12 col-md-10 col-lg-8">
+    <div class="card shadow-sm border-0">
+      <div class="card-body p-4 p-md-5">
+        <h1 class="h-page-title mb-1">Application status</h1>
+        <p class="text-13 text-secondary mb-4">
+          Submitted <%= @application.submitted_at ? l(@application.submitted_at.to_date, format: :long) : 'recently' %>
+          · <%= @application.email %>
+        </p>
+
+        <p class="text-body mb-4"><%= @status.headline %></p>
+
+        <%= render 'application_status_progress', status: @status %>
+
+        <% if @timing[:waiting_label].present? %>
+          <div class="text-13 mt-4">
+            <p class="mb-2">
+              Your application was submitted
+              <span class="text-body fw-medium"><%= @timing[:waiting_label] %></span> ago.
+            </p>
+            <% if @timing[:estimate][:estimated_label].present? %>
+              <p class="mb-0 text-secondary">
+                Based on applications reviewed in the last two months, review typically takes about
+                <span class="text-body"><%= @timing[:estimate][:estimated_label] %></span>.
+              </p>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if @timing[:show_apology] && @timing[:apology_content].present? %>
+          <div class="alert alert-warning text-start text-13 mt-3 mb-0">
+            <%= sanitize(@timing[:apology_content], tags: %w[p br strong b em i u a], attributes: %w[href class]) %>
+          </div>
+        <% elsif @timing[:show_apology] %>
+          <div class="alert alert-warning text-start text-13 mt-3 mb-0">
+            <p class="mb-0">
+              We're sorry your application is taking longer than usual. PDX Hackerspace is run entirely
+              by volunteers, and sometimes review can take longer than we'd like. Thank you for your patience.
+            </p>
+          </div>
+        <% end %>
+
+        <% if @status.complete? && @outcome_email.present? %>
+          <div class="mt-4">
+            <div class="h-section-label mb-2">Decision email</div>
+            <div class="card border-0 bg-body-tertiary">
+              <div class="card-header bg-transparent border-bottom py-2 px-3">
+                <strong class="text-13"><%= @outcome_email[:subject] %></strong>
+              </div>
+              <div class="card-body text-13 px-3 py-3 application-status-outcome-email">
+                <%= sanitize(@outcome_email[:body_html], tags: %w[h1 h2 h3 h4 h5 h6 p br strong b em i u s ul ol li a div span hr], attributes: %w[href target class]) %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+
+        <div class="mt-4">
+          <%= link_to "← Back to Sign In", login_path, class: "btn btn-outline-secondary btn-sm" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/membership_applications/_applicant_status_link.html.erb
+++ b/app/views/membership_applications/_applicant_status_link.html.erb
@@ -1,0 +1,5 @@
+<%# locals: (application:, label: 'Applicant status', btn_class: 'btn btn-outline-secondary btn-sm') %>
+<% status_path = membership_application_applicant_status_path(application) %>
+<% if status_path %>
+  <%= link_to label, status_path, class: btn_class, target: '_blank', rel: 'noopener' %>
+<% end %>

--- a/app/views/membership_applications/confirmation.html.erb
+++ b/app/views/membership_applications/confirmation.html.erb
@@ -9,7 +9,12 @@
           and will be reviewed by our membership committee. We will contact you at the
           email address you provided.
         </p>
-        <%= link_to "← Back to Home", login_path, class: "btn btn-outline-primary" %>
+        <% if session[:verified_application_token].present? %>
+          <%= link_to "View application status",
+              apply_application_status_path(token: session[:verified_application_token]),
+              class: "btn btn-primary btn-sm me-2" %>
+        <% end %>
+        <%= link_to "← Back to Home", login_path, class: "btn btn-outline-secondary btn-sm" %>
       </div>
     </div>
   </div>

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -1,8 +1,19 @@
 <% ma_nav = { q: params[:q].presence }.compact %>
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-  <h1 class="h3 mb-0">Membership Applications</h1>
-  <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#importApplicationsCsvModal">Import CSV</button>
+<div class="d-flex align-items-end justify-content-between mb-3">
+  <div>
+    <h1 class="h-page-title mb-0">Membership Applications</h1>
+    <div class="text-13 text-secondary mt-1">
+      <% if @processing_time_stats[:count].positive? %>
+        Average processing time (last 2 months):
+        <span class="text-body"><%= @processing_time_stats[:average_label] %></span>
+        <span class="text-secondary"> · <%= @processing_time_stats[:count] %> approved or rejected</span>
+      <% else %>
+        <span class="text-secondary">No applications approved or rejected in the last 2 months</span>
+      <% end %>
+    </div>
+  </div>
+  <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#importApplicationsCsvModal">Import CSV</button>
 </div>
 
 <div class="modal fade" id="importApplicationsCsvModal" tabindex="-1" aria-labelledby="importApplicationsCsvModalLabel" aria-hidden="true">
@@ -234,6 +245,14 @@
               </td>
               <td>
                 <span class="badge bg-<%= app.status_badge_color %><%= ' text-dark' if app.in_review? %>"><%= app.status_display %></span>
+                <% if membership_application_applicant_status_path(app) %>
+                  <div class="mt-1">
+                    <%= render 'applicant_status_link',
+                        application: app,
+                        label: 'Applicant view',
+                        btn_class: 'text-12 text-decoration-none' %>
+                  </div>
+                <% end %>
               </td>
               <td><%= app.submitted_at&.strftime('%b %d, %Y') || '—' %></td>
               <td class="text-nowrap">

--- a/app/views/membership_applications/show.html.erb
+++ b/app/views/membership_applications/show.html.erb
@@ -18,8 +18,9 @@
     Application #<%= @application.id %>
     <span class="badge bg-<%= @application.status_badge_color %><%= ' text-dark' if @application.in_review? %>"><%= @application.status_display %></span>
   </h1>
-  <div>
-    <%= link_to membership_applications_path, class: "btn btn-outline-secondary" do %>
+  <div class="d-flex gap-2">
+    <%= render 'applicant_status_link', application: @application %>
+    <%= link_to membership_applications_path, class: "btn btn-outline-secondary btn-sm" do %>
       <i class="bi bi-arrow-left me-1"></i> Back
     <% end %>
   </div>

--- a/app/views/membership_applications/start.html.erb
+++ b/app/views/membership_applications/start.html.erb
@@ -21,31 +21,19 @@
           <div class="form-text">This is the email you verified. It will be used for your application.</div>
         </div>
 
-        <% if @existing_application %>
-          <div class="alert alert-<%= @existing_application.status_badge_color %> mb-3">
+        <% if @application %>
+          <div class="alert alert-info mb-3">
             <i class="bi bi-info-circle me-1"></i>
-            You already have an application that was submitted on
-            <strong><%= @existing_application.submitted_at&.strftime('%B %-d, %Y') || 'a previous date' %></strong>.
-            Its current status is <strong><%= @existing_application.status_display %></strong>.
+            You have a draft application in progress. Click Continue to resume where you left off.
           </div>
+        <% end %>
+
+        <%= form_with url: apply_start_path, method: :post, local: true do |f| %>
+          <input type="hidden" name="page_number" value="0">
           <div class="d-flex justify-content-between">
             <%= link_to "← Back to Sign In", login_path, class: "btn btn-outline-secondary" %>
+            <button type="submit" class="btn btn-primary btn-lg">Continue →</button>
           </div>
-        <% else %>
-          <% if @application %>
-            <div class="alert alert-info mb-3">
-              <i class="bi bi-info-circle me-1"></i>
-              You have a draft application in progress. Click Continue to resume where you left off.
-            </div>
-          <% end %>
-
-          <%= form_with url: apply_start_path, method: :post, local: true do |f| %>
-            <input type="hidden" name="page_number" value="0">
-            <div class="d-flex justify-content-between">
-              <%= link_to "← Back to Sign In", login_path, class: "btn btn-outline-secondary" %>
-              <button type="submit" class="btn btn-primary btn-lg">Continue →</button>
-            </div>
-          <% end %>
         <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get  "/apply/new",                    to: "application_verifications#gate", as: :apply_new
   post "/apply/new",                    to: "application_verifications#send_verification"
   get  "/apply/new/verify/:token",      to: "application_verifications#verify_email", as: :apply_verify_email
+  get  "/apply/new/status/:token",      to: "application_verifications#status", as: :apply_application_status
   get  "/apply/new/check_email",        to: "application_verifications#check_email", as: :apply_check_email
   get  "/apply/new/code_of_conduct.pdf", to: "application_verifications#code_of_conduct_pdf", as: :apply_code_of_conduct_pdf
 

--- a/db/migrate/20260619120000_seed_application_verification_check_email_fragment.rb
+++ b/db/migrate/20260619120000_seed_application_verification_check_email_fragment.rb
@@ -1,0 +1,19 @@
+class SeedApplicationVerificationCheckEmailFragment < ActiveRecord::Migration[8.1]
+  def up
+    TextFragment.ensure_exists!(
+      key: 'application_verification_check_email',
+      title: 'Application Verification: Check Email',
+      content: <<~HTML
+        <h2 class="h4 mb-3">Check Your Email</h2>
+        <p class="mb-4">
+          We've sent a verification link to the email address you provided.
+          Please check your inbox and click the link to begin your membership application.
+        </p>
+      HTML
+    )
+  end
+
+  def down
+    TextFragment.find_by(key: 'application_verification_check_email')&.destroy
+  end
+end

--- a/db/migrate/20260619120100_seed_application_verification_gate_intro_fragment.rb
+++ b/db/migrate/20260619120100_seed_application_verification_gate_intro_fragment.rb
@@ -1,0 +1,18 @@
+class SeedApplicationVerificationGateIntroFragment < ActiveRecord::Migration[8.1]
+  def up
+    TextFragment.ensure_exists!(
+      key: 'application_verification_gate_intro',
+      title: 'Application Verification: Gate Introduction',
+      content: <<~HTML
+        <p>
+          Thank you for your interest in joining! Before you begin your application, please
+          confirm the following and provide your email address.
+        </p>
+      HTML
+    )
+  end
+
+  def down
+    TextFragment.find_by(key: 'application_verification_gate_intro')&.destroy
+  end
+end

--- a/db/migrate/20260619130000_add_outcome_email_to_membership_applications.rb
+++ b/db/migrate/20260619130000_add_outcome_email_to_membership_applications.rb
@@ -1,0 +1,9 @@
+class AddOutcomeEmailToMembershipApplications < ActiveRecord::Migration[8.1]
+  def change
+    change_table :membership_applications, bulk: true do |t|
+      t.references :outcome_queued_mail, foreign_key: { to_table: :queued_mails }
+      t.string :outcome_email_subject
+      t.text :outcome_email_body_html
+    end
+  end
+end

--- a/db/migrate/20260619140000_seed_application_status_overdue_apology_fragment.rb
+++ b/db/migrate/20260619140000_seed_application_status_overdue_apology_fragment.rb
@@ -1,0 +1,19 @@
+class SeedApplicationStatusOverdueApologyFragment < ActiveRecord::Migration[8.1]
+  def up
+    TextFragment.ensure_exists!(
+      key: 'application_status_overdue_apology',
+      title: 'Application Status: Overdue Apology',
+      content: <<~HTML
+        <p>
+          We're sorry your application is taking longer than usual. PDX Hackerspace is run entirely
+          by volunteers, and sometimes review can take longer than we'd like. Thank you for your patience
+          while our team catches up.
+        </p>
+      HTML
+    )
+  end
+
+  def down
+    TextFragment.find_by(key: 'application_status_overdue_apology')&.destroy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_13_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_19_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -549,6 +549,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_120000) do
     t.datetime "application_nag_sent_at"
     t.datetime "created_at", null: false
     t.string "email", null: false
+    t.text "outcome_email_body_html"
+    t.string "outcome_email_subject"
+    t.bigint "outcome_queued_mail_id"
     t.datetime "reviewed_at"
     t.bigint "reviewed_by_id"
     t.string "status", default: "draft", null: false
@@ -559,6 +562,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_120000) do
     t.index ["ai_feedback_processed_at"], name: "index_membership_applications_on_ai_feedback_processed_at"
     t.index ["application_nag_sent_at"], name: "index_membership_applications_on_application_nag_sent_at"
     t.index ["email"], name: "index_membership_applications_on_email"
+    t.index ["outcome_queued_mail_id"], name: "index_membership_applications_on_outcome_queued_mail_id"
     t.index ["reviewed_by_id"], name: "index_membership_applications_on_reviewed_by_id"
     t.index ["status"], name: "index_membership_applications_on_status"
     t.index ["token"], name: "index_membership_applications_on_token", unique: true
@@ -1105,6 +1109,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_120000) do
   add_foreign_key "membership_application_ai_feedback_votes", "users"
   add_foreign_key "membership_application_tour_feedbacks", "membership_applications"
   add_foreign_key "membership_application_tour_feedbacks", "users"
+  add_foreign_key "membership_applications", "queued_mails", column: "outcome_queued_mail_id"
   add_foreign_key "membership_applications", "users"
   add_foreign_key "membership_applications", "users", column: "reviewed_by_id"
   add_foreign_key "membership_plans", "users"

--- a/lib/tasks/membership_applications.rake
+++ b/lib/tasks/membership_applications.rake
@@ -57,4 +57,28 @@ namespace :membership_applications do
 
     puts "Done. Success: #{ok}, skipped: #{skipped}, failed: #{failed}."
   end
+
+  desc 'Associate sent acceptance/rejection emails with finalized applications missing outcome links (preview)'
+  task backfill_outcome_emails_preview: :environment do
+    run_backfill_outcome_emails(dry_run: true)
+  end
+
+  desc 'Associate sent acceptance/rejection emails with finalized applications missing outcome links'
+  task backfill_outcome_emails: :environment do
+    run_backfill_outcome_emails(dry_run: false)
+  end
+
+  def run_backfill_outcome_emails(dry_run:)
+    prefix = dry_run ? '[DRY RUN] ' : ''
+    puts "#{prefix}Backfilling outcome email links for finalized membership applications…"
+    puts
+
+    result = MembershipApplications::BackfillOutcomeEmails.call(dry_run: dry_run)
+
+    puts
+    puts 'Summary:'
+    puts "  Linked via queued mail: #{result.linked_queued_mail}"
+    puts "  Linked via mail log snapshot: #{result.linked_snapshot}"
+    puts "  Unmatched: #{result.unmatched}"
+  end
 end

--- a/test/controllers/application_verifications_controller_test.rb
+++ b/test/controllers/application_verifications_controller_test.rb
@@ -14,8 +14,23 @@ class ApplicationVerificationsControllerTest < ActionDispatch::IntegrationTest
     get apply_new_path
     assert_response :success
     assert_match 'Membership Application', response.body
+    assert_match 'Thank you for your interest in joining', response.body
     assert_match 'attended an open house', response.body
     assert_match 'Code of Conduct', response.body
+  end
+
+  test 'gate page renders text fragment content when configured' do
+    TextFragment.ensure_exists!(
+      key: 'application_verification_gate_intro',
+      title: 'Application Verification: Gate Introduction',
+      content: '<p>Custom gate intro text for applicants.</p>'
+    )
+
+    get apply_new_path
+
+    assert_response :success
+    assert_match 'Custom gate intro text for applicants', response.body
+    assert_no_match 'Thank you for your interest in joining', response.body
   end
 
   # ─── Validation Errors ──────────────────────────────────────────
@@ -87,6 +102,21 @@ class ApplicationVerificationsControllerTest < ActionDispatch::IntegrationTest
     assert_match 'Check Your Email', response.body
   end
 
+  test 'check_email page renders text fragment content when configured' do
+    TextFragment.ensure_exists!(
+      key: 'application_verification_check_email',
+      title: 'Application Verification: Check Email',
+      content: '<h2 class="h4 mb-3">Custom check-email heading</h2><p class="mb-4">Custom check-email body.</p>'
+    )
+
+    get apply_check_email_path
+
+    assert_response :success
+    assert_match 'Custom check-email heading', response.body
+    assert_match 'Custom check-email body', response.body
+    assert_no_match 'Check Your Email', response.body
+  end
+
   # ─── Email Verification ────────────────────────────────────────
 
   test 'valid token verifies email and redirects to application' do
@@ -102,6 +132,128 @@ class ApplicationVerificationsControllerTest < ActionDispatch::IntegrationTest
     verification.reload
     assert verification.email_verified?
     assert_not_nil verification.verified_at
+  end
+
+  test 'verify link redirects to status page when application already submitted' do
+    verification = ApplicationVerification.create!(
+      email: 'status-link@example.com',
+      confirmed_open_house: true,
+      confirmed_code_of_conduct: true
+    )
+    MembershipApplication.create!(
+      email: 'status-link@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+
+    get apply_verify_email_path(token: verification.token)
+
+    assert_redirected_to apply_application_status_path(token: verification.token)
+    assert verification.reload.email_verified?
+  end
+
+  test 'status link works after verification expires when application was submitted' do
+    verification = ApplicationVerification.create!(
+      email: 'expired-status@example.com',
+      confirmed_open_house: true,
+      confirmed_code_of_conduct: true
+    )
+    verification.update_columns(expires_at: 1.hour.ago, email_verified: true, verified_at: 1.day.ago)
+    MembershipApplication.create!(
+      email: 'expired-status@example.com',
+      status: 'submitted',
+      submitted_at: 2.days.ago
+    )
+
+    get apply_application_status_path(token: verification.token)
+
+    assert_response :success
+    assert_match 'in the queue for review', response.body
+    assert_match 'Application submitted', response.body
+    assert_match '1/3', response.body
+  end
+
+  test 'status page shows timing guidance and overdue apology' do
+    travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+      opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+      MembershipApplication.create!(
+        email: 'baseline@example.com',
+        status: 'approved',
+        submitted_at: opened_at,
+        reviewed_at: opened_at + 2.days
+      )
+      TextFragment.ensure_exists!(
+        key: MembershipApplications::ApplicantStatusTiming::OVERDUE_APOLOGY_FRAGMENT_KEY,
+        title: 'Application Status: Overdue Apology',
+        content: '<p>Sorry for the delay from the fragment.</p>'
+      )
+      verification = ApplicationVerification.create!(
+        email: 'timing-status@example.com',
+        confirmed_open_house: true,
+        confirmed_code_of_conduct: true
+      )
+      MembershipApplication.create!(
+        email: 'timing-status@example.com',
+        status: 'submitted',
+        submitted_at: 5.days.ago
+      )
+
+      get apply_application_status_path(token: verification.token)
+
+      assert_response :success
+      assert_match 'submitted', response.body
+      assert_match '5 days', response.body
+      assert_match 'review typically takes about', response.body
+      assert_match '3 days', response.body
+      assert_match 'Sorry for the delay from the fragment', response.body
+    end
+  end
+
+  test 'status page shows review begun progress when admin reviews exist' do
+    verification = ApplicationVerification.create!(
+      email: 'review-status@example.com',
+      confirmed_open_house: true,
+      confirmed_code_of_conduct: true
+    )
+    app = MembershipApplication.create!(
+      email: 'review-status@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    MembershipApplicationAcceptanceVote.create!(
+      membership_application: app,
+      user: users(:one),
+      decision: 'accept'
+    )
+
+    get apply_application_status_path(token: verification.token)
+
+    assert_response :success
+    assert_match 'being reviewed', response.body
+    assert_match 'Review process begun', response.body
+    assert_match '2/3', response.body
+  end
+
+  test 'status page shows outcome email when application is rejected' do
+    verification = ApplicationVerification.create!(
+      email: 'rejected-status@example.com',
+      confirmed_open_house: true,
+      confirmed_code_of_conduct: true
+    )
+    app = MembershipApplication.create!(
+      email: 'rejected-status@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    app.reject!(users(:one), notes: 'Not a fit right now')
+
+    get apply_application_status_path(token: verification.token)
+
+    assert_response :success
+    assert_match 'Application process complete', response.body
+    assert_match '3/3', response.body
+    assert_match 'Decision email', response.body
+    assert_match 'Not a fit right now', response.body
   end
 
   test 'invalid token redirects to gate with error' do
@@ -220,5 +372,74 @@ class ApplicationVerificationsControllerTest < ActionDispatch::IntegrationTest
 
     get apply_start_path
     assert_redirected_to apply_new_path
+  end
+
+  test 'apply start redirects to applicant status when application already submitted' do
+    verification = ApplicationVerification.create!(
+      email: 'start-status-redirect@example.com',
+      confirmed_open_house: true,
+      confirmed_code_of_conduct: true
+    )
+
+    get apply_verify_email_path(token: verification.token)
+    follow_redirect!
+    assert_response :success
+
+    MembershipApplication.create!(
+      email: 'start-status-redirect@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+
+    get apply_start_path
+
+    assert_redirected_to apply_application_status_path(token: verification.token)
+  end
+
+  test 'confirmation page links to applicant status when session has verification token' do
+    verification = ApplicationVerification.create!(
+      email: 'confirmation-status@example.com',
+      confirmed_open_house: true,
+      confirmed_code_of_conduct: true
+    )
+    verification.verify_email!
+
+    get apply_verify_email_path(token: verification.token)
+    get apply_confirmation_path
+
+    assert_response :success
+    assert_select 'a[href=?]', apply_application_status_path(token: verification.token), text: 'View application status'
+  end
+
+  test 'status page shows approved outcome email content' do
+    verification = ApplicationVerification.create!(
+      email: 'approved-status@example.com',
+      confirmed_open_house: true,
+      confirmed_code_of_conduct: true
+    )
+    queued_mail = QueuedMail.create!(
+      to: verification.email,
+      subject: 'Welcome to the space',
+      body_html: '<p>You are approved!</p>',
+      body_text: 'You are approved!',
+      reason: 'Application approved',
+      mailer_action: 'application_approved',
+      status: 'approved',
+      sent_at: Time.current
+    )
+    MembershipApplication.create!(
+      email: verification.email,
+      status: 'approved',
+      submitted_at: 1.week.ago,
+      reviewed_at: Time.current,
+      outcome_queued_mail: queued_mail
+    )
+
+    get apply_application_status_path(token: verification.token)
+
+    assert_response :success
+    assert_match 'Decision email', response.body
+    assert_match 'Welcome to the space', response.body
+    assert_match 'You are approved!', response.body
   end
 end

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -104,6 +104,25 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'button', text: 'Link member', count: 0
   end
 
+  test 'index shows average processing time for finalized applications' do
+    travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+      since = 2.months.ago
+      MembershipApplication.create!(
+        email: 'index-stats@example.com',
+        status: 'approved',
+        submitted_at: since + 1.day,
+        reviewed_at: since + 3.days
+      )
+
+      get membership_applications_path
+
+      assert_response :success
+      assert_select '.text-13', text: /Average processing time \(last 2 months\):/
+      assert_select '.text-13', text: /2 days/
+      assert_select '.text-13', text: /1 approved or rejected/
+    end
+  end
+
   test 'index under review tab does not offer link member action' do
     MembershipApplication.create!(
       email: 'review-no-link@example.com',
@@ -130,6 +149,32 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'button', text: 'Link member'
     assert_select 'button[data-ma-link-action=?]', link_user_membership_application_path(app)
+  end
+
+  test 'index and show link to applicant status page when verification exists' do
+    verification = ApplicationVerification.create!(
+      email: 'admin-status-link@example.com',
+      confirmed_open_house: true,
+      confirmed_code_of_conduct: true,
+      email_verified: true,
+      verified_at: Time.current
+    )
+    app = MembershipApplication.create!(
+      email: 'admin-status-link@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    status_path = apply_application_status_path(token: verification.token)
+
+    get membership_applications_path(status: 'submitted')
+
+    assert_response :success
+    assert_select 'a[href=?][target=_blank]', status_path, text: 'Applicant view'
+
+    get membership_application_path(app)
+
+    assert_response :success
+    assert_select 'a[href=?][target=_blank]', status_path, text: 'Applicant status'
   end
 
   test 'index search filters by query param' do
@@ -387,6 +432,7 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'approve-ok@example.com', app.user.email
     assert_equal "123 Privacy Way\nPortland, OR", app.user.mailing_address
     assert_equal '555-123-4567', app.user.phone_number
+    assert_equal qm.id, app.outcome_queued_mail_id
     assert_equal 'application_approved', qm.mailer_action
     assert_equal app.user, qm.recipient
   end

--- a/test/helpers/membership_applications_helper_test.rb
+++ b/test/helpers/membership_applications_helper_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MembershipApplicationsHelperTest < ActionView::TestCase
+  test 'membership_application_applicant_status_path returns status url when verification exists' do
+    verification = ApplicationVerification.create!(email: 'helper-status@example.com')
+    app = MembershipApplication.create!(
+      email: 'helper-status@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+
+    assert_equal apply_application_status_path(token: verification.token),
+                 membership_application_applicant_status_path(app)
+  end
+
+  test 'membership_application_applicant_status_path returns nil without verification' do
+    app = MembershipApplication.create!(
+      email: 'helper-no-verification@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+
+    assert_nil membership_application_applicant_status_path(app)
+  end
+end

--- a/test/models/application_verification_test.rb
+++ b/test/models/application_verification_test.rb
@@ -113,4 +113,47 @@ class ApplicationVerificationTest < ActiveSupport::TestCase
 
     assert_in_delta 1.week.from_now, verification.expires_at, 5.seconds
   end
+
+  test 'submitted_application returns newest non-draft application for email' do
+    verification = ApplicationVerification.create!(email: 'status-lookup@example.com')
+    draft = MembershipApplication.create!(email: 'status-lookup@example.com', status: 'draft')
+    submitted = MembershipApplication.create!(
+      email: 'status-lookup@example.com',
+      status: 'submitted',
+      submitted_at: 1.day.ago
+    )
+
+    assert_equal submitted.id, verification.submitted_application.id
+    assert_not_equal draft.id, verification.submitted_application.id
+  end
+
+  test 'status_link? is true when a submitted application exists' do
+    verification = ApplicationVerification.create!(email: 'has-status@example.com')
+    assert_not verification.status_link?
+
+    MembershipApplication.create!(
+      email: 'has-status@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+
+    assert verification.status_link?
+  end
+
+  test 'received_application? and awaiting_application? reflect submitted apps' do
+    verification = ApplicationVerification.create!(email: 'awaiting@example.com')
+
+    assert verification.awaiting_application?
+    assert_not verification.received_application?
+
+    MembershipApplication.create!(
+      email: 'awaiting@example.com',
+      status: 'approved',
+      submitted_at: Time.current,
+      reviewed_at: Time.current
+    )
+
+    assert verification.received_application?
+    assert_not verification.awaiting_application?
+  end
 end

--- a/test/models/membership_application_test.rb
+++ b/test/models/membership_application_test.rb
@@ -117,6 +117,7 @@ class MembershipApplicationTest < ActiveSupport::TestCase
     assert_equal 'pending', qm.status
     assert_equal 'application_rejected', qm.mailer_action
     assert_equal app.email, qm.to
+    assert_equal qm.id, app.outcome_queued_mail_id
     assert_includes qm.body_html, 'Does not meet requirements'
   end
 
@@ -255,5 +256,77 @@ class MembershipApplicationTest < ActiveSupport::TestCase
     assert_equal 'warning', app.ai_feedback_recommendation_badge_color
     app.ai_feedback_recommendation = 'something_else'
     assert_equal 'secondary', app.ai_feedback_recommendation_badge_color
+  end
+
+  test 'processing_time_stats averages finalized applications since cutoff' do
+    travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+      since = Time.zone.local(2026, 4, 19, 12, 0, 0)
+      opened_at = Time.zone.local(2026, 4, 20, 12, 0, 0)
+      MembershipApplication.create!(
+        email: 'processed-fast@example.com',
+        status: 'approved',
+        submitted_at: opened_at,
+        reviewed_at: opened_at + 1.day
+      )
+      MembershipApplication.create!(
+        email: 'processed-slow@example.com',
+        status: 'rejected',
+        submitted_at: opened_at,
+        reviewed_at: opened_at + 3.days
+      )
+      MembershipApplication.create!(
+        email: 'still-open@example.com',
+        status: 'submitted',
+        submitted_at: opened_at
+      )
+      MembershipApplication.create!(
+        email: 'parked-review@example.com',
+        status: 'needs_review',
+        submitted_at: opened_at,
+        reviewed_at: opened_at + 1.day
+      )
+      MembershipApplication.create!(
+        email: 'processed-old@example.com',
+        status: 'approved',
+        submitted_at: since - 10.days,
+        reviewed_at: since - 1.day
+      )
+
+      stats = MembershipApplications::ProcessingTimeStats.call(since: since)
+
+      assert_equal 2, stats[:count]
+      assert_in_delta 2.days.to_i, stats[:average_seconds], 1.0
+      assert_equal '2 days', stats[:average_label]
+    end
+  end
+
+  test 'processing_time_stats returns empty stats when no finalized applications' do
+    travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+      stats = MembershipApplications::ProcessingTimeStats.call(since: 2.months.ago)
+
+      assert_equal 0, stats[:count]
+      assert_nil stats[:average_seconds]
+      assert_nil stats[:average_label]
+    end
+  end
+
+  test 'status_page_verification returns newest verification for email' do
+    app = MembershipApplication.create!(
+      email: 'status-page-verification@example.com',
+      status: 'submitted',
+      submitted_at: Time.current
+    )
+    older = ApplicationVerification.create!(email: app.email, created_at: 2.days.ago)
+    newer = ApplicationVerification.create!(email: app.email, created_at: 1.day.ago)
+
+    assert_equal newer.id, app.status_page_verification.id
+    assert_not_equal older.id, app.status_page_verification.id
+  end
+
+  test 'status_page_verification is nil for draft applications' do
+    app = MembershipApplication.create!(email: 'draft-no-status@example.com', status: 'draft')
+    ApplicationVerification.create!(email: app.email)
+
+    assert_nil app.status_page_verification
   end
 end

--- a/test/services/membership_applications/applicant_status_test.rb
+++ b/test/services/membership_applications/applicant_status_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MembershipApplications
+  class ApplicantStatusTest < ActiveSupport::TestCase
+    test 'submitted application is stage one' do
+      app = MembershipApplication.create!(
+        email: 'status-submitted@example.com',
+        status: 'submitted',
+        submitted_at: Time.current
+      )
+
+      status = ApplicantStatus.for(app)
+
+      assert_equal :submitted, status.stage
+      assert_equal 1, status.step_number
+      assert_in_delta 33.0, status.progress_percent, 1.0
+      assert_match 'queue for review', status.headline
+    end
+
+    test 'acceptance votes move application to review begun' do
+      app = MembershipApplication.create!(
+        email: 'status-review@example.com',
+        status: 'submitted',
+        submitted_at: Time.current
+      )
+      MembershipApplicationAcceptanceVote.create!(
+        membership_application: app,
+        user: users(:one),
+        decision: 'accept'
+      )
+
+      status = ApplicantStatus.for(app)
+
+      assert_equal :review_begun, status.stage
+      assert_equal 2, status.step_number
+      assert_in_delta 67.0, status.progress_percent, 1.0
+    end
+
+    test 'approved application is complete' do
+      app = MembershipApplication.create!(
+        email: 'status-approved@example.com',
+        status: 'approved',
+        submitted_at: 1.week.ago,
+        reviewed_at: Time.current
+      )
+
+      status = ApplicantStatus.for(app)
+
+      assert_equal :complete, status.stage
+      assert_equal 3, status.step_number
+      assert_equal 100, status.progress_percent
+      assert status.complete?
+    end
+
+    test 'rejected application is complete' do
+      app = MembershipApplication.create!(
+        email: 'status-rejected@example.com',
+        status: 'rejected',
+        submitted_at: 1.week.ago,
+        reviewed_at: Time.current
+      )
+
+      assert_equal :complete, ApplicantStatus.for(app).stage
+    end
+
+    test 'under review status is review begun' do
+      app = MembershipApplication.create!(
+        email: 'status-under-review@example.com',
+        status: 'under_review',
+        submitted_at: Time.current,
+        reviewed_at: Time.current
+      )
+
+      status = ApplicantStatus.for(app)
+
+      assert_equal :review_begun, status.stage
+      assert_match 'being reviewed', status.headline
+    end
+
+    test 'tour feedback moves application to review begun' do
+      app = MembershipApplication.create!(
+        email: 'status-tour@example.com',
+        status: 'submitted',
+        submitted_at: Time.current
+      )
+      MembershipApplicationTourFeedback.create!(
+        membership_application: app,
+        user: users(:one),
+        attitude: 'Positive'
+      )
+
+      assert_equal :review_begun, ApplicantStatus.for(app).stage
+    end
+  end
+end

--- a/test/services/membership_applications/applicant_status_timing_test.rb
+++ b/test/services/membership_applications/applicant_status_timing_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MembershipApplications
+  class ApplicantStatusTimingTest < ActiveSupport::TestCase
+    test 'shows estimated review time at one point two five times recent average' do
+      travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+        opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+        MembershipApplication.create!(
+          email: 'avg-fast@example.com',
+          status: 'approved',
+          submitted_at: opened_at,
+          reviewed_at: opened_at + 2.days
+        )
+        MembershipApplication.create!(
+          email: 'avg-slow@example.com',
+          status: 'rejected',
+          submitted_at: opened_at,
+          reviewed_at: opened_at + 4.days
+        )
+        app = MembershipApplication.create!(
+          email: 'waiting-applicant@example.com',
+          status: 'submitted',
+          submitted_at: 1.day.ago
+        )
+
+        timing = ApplicantStatusTiming.for(app, now: Time.current)
+
+        assert_equal '4 days', timing[:estimate][:estimated_label]
+        assert_equal '1 day', timing[:waiting_label]
+        assert_not timing[:show_apology]
+      end
+    end
+
+    test 'shows apology when waiting longer than recent average' do
+      travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+        opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+        MembershipApplication.create!(
+          email: 'baseline@example.com',
+          status: 'approved',
+          submitted_at: opened_at,
+          reviewed_at: opened_at + 2.days
+        )
+        TextFragment.ensure_exists!(
+          key: ApplicantStatusTiming::OVERDUE_APOLOGY_FRAGMENT_KEY,
+          title: 'Application Status: Overdue Apology',
+          content: '<p>Custom overdue apology message.</p>'
+        )
+        app = MembershipApplication.create!(
+          email: 'long-wait@example.com',
+          status: 'submitted',
+          submitted_at: 5.days.ago
+        )
+
+        timing = ApplicantStatusTiming.for(app, now: Time.current)
+
+        assert timing[:show_apology]
+        assert_match 'Custom overdue apology message', timing[:apology_content]
+      end
+    end
+
+    test 'does not show apology for finalized applications' do
+      travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+        opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+        MembershipApplication.create!(
+          email: 'baseline@example.com',
+          status: 'approved',
+          submitted_at: opened_at,
+          reviewed_at: opened_at + 2.days
+        )
+        app = MembershipApplication.create!(
+          email: 'already-done@example.com',
+          status: 'approved',
+          submitted_at: 10.days.ago,
+          reviewed_at: Time.current
+        )
+
+        timing = ApplicantStatusTiming.for(app, now: Time.current)
+
+        assert_not timing[:show_apology]
+      end
+    end
+  end
+end

--- a/test/services/membership_applications/backfill_outcome_emails_test.rb
+++ b/test/services/membership_applications/backfill_outcome_emails_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MembershipApplications
+  class BackfillOutcomeEmailsTest < ActiveSupport::TestCase
+    test 'prefers queued mail sent closest to reviewed_at' do
+      reviewed_at = Time.zone.local(2026, 5, 10, 12, 0, 0)
+      app = MembershipApplication.create!(
+        email: 'pick-closest@example.com',
+        status: 'rejected',
+        submitted_at: reviewed_at - 1.day,
+        reviewed_at: reviewed_at
+      )
+      older = QueuedMail.create!(
+        to: app.email,
+        subject: 'Older rejection',
+        body_html: '<p>Older</p>',
+        body_text: 'Older',
+        reason: 'Application rejected',
+        mailer_action: 'application_rejected',
+        status: 'approved',
+        sent_at: reviewed_at - 2.days
+      )
+      match = QueuedMail.create!(
+        to: app.email,
+        subject: 'Matching rejection',
+        body_html: '<p>Match</p>',
+        body_text: 'Match',
+        reason: 'Application rejected',
+        mailer_action: 'application_rejected',
+        status: 'approved',
+        sent_at: reviewed_at + 10.minutes
+      )
+
+      result = BackfillOutcomeEmails.call
+
+      assert_equal 1, result.linked_queued_mail
+      assert_equal match.id, app.reload.outcome_queued_mail_id
+      assert_not_equal older.id, app.outcome_queued_mail_id
+    end
+  end
+end

--- a/test/services/membership_applications/outcome_email_recorder_test.rb
+++ b/test/services/membership_applications/outcome_email_recorder_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MembershipApplications
+  class OutcomeEmailRecorderTest < ActiveSupport::TestCase
+    test 'assign! links queued mail to application' do
+      app = MembershipApplication.create!(
+        email: 'recorder-queued@example.com',
+        status: 'rejected',
+        submitted_at: Time.current,
+        reviewed_at: Time.current
+      )
+      queued_mail = QueuedMail.create!(
+        to: app.email,
+        subject: 'Decision',
+        body_html: '<p>Rejected</p>',
+        body_text: 'Rejected',
+        reason: 'Application rejected',
+        mailer_action: 'application_rejected',
+        status: 'pending'
+      )
+
+      OutcomeEmailRecorder.assign!(app, queued_mail)
+
+      assert_equal queued_mail.id, app.reload.outcome_queued_mail_id
+    end
+
+    test 'assign! stores immediate delivery snapshot' do
+      app = MembershipApplication.create!(
+        email: 'recorder-immediate@example.com',
+        status: 'approved',
+        submitted_at: Time.current,
+        reviewed_at: Time.current
+      )
+      delivery = QueuedMail::ImmediateDelivery.new(
+        to: app.email,
+        subject: 'Welcome',
+        body_html: '<p>Approved</p>',
+        body_text: 'Approved',
+        email_template: nil
+      )
+
+      OutcomeEmailRecorder.assign!(app, delivery)
+
+      app.reload
+      assert_nil app.outcome_queued_mail_id
+      assert_equal 'Welcome', app.outcome_email_subject
+      assert_includes app.outcome_email_body_html, 'Approved'
+    end
+
+    test 'for_display prefers queued mail over snapshot fields' do
+      queued_mail = QueuedMail.create!(
+        to: 'display@example.com',
+        subject: 'Queued subject',
+        body_html: '<p>Queued body</p>',
+        body_text: 'Queued body',
+        reason: 'Application rejected',
+        mailer_action: 'application_rejected',
+        status: 'pending'
+      )
+      app = MembershipApplication.create!(
+        email: 'display@example.com',
+        status: 'rejected',
+        submitted_at: Time.current,
+        reviewed_at: Time.current,
+        outcome_queued_mail: queued_mail,
+        outcome_email_subject: 'Snapshot subject',
+        outcome_email_body_html: '<p>Snapshot body</p>'
+      )
+
+      display = OutcomeEmailRecorder.for_display(app)
+
+      assert_equal 'Queued subject', display[:subject]
+      assert_includes display[:body_html], 'Queued body'
+    end
+
+    test 'for_display falls back to snapshot fields' do
+      app = MembershipApplication.create!(
+        email: 'display-snapshot@example.com',
+        status: 'approved',
+        submitted_at: Time.current,
+        reviewed_at: Time.current,
+        outcome_email_subject: 'Snapshot subject',
+        outcome_email_body_html: '<p>Snapshot body</p>'
+      )
+
+      display = OutcomeEmailRecorder.for_display(app)
+
+      assert_equal 'Snapshot subject', display[:subject]
+      assert_includes display[:body_html], 'Snapshot body'
+    end
+  end
+end

--- a/test/services/membership_applications/processing_time_stats_test.rb
+++ b/test/services/membership_applications/processing_time_stats_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MembershipApplications
+  class ProcessingTimeStatsTest < ActiveSupport::TestCase
+    test 'call averages finalized applications decided since cutoff' do
+      travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+        since = Time.zone.local(2026, 4, 20, 12, 0, 0)
+        opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+        MembershipApplication.create!(
+          email: 'stats-fast@example.com',
+          status: 'approved',
+          submitted_at: opened_at,
+          reviewed_at: opened_at + 1.day
+        )
+        MembershipApplication.create!(
+          email: 'stats-slow@example.com',
+          status: 'rejected',
+          submitted_at: opened_at,
+          reviewed_at: opened_at + 3.days
+        )
+        MembershipApplication.create!(
+          email: 'stats-open@example.com',
+          status: 'submitted',
+          submitted_at: opened_at
+        )
+        MembershipApplication.create!(
+          email: 'stats-old@example.com',
+          status: 'approved',
+          submitted_at: since - 10.days,
+          reviewed_at: since - 1.day
+        )
+
+        stats = ProcessingTimeStats.call(since: since)
+
+        assert_equal 2, stats[:count]
+        assert_in_delta 2.days.to_i, stats[:average_seconds], 1.0
+        assert_equal '2 days', stats[:average_label]
+      end
+    end
+
+    test 'applicant_estimate multiplies average by one point two five' do
+      travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+        opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+        MembershipApplication.create!(
+          email: 'estimate-base@example.com',
+          status: 'approved',
+          submitted_at: opened_at,
+          reviewed_at: opened_at + 2.days
+        )
+
+        stats = ProcessingTimeStats.applicant_estimate
+
+        assert_equal 1, stats[:count]
+        assert_in_delta 2.5.days.to_i, stats[:estimated_seconds], 1.0
+        assert_equal '3 days', stats[:estimated_label]
+      end
+    end
+
+    test 'format_duration handles minutes hours and days' do
+      assert_equal 'less than a minute', ProcessingTimeStats.format_duration(30)
+      assert_equal '5 minutes', ProcessingTimeStats.format_duration(300)
+      assert_equal '2 hours', ProcessingTimeStats.format_duration(7200)
+      assert_equal '4 days', ProcessingTimeStats.format_duration(4.days.to_i)
+    end
+  end
+end

--- a/test/tasks/membership_applications_backfill_outcome_emails_test.rb
+++ b/test/tasks/membership_applications_backfill_outcome_emails_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MembershipApplicationsBackfillOutcomeEmailsTaskTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks
+    @task = Rake::Task['membership_applications:backfill_outcome_emails']
+    @task.reenable
+  end
+
+  test 'links sent queued rejection mail to finalized application' do
+    reviewed_at = Time.zone.local(2026, 5, 1, 12, 0, 0)
+    app = MembershipApplication.create!(
+      email: 'backfill-reject@example.com',
+      status: 'rejected',
+      submitted_at: reviewed_at - 2.days,
+      reviewed_at: reviewed_at
+    )
+    queued_mail = QueuedMail.create!(
+      to: app.email,
+      subject: 'Application update',
+      body_html: '<p>We are unable to approve your application.</p>',
+      body_text: 'We are unable to approve your application.',
+      reason: 'Application rejected',
+      mailer_action: 'application_rejected',
+      status: 'approved',
+      sent_at: reviewed_at + 5.minutes
+    )
+
+    @task.invoke
+
+    assert_equal queued_mail.id, app.reload.outcome_queued_mail_id
+  end
+
+  test 'links direct mail log snapshot when no queued mail exists' do
+    reviewed_at = Time.zone.local(2026, 5, 2, 12, 0, 0)
+    app = MembershipApplication.create!(
+      email: 'backfill-direct@example.com',
+      status: 'approved',
+      submitted_at: reviewed_at - 1.day,
+      reviewed_at: reviewed_at
+    )
+    MailLogEntry.log_direct_delivery!(
+      to: app.email,
+      subject: 'Welcome aboard',
+      mailer_class: 'MemberMailer',
+      mailer_action: 'application_approved',
+      body_html: '<p>Your application was approved.</p>'
+    )
+
+    @task.invoke
+
+    app.reload
+    assert_nil app.outcome_queued_mail_id
+    assert_equal 'Welcome aboard', app.outcome_email_subject
+    assert_includes app.outcome_email_body_html, 'approved'
+  end
+
+  test 'skips applications that already have outcome links' do
+    existing_mail = QueuedMail.create!(
+      to: 'already-linked@example.com',
+      subject: 'Existing',
+      body_html: '<p>Existing</p>',
+      body_text: 'Existing',
+      reason: 'Application rejected',
+      mailer_action: 'application_rejected',
+      status: 'approved',
+      sent_at: Time.current
+    )
+    app = MembershipApplication.create!(
+      email: 'already-linked@example.com',
+      status: 'rejected',
+      submitted_at: 2.days.ago,
+      reviewed_at: 1.day.ago,
+      outcome_queued_mail: existing_mail
+    )
+    duplicate_mail = QueuedMail.create!(
+      to: app.email,
+      subject: 'Duplicate',
+      body_html: '<p>Duplicate</p>',
+      body_text: 'Duplicate',
+      reason: 'Application rejected',
+      mailer_action: 'application_rejected',
+      status: 'approved',
+      sent_at: Time.current
+    )
+
+    @task.invoke
+
+    assert_equal existing_mail.id, app.reload.outcome_queued_mail_id
+    assert_not_equal duplicate_mail.id, app.outcome_queued_mail_id
+  end
+end


### PR DESCRIPTION
## Summary

- Add a reusable applicant status page (`/apply/new/status/:token`) with a 3-step progress bar (submitted → review begun → complete), estimated review time (recent average × 1.25), wait duration, and overdue apology from a text fragment when wait exceeds the raw average.
- Verification links redirect to the status page after submit; approve/reject stores the decision email snapshot on the application; admin index/show link to the applicant status page; admin index shows average processing time for the last two months.
- Move check-email and gate intro copy to editable text fragments (seeds + migrations); add rake tasks to backfill outcome emails for previously sent acceptance/rejection messages.

## Test plan

- [x] Full test suite: 1330 runs, 0 failures
- [x] RuboCop clean
- [ ] Submit an application and confirm status page shows progress stages as review advances
- [ ] Approve/reject an application and confirm decision email appears on status page
- [ ] Verify admin index shows average processing time subtitle
- [ ] Run `membership_applications:backfill_outcome_emails_preview` then `backfill_outcome_emails` on staging if needed


Made with [Cursor](https://cursor.com)