### PR TITLE
Cap applicant review time estimates at membership setting

### DIFF
--- a/app/controllers/membership_settings_controller.rb
+++ b/app/controllers/membership_settings_controller.rb
@@ -24,6 +24,7 @@ class MembershipSettingsController < AdminController
                                          invitation_expiry_hours login_link_expiry_hours
                                          admin_login_link_expiry_minutes
                                          application_verification_expiry_hours
-                                         manual_payment_due_soon_days])
+                                         manual_payment_due_soon_days
+                                         application_review_time_cap_days])
   end
 end

--- a/app/models/membership_setting.rb
+++ b/app/models/membership_setting.rb
@@ -6,6 +6,7 @@ class MembershipSetting < ApplicationRecord
   validates :admin_login_link_expiry_minutes, presence: true, numericality: { greater_than: 0 }
   validates :application_verification_expiry_hours, presence: true, numericality: { greater_than: 0 }
   validates :manual_payment_due_soon_days, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :application_review_time_cap_days, presence: true, numericality: { greater_than: 0 }
 
   # Singleton pattern - only one row should exist
   def self.instance
@@ -16,7 +17,8 @@ class MembershipSetting < ApplicationRecord
       login_link_expiry_hours: 180,
       admin_login_link_expiry_minutes: 15,
       application_verification_expiry_hours: 24,
-      manual_payment_due_soon_days: 7
+      manual_payment_due_soon_days: 7,
+      application_review_time_cap_days: 15
     )
   end
 
@@ -47,6 +49,10 @@ class MembershipSetting < ApplicationRecord
 
   def self.manual_payment_due_soon_days
     instance.manual_payment_due_soon_days
+  end
+
+  def self.application_review_time_cap_days
+    instance.application_review_time_cap_days
   end
 
   def self.use_builtin_membership_application?

--- a/app/services/membership_applications/processing_time_stats.rb
+++ b/app/services/membership_applications/processing_time_stats.rb
@@ -30,11 +30,18 @@ module MembershipApplications
       average_seconds = stats[:average_seconds]
       return stats.merge(estimated_seconds: nil, estimated_label: nil) unless average_seconds
 
-      estimated_seconds = average_seconds * multiplier
+      estimated_seconds = cap_applicant_estimate_seconds(average_seconds * multiplier)
       stats.merge(
         estimated_seconds: estimated_seconds,
         estimated_label: format_duration(estimated_seconds)
       )
+    end
+
+    def self.cap_applicant_estimate_seconds(seconds)
+      return nil if seconds.nil?
+
+      cap_seconds = MembershipSetting.application_review_time_cap_days.days.to_i
+      [seconds, cap_seconds].min
     end
 
     def initialize(since:)

--- a/app/views/membership_settings/edit.html.erb
+++ b/app/views/membership_settings/edit.html.erb
@@ -101,6 +101,14 @@
             <div class="form-text">How long the email verification link for membership applications remains valid.</div>
           </div>
 
+          <div class="mb-4">
+            <%= f.label :application_review_time_cap_days, "Application review time cap (days)", class: "form-label" %>
+            <%= f.number_field :application_review_time_cap_days, class: "form-control", min: 1, style: "max-width: 150px;" %>
+            <div class="form-text">
+              Maximum review time shown to applicants on the status page. Admins still see the actual average from recent reviews.
+            </div>
+          </div>
+
           <div class="d-flex gap-2">
             <%= f.submit "Save Settings", class: "btn btn-primary" %>
             <%= link_to "Cancel", membership_settings_path, class: "btn btn-outline-secondary" %>
@@ -142,6 +150,10 @@
         <p class="small text-muted mb-0">
           <strong>Application Email Verification:</strong> When someone starts a membership application,
           they must verify their email address. The verification link expires after this many hours.
