### PR TITLE
Use last month for application review time stats

### DIFF
--- a/app/services/membership_applications/processing_time_stats.rb
+++ b/app/services/membership_applications/processing_time_stats.rb
@@ -1,8 +1,9 @@
 module MembershipApplications
   class ProcessingTimeStats
+    RECENT_WINDOW = 1.month
     APPLICANT_ESTIMATE_MULTIPLIER = 1.25
 
-    def self.call(since: 2.months.ago)
+    def self.call(since: RECENT_WINDOW.ago)
       new(since: since).call
     end
 
@@ -24,7 +25,7 @@ module MembershipApplications
       end
     end
 
-    def self.applicant_estimate(since: 2.months.ago, multiplier: APPLICANT_ESTIMATE_MULTIPLIER)
+    def self.applicant_estimate(since: RECENT_WINDOW.ago, multiplier: APPLICANT_ESTIMATE_MULTIPLIER)
       stats = call(since: since)
       average_seconds = stats[:average_seconds]
       return stats.merge(estimated_seconds: nil, estimated_label: nil) unless average_seconds

--- a/app/views/application_verifications/status.html.erb
+++ b/app/views/application_verifications/status.html.erb
@@ -20,7 +20,7 @@
             </p>
             <% if @timing[:estimate][:estimated_label].present? %>
               <p class="mb-0 text-secondary">
-                Based on applications reviewed in the last two months, review typically takes about
+                Based on applications reviewed in the last month, review typically takes about
                 <span class="text-body"><%= @timing[:estimate][:estimated_label] %></span>.
               </p>
             <% end %>

--- a/app/views/membership_applications/index.html.erb
+++ b/app/views/membership_applications/index.html.erb
@@ -5,11 +5,11 @@
     <h1 class="h-page-title mb-0">Membership Applications</h1>
     <div class="text-13 text-secondary mt-1">
       <% if @processing_time_stats[:count].positive? %>
-        Average processing time (last 2 months):
+        Average processing time (last month):
         <span class="text-body"><%= @processing_time_stats[:average_label] %></span>
         <span class="text-secondary"> · <%= @processing_time_stats[:count] %> approved or rejected</span>
       <% else %>
-        <span class="text-secondary">No applications approved or rejected in the last 2 months</span>
+        <span class="text-secondary">No applications approved or rejected in the last month</span>
       <% end %>
     </div>
   </div>

--- a/test/controllers/application_verifications_controller_test.rb
+++ b/test/controllers/application_verifications_controller_test.rb
@@ -175,7 +175,7 @@ class ApplicationVerificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'status page shows timing guidance and overdue apology' do
     travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
-      opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+      opened_at = Time.zone.local(2026, 5, 21, 12, 0, 0)
       MembershipApplication.create!(
         email: 'baseline@example.com',
         status: 'approved',

--- a/test/controllers/membership_applications_controller_test.rb
+++ b/test/controllers/membership_applications_controller_test.rb
@@ -106,7 +106,7 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'index shows average processing time for finalized applications' do
     travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
-      since = 2.months.ago
+      since = 1.month.ago
       MembershipApplication.create!(
         email: 'index-stats@example.com',
         status: 'approved',
@@ -117,7 +117,7 @@ class MembershipApplicationsControllerTest < ActionDispatch::IntegrationTest
       get membership_applications_path
 
       assert_response :success
-      assert_select '.text-13', text: /Average processing time \(last 2 months\):/
+      assert_select '.text-13', text: /Average processing time \(last month\):/
       assert_select '.text-13', text: /2 days/
       assert_select '.text-13', text: /1 approved or rejected/
     end

--- a/test/models/membership_application_test.rb
+++ b/test/models/membership_application_test.rb
@@ -302,7 +302,7 @@ class MembershipApplicationTest < ActiveSupport::TestCase
 
   test 'processing_time_stats returns empty stats when no finalized applications' do
     travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
-      stats = MembershipApplications::ProcessingTimeStats.call(since: 2.months.ago)
+      stats = MembershipApplications::ProcessingTimeStats.call(since: 1.month.ago)
 
       assert_equal 0, stats[:count]
       assert_nil stats[:average_seconds]

--- a/test/services/membership_applications/applicant_status_timing_test.rb
+++ b/test/services/membership_applications/applicant_status_timing_test.rb
@@ -6,7 +6,7 @@ module MembershipApplications
   class ApplicantStatusTimingTest < ActiveSupport::TestCase
     test 'shows estimated review time at one point two five times recent average' do
       travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
-        opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+        opened_at = Time.zone.local(2026, 5, 21, 12, 0, 0)
         MembershipApplication.create!(
           email: 'avg-fast@example.com',
           status: 'approved',
@@ -35,7 +35,7 @@ module MembershipApplications
 
     test 'shows apology when waiting longer than recent average' do
       travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
-        opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+        opened_at = Time.zone.local(2026, 5, 21, 12, 0, 0)
         MembershipApplication.create!(
           email: 'baseline@example.com',
           status: 'approved',
@@ -62,7 +62,7 @@ module MembershipApplications
 
     test 'does not show apology for finalized applications' do
       travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
-        opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+        opened_at = Time.zone.local(2026, 5, 21, 12, 0, 0)
         MembershipApplication.create!(
           email: 'baseline@example.com',
           status: 'approved',

--- a/test/services/membership_applications/processing_time_stats_test.rb
+++ b/test/services/membership_applications/processing_time_stats_test.rb
@@ -42,7 +42,7 @@ module MembershipApplications
 
     test 'applicant_estimate multiplies average by one point two five' do
       travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
-        opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+        opened_at = Time.zone.local(2026, 5, 21, 12, 0, 0)
         MembershipApplication.create!(
           email: 'estimate-base@example.com',
           status: 'approved',
@@ -55,6 +55,30 @@ module MembershipApplications
         assert_equal 1, stats[:count]
         assert_in_delta 2.5.days.to_i, stats[:estimated_seconds], 1.0
         assert_equal '3 days', stats[:estimated_label]
+      end
+    end
+
+    test 'default window excludes finalized applications older than one month' do
+      travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+        recent_opened_at = Time.zone.local(2026, 5, 21, 12, 0, 0)
+        old_opened_at = Time.zone.local(2026, 4, 21, 12, 0, 0)
+        MembershipApplication.create!(
+          email: 'recent-stats@example.com',
+          status: 'approved',
+          submitted_at: recent_opened_at,
+          reviewed_at: recent_opened_at + 2.days
+        )
+        MembershipApplication.create!(
+          email: 'old-stats@example.com',
+          status: 'approved',
+          submitted_at: old_opened_at,
+          reviewed_at: old_opened_at + 10.days
+        )
+
+        stats = ProcessingTimeStats.call
+
+        assert_equal 1, stats[:count]
+        assert_equal '2 days', stats[:average_label]
       end
     end
 


### PR DESCRIPTION
## Summary

- Narrow `ProcessingTimeStats` default window from two months to one month (`RECENT_WINDOW = 1.month`).
- Update admin index subtitle and applicant status page copy to say "last month" instead of "last 2 months" / "last two months".

## Test plan

- [x] `processing_time_stats_test.rb` — includes new test excluding apps older than one month
- [x] `applicant_status_timing_test.rb`, controller/model tests updated
- [ ] Admin applications index shows "Average processing time (last month)"
- [ ] Applicant status page estimate line references last month


Made with [Cursor](https://cursor.com)