+        </p>
+        <p class="small text-muted mb-0 mt-2">
+          <strong>Application review time cap:</strong> The estimated review time on the applicant status page
+          never exceeds this many days, even when recent reviews took longer.
         </p>
       </div>
     </div>

--- a/app/views/membership_settings/show.html.erb
+++ b/app/views/membership_settings/show.html.erb
@@ -66,6 +66,12 @@
             <% end %>
             <div class="form-text">How long application email verification links remain valid.</div>
           </dd>
+
+          <dt class="col-sm-6 mt-3">Application review time cap</dt>
+          <dd class="col-sm-6 mt-3">
+            <strong><%= @membership_setting.application_review_time_cap_days %></strong> <%= 'day'.pluralize(@membership_setting.application_review_time_cap_days) %>
+            <div class="form-text">Maximum review time shown to applicants on the status page. Admins still see the actual average.</div>
+          </dd>
         </dl>
       </div>
     </div>
@@ -103,6 +109,10 @@
         <p class="small text-muted mb-0">
           <strong>Application Email Verification:</strong> When someone starts a membership application,
           they must verify their email address. The verification link expires after this many hours.
+        </p>
+        <p class="small text-muted mb-0 mt-2">
+          <strong>Application review time cap:</strong> The estimated review time on the applicant status page
+          never exceeds this many days, even when recent reviews took longer.
         </p>
       </div>
     </div>

--- a/db/migrate/20260619150000_add_application_review_time_cap_days_to_membership_settings.rb
+++ b/db/migrate/20260619150000_add_application_review_time_cap_days_to_membership_settings.rb
@@ -1,0 +1,5 @@
+class AddApplicationReviewTimeCapDaysToMembershipSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :membership_settings, :application_review_time_cap_days, :integer, default: 15, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_19_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_19_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -594,6 +594,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_140000) do
 
   create_table "membership_settings", force: :cascade do |t|
     t.integer "admin_login_link_expiry_minutes", default: 15, null: false
+    t.integer "application_review_time_cap_days", default: 15, null: false
     t.integer "application_verification_expiry_hours", default: 24, null: false
     t.datetime "created_at", null: false
     t.integer "invitation_expiry_hours", default: 72, null: false

--- a/test/controllers/application_verifications_controller_test.rb
+++ b/test/controllers/application_verifications_controller_test.rb
@@ -209,6 +209,37 @@ class ApplicationVerificationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'status page shows capped review estimate without mentioning cap' do
+    travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+      MembershipSetting.instance.update!(application_review_time_cap_days: 15)
+      opened_at = Time.zone.local(2026, 5, 21, 12, 0, 0)
+      MembershipApplication.create!(
+        email: 'slow-baseline@example.com',
+        status: 'approved',
+        submitted_at: opened_at,
+        reviewed_at: opened_at + 14.days
+      )
+      verification = ApplicationVerification.create!(
+        email: 'slow-status@example.com',
+        confirmed_open_house: true,
+        confirmed_code_of_conduct: true
+      )
+      MembershipApplication.create!(
+        email: 'slow-status@example.com',
+        status: 'submitted',
+        submitted_at: 1.day.ago
+      )
+
+      get apply_application_status_path(token: verification.token)
+
+      assert_response :success
+      assert_match 'review typically takes about', response.body
+      assert_match '15 days', response.body
+      assert_no_match '18 days', response.body
+      assert_no_match '19 days', response.body
+    end
+  end
+
   test 'status page shows review begun progress when admin reviews exist' do
     verification = ApplicationVerification.create!(
       email: 'review-status@example.com',

--- a/test/controllers/membership_settings_controller_test.rb
+++ b/test/controllers/membership_settings_controller_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MembershipSettingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+    sign_in_as_admin
+    @membership_setting = MembershipSetting.instance
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+  end
+
+  test 'show displays application review time cap' do
+    @membership_setting.update!(application_review_time_cap_days: 15)
+
+    get membership_settings_url
+
+    assert_response :success
+    assert_match 'Application review time cap', response.body
+    assert_select 'dt', text: 'Application review time cap'
+    assert_select 'dd strong', text: '15'
+  end
+
+  test 'update saves application review time cap' do
+    patch membership_settings_url, params: {
+      membership_setting: {
+        payment_grace_period_days: @membership_setting.payment_grace_period_days,
+        reactivation_grace_period_months: @membership_setting.reactivation_grace_period_months,
+        invitation_expiry_hours: @membership_setting.invitation_expiry_hours,
+        login_link_expiry_hours: @membership_setting.login_link_expiry_hours,
+        admin_login_link_expiry_minutes: @membership_setting.admin_login_link_expiry_minutes,
+        application_verification_expiry_hours: @membership_setting.application_verification_expiry_hours,
+        manual_payment_due_soon_days: @membership_setting.manual_payment_due_soon_days,
+        application_review_time_cap_days: 10
+      }
+    }
+
+    assert_redirected_to membership_settings_url
+    assert_equal 10, @membership_setting.reload.application_review_time_cap_days
+  end
+
+  private
+
+  def sign_in_as_admin
+    account = local_accounts(:active_admin)
+    post local_login_path, params: {
+      session: { email: account.email, password: 'localpassword123' }
+    }
+  end
+end

--- a/test/services/membership_applications/processing_time_stats_test.rb
+++ b/test/services/membership_applications/processing_time_stats_test.rb
@@ -88,5 +88,44 @@ module MembershipApplications
       assert_equal '2 hours', ProcessingTimeStats.format_duration(7200)
       assert_equal '4 days', ProcessingTimeStats.format_duration(4.days.to_i)
     end
+
+    test 'applicant_estimate caps reported time at membership setting' do
+      travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+        MembershipSetting.instance.update!(application_review_time_cap_days: 15)
+        opened_at = Time.zone.local(2026, 5, 21, 12, 0, 0)
+        MembershipApplication.create!(
+          email: 'slow-review@example.com',
+          status: 'approved',
+          submitted_at: opened_at,
+          reviewed_at: opened_at + 14.days
+        )
+
+        estimate = ProcessingTimeStats.applicant_estimate
+        admin_stats = ProcessingTimeStats.call
+
+        assert_equal '14 days', admin_stats[:average_label]
+        assert_equal 15.days.to_i, estimate[:estimated_seconds]
+        assert_equal '15 days', estimate[:estimated_label]
+        assert_in_delta 14.days.to_i, estimate[:average_seconds], 1.0
+      end
+    end
+
+    test 'applicant_estimate leaves estimate unchanged when below cap' do
+      travel_to Time.zone.local(2026, 6, 19, 12, 0, 0) do
+        MembershipSetting.instance.update!(application_review_time_cap_days: 15)
+        opened_at = Time.zone.local(2026, 5, 21, 12, 0, 0)
+        MembershipApplication.create!(
+          email: 'fast-review@example.com',
+          status: 'approved',
+          submitted_at: opened_at,
+          reviewed_at: opened_at + 2.days
+        )
+
+        estimate = ProcessingTimeStats.applicant_estimate
+
+        assert_in_delta 2.5.days.to_i, estimate[:estimated_seconds], 1.0
+        assert_equal '3 days', estimate[:estimated_label]
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Add `application_review_time_cap_days` to Membership Settings (default 15 days), editable on the membership settings show/edit pages.
- Applicant status page estimates are capped at this value after the ×1.25 multiplier — applicants see the capped time with no indication it was capped.
- Admin applications index continues to show the actual uncapped average from recent reviews.

## Test plan

- [x] Full test suite: 1336 runs, 0 failures
- [x] RuboCop clean
- [ ] Set cap to 10 days in Membership Settings and confirm applicant status page never shows more than 10 days
- [ ] Confirm admin applications index still shows real average when reviews are slower than the cap


Made with [Cursor](https://cursor.com)