### PR TITLE
Add print buttons to parking permit and ticket lists

### DIFF
--- a/app/controllers/concerns/parking_notice_printing.rb
+++ b/app/controllers/concerns/parking_notice_printing.rb
@@ -1,0 +1,36 @@
+module ParkingNoticePrinting
+  extend ActiveSupport::Concern
+
+  private
+
+  def parking_notice_pdf_and_cups_options(parking_notice, printer)
+    force_letter = params[:layout].to_s.in?(%w[letter full_page])
+    if !force_letter && printer.thermal_receipt_printer?
+      pdf = ParkingNoticeReceiptPdf.new(
+        parking_notice,
+        layout: :thermal,
+        thermal_width_mm: printer.thermal_roll_width_mm
+      )
+      [pdf, CupsService::THERMAL_PDF_OPTIONS]
+    else
+      [ParkingNoticeReceiptPdf.new(parking_notice, layout: :full_page), {}]
+    end
+  end
+
+  def print_parking_notice(parking_notice, printer)
+    pdf, cups_options = parking_notice_pdf_and_cups_options(parking_notice, printer)
+
+    CupsService.print_data(
+      pdf.render,
+      printer.cups_printer_name,
+      cups_printer_server: printer.cups_printer_server,
+      filename: "parking_notice_#{parking_notice.id}.pdf",
+      options: cups_options
+    )
+  end
+
+  def print_parking_notice_to_printer(parking_notice, printer)
+    cookies[:last_printer_id] = { value: printer.id.to_s, expires: 1.year.from_now }
+    print_parking_notice(parking_notice, printer)
+  end
+end

--- a/app/controllers/member_parking_permits_controller.rb
+++ b/app/controllers/member_parking_permits_controller.rb
@@ -1,11 +1,15 @@
 class MemberParkingPermitsController < AuthenticatedController
+  include ParkingNoticePrinting
+
   MAX_MEMBER_PERMIT_DURATION = 2.weeks
 
-  before_action :set_owned_notice, only: %i[show edit update close request_clearance add_note]
-  before_action :require_owned_permit, only: %i[edit update]
+  before_action :set_owned_notice, only: %i[show edit update close request_clearance add_note print_notice]
+  before_action :require_owned_permit, only: %i[edit update print_notice]
 
   # Members may view their own permits and tickets.
-  def show; end
+  def show
+    @printers = Printer.ordered
+  end
 
   def new
     @parking_notice = ParkingNotice.new(
@@ -80,6 +84,17 @@ class MemberParkingPermitsController < AuthenticatedController
     @parking_notice.request_clearance!(current_user)
     redirect_to user_path(current_user, tab: :parking),
                 notice: 'Clearance requested. An admin will review your request.'
+  end
+
+  def print_notice
+    printer = Printer.find(params[:printer_id])
+    job_id = print_parking_notice_to_printer(@parking_notice, printer)
+
+    redirect_to member_parking_permit_path(@parking_notice),
+                notice: "Printed to #{printer.name} (job #{job_id})."
+  rescue CupsService::PrintError => e
+    redirect_to member_parking_permit_path(@parking_notice),
+                alert: "Print failed: #{e.message}"
   end
 
   # Members may add a note to the history of their own notice.

--- a/app/controllers/parking_notices_controller.rb
+++ b/app/controllers/parking_notices_controller.rb
@@ -1,5 +1,6 @@
 class ParkingNoticesController < AdminController
   include Pagy::Method
+  include ParkingNoticePrinting
 
   before_action :set_parking_notice,
                 only: %i[show edit update clear add_note download_pdf print_notice remove_photo download_photo]
@@ -18,6 +19,7 @@ class ParkingNoticesController < AdminController
     }
 
     @pagy, @parking_notices = pagy(@parking_notices, limit: 25)
+    @printers = Printer.ordered
   end
 
   def show
@@ -113,9 +115,7 @@ class ParkingNoticesController < AdminController
 
   def print_notice
     printer = Printer.find(params[:printer_id])
-    cookies[:last_printer_id] = { value: printer.id.to_s, expires: 1.year.from_now }
-
-    job_id = print_parking_notice(printer)
+    job_id = print_parking_notice_to_printer(@parking_notice, printer)
 
     redirect_to parking_notice_path(@parking_notice),
                 notice: "Printed to #{printer.name} (job #{job_id})."
@@ -141,32 +141,6 @@ class ParkingNoticesController < AdminController
   end
 
   private
-
-  def parking_notice_pdf_and_cups_options(printer)
-    force_letter = params[:layout].to_s.in?(%w[letter full_page])
-    if !force_letter && printer.thermal_receipt_printer?
-      pdf = ParkingNoticeReceiptPdf.new(
-        @parking_notice,
-        layout: :thermal,
-        thermal_width_mm: printer.thermal_roll_width_mm
-      )
-      [pdf, CupsService::THERMAL_PDF_OPTIONS]
-    else
-      [ParkingNoticeReceiptPdf.new(@parking_notice, layout: :full_page), {}]
-    end
-  end
-
-  def print_parking_notice(printer)
-    pdf, cups_options = parking_notice_pdf_and_cups_options(printer)
-
-    CupsService.print_data(
-      pdf.render,
-      printer.cups_printer_name,
-      cups_printer_server: printer.cups_printer_server,
-      filename: "parking_notice_#{@parking_notice.id}.pdf",
-      options: cups_options
-    )
-  end
 
   def set_parking_notice
     @parking_notice = ParkingNotice.find(params[:id])
@@ -210,8 +184,7 @@ class ParkingNoticesController < AdminController
       return
     end
 
-    cookies[:last_printer_id] = { value: printer.id.to_s, expires: 1.year.from_now }
-    job_id = print_parking_notice(printer)
+    job_id = print_parking_notice_to_printer(@parking_notice, printer)
 
     redirect_to redirect_path,
                 notice: "Parking permit created and printed to #{printer.name} (job #{job_id})."

--- a/app/views/member_parking_permits/show.html.erb
+++ b/app/views/member_parking_permits/show.html.erb
@@ -23,11 +23,24 @@
         <% end %>
       <% end %>
     <% end %>
+    <% if @parking_notice.permit? %>
+      <%= render 'shared/printer_print_button',
+          notice: @parking_notice,
+          printers: @printers,
+          print_route: :print_notice_member_parking_permit_path %>
+    <% end %>
     <%= link_to user_path(current_user, tab: :parking), class: 'btn btn-outline-secondary' do %>
       <i class="bi bi-arrow-left me-1"></i> Back
     <% end %>
   </div>
 </div>
+
+<% if @parking_notice.permit? && @printers.any? %>
+  <p class="text-12 text-secondary mb-3">
+    Parking print jobs use each printer's receipt paper setting configured by staff.
+    Choose the thermal roll width on the printer so receipts fill the roll instead of shrinking.
+  </p>
+<% end %>
 
 <% if @parking_notice.ticket? %>
   <p class="text-secondary mb-3">This parking ticket was issued by staff. Contact a member of the team if you have questions.</p>

--- a/app/views/parking_notices/index.html.erb
+++ b/app/views/parking_notices/index.html.erb
@@ -91,7 +91,15 @@
                 <span class="badge text-bg-<%= notice.status_badge_color %>-subtle"><%= notice.status_display %></span>
               </td>
               <td class="text-end">
-                <%= link_to "View", parking_notice_path(notice), class: "btn btn-sm btn-outline-secondary" %>
+                <div class="d-flex gap-1 justify-content-end align-items-center">
+                  <%= link_to "View", parking_notice_path(notice), class: "btn btn-sm btn-outline-secondary" %>
+                  <%= render 'shared/printer_print_button',
+                      notice: notice,
+                      printers: @printers,
+                      print_route: :print_notice_parking_notice_path,
+                      btn_size: :sm,
+                      dropdown_suffix: notice.id %>
+                </div>
               </td>
             </tr>
           <% end %>

--- a/app/views/parking_notices/show.html.erb
+++ b/app/views/parking_notices/show.html.erb
@@ -18,38 +18,10 @@
     <%= link_to download_pdf_parking_notice_path(@parking_notice), class: "btn btn-outline-dark" do %>
       <i class="bi bi-file-earmark-pdf me-1"></i> Download PDF
     <% end %>
-    <% if @printers.any? %>
-      <% if @printers.size == 1 %>
-        <%= link_to print_notice_parking_notice_path(@parking_notice, printer_id: @printers.first.id),
-            data: { turbo_method: :post },
-            class: "btn btn-outline-info" do %>
-          <i class="bi bi-printer me-1"></i> Print
-        <% end %>
-      <% else %>
-        <div class="btn-group">
-          <button type="button" class="btn btn-outline-info dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-            <i class="bi bi-printer me-1"></i> Print
-          </button>
-          <ul class="dropdown-menu dropdown-menu-end" id="printer-dropdown">
-            <% last_printer_id = cookies[:last_printer_id].to_i %>
-            <% @printers.each do |printer| %>
-              <li>
-                <%= link_to print_notice_parking_notice_path(@parking_notice, printer_id: printer.id),
-                    data: { turbo_method: :post },
-                    class: "dropdown-item #{'fw-bold' if printer.id == last_printer_id || (last_printer_id.zero? && printer.default_printer?)}" do %>
-                  <%= printer.name %>
-                  <% if printer.id == last_printer_id %>
-                    <span class="badge bg-secondary ms-1">Last used</span>
-                  <% elsif printer.default_printer? %>
-                    <span class="badge bg-primary ms-1">Default</span>
-                  <% end %>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
-    <% end %>
+    <%= render 'shared/printer_print_button',
+        notice: @parking_notice,
+        printers: @printers,
+        print_route: :print_notice_parking_notice_path %>
     <%= link_to parking_notices_path, class: "btn btn-outline-secondary" do %>
       <i class="bi bi-arrow-left me-1"></i> Back
     <% end %>

--- a/app/views/shared/_printer_print_button.html.erb
+++ b/app/views/shared/_printer_print_button.html.erb
@@ -1,0 +1,38 @@
+<%# locals: notice:, printers:, print_route:, btn_size: nil, dropdown_suffix: nil %>
+<% if printers.present? %>
+  <% small = local_assigns[:btn_size] == :sm %>
+  <% btn_class = small ? 'btn btn-sm btn-outline-info' : 'btn btn-outline-info' %>
+  <% toggle_class = small ? 'btn btn-sm btn-outline-info dropdown-toggle' : 'btn btn-outline-info dropdown-toggle' %>
+  <% dropdown_id = local_assigns[:dropdown_suffix].present? ? "printer-dropdown-#{local_assigns[:dropdown_suffix]}" : 'printer-dropdown' %>
+  <% last_printer_id = cookies[:last_printer_id].to_i %>
+
+  <% if printers.size == 1 %>
+    <%= link_to send(print_route, notice, printer_id: printers.first.id),
+        data: { turbo_method: :post },
+        class: btn_class do %>
+      <i class="bi bi-printer<%= ' me-1' unless small %>"></i><%= 'Print' unless small %>
+    <% end %>
+  <% else %>
+    <div class="btn-group">
+      <button type="button" class="<%= toggle_class %>" data-bs-toggle="dropdown" aria-expanded="false">
+        <i class="bi bi-printer<%= ' me-1' unless small %>"></i><%= 'Print' unless small %>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end" id="<%= dropdown_id %>">
+        <% printers.each do |printer| %>
+          <li>
+            <%= link_to send(print_route, notice, printer_id: printer.id),
+                data: { turbo_method: :post },
+                class: "dropdown-item #{'fw-bold' if printer.id == last_printer_id || (last_printer_id.zero? && printer.default_printer?)}" do %>
+              <%= printer.name %>
+              <% if printer.id == last_printer_id %>
+                <span class="badge bg-secondary ms-1">Last used</span>
+              <% elsif printer.default_printer? %>
+                <span class="badge bg-primary ms-1">Default</span>
+              <% end %>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/users/_tab_parking.html.erb
+++ b/app/views/users/_tab_parking.html.erb
@@ -1,6 +1,7 @@
 <%# actions: :admin (view/edit/clear all), :member (own permits editable/clearable, tickets view-only), or nil %>
 <% actions = local_assigns[:actions] %>
 <% show_actions_column = actions.present? %>
+<% printers = local_assigns.fetch(:printers) { Printer.ordered } %>
 <% if parking_notices.any? %>
   <div class="card shadow-sm border-0">
     <div class="table-responsive">
@@ -43,6 +44,12 @@
                     <% end %>
                     <% if actions == :admin %>
                       <%= link_to "View", parking_notice_path(notice), class: "btn btn-sm btn-outline-secondary" %>
+                      <%= render 'shared/printer_print_button',
+                          notice: notice,
+                          printers: printers,
+                          print_route: :print_notice_parking_notice_path,
+                          btn_size: :sm,
+                          dropdown_suffix: notice.id %>
                       <% unless notice.cleared? %>
                         <%= link_to "Edit", edit_parking_notice_path(notice), class: "btn btn-sm btn-outline-secondary" %>
                         <%= button_to "Clear", clear_parking_notice_path(notice), method: :post,
@@ -51,6 +58,14 @@
                       <% end %>
                     <% elsif actions == :member %>
                       <%= link_to "View", member_parking_permit_path(notice), class: "btn btn-sm btn-outline-secondary" %>
+                      <% if notice.permit? %>
+                        <%= render 'shared/printer_print_button',
+                            notice: notice,
+                            printers: printers,
+                            print_route: :print_notice_member_parking_permit_path,
+                            btn_size: :sm,
+                            dropdown_suffix: notice.id %>
+                      <% end %>
                       <% unless notice.cleared? %>
                         <% if notice.permit? %>
                           <%= link_to "Edit", edit_member_parking_permit_path(notice), class: "btn btn-sm btn-outline-secondary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
       patch :close
       post :request_clearance
       post :add_note
+      post :print_notice
     end
   end
 

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -43,6 +43,25 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Request training/i, response.body)
   end
 
+  test 'admin home parking tab shows print for permits but not tickets' do
+    admin_user = User.find_by!(email: local_accounts(:active_admin).email)
+    printer = Printer.create!(name: 'Front Desk', cups_printer_name: 'front_desk')
+    permit = admin_user.parking_notices.create!(
+      notice_type: 'permit', status: 'active', issued_by: admin_user,
+      expires_at: 3.days.from_now, description: 'Home permit', location: 'Woodshop'
+    )
+    ticket = ParkingNotice.create!(
+      notice_type: 'ticket', status: 'active', user: admin_user, issued_by: admin_user,
+      expires_at: 3.days.from_now, description: 'Home ticket', location: 'Main Area'
+    )
+
+    get root_path(tab: :parking)
+
+    assert_response :success
+    assert_select 'a[href=?]', print_notice_member_parking_permit_path(permit, printer_id: printer.id)
+    assert_select 'a[href=?]', print_notice_member_parking_permit_path(ticket, printer_id: printer.id), count: 0
+  end
+
   test 'member home payments details use source labels without payer emails' do
     admin_user = User.find_by!(email: local_accounts(:active_admin).email)
     [

--- a/test/controllers/member_parking_permits_controller_test.rb
+++ b/test/controllers/member_parking_permits_controller_test.rb
@@ -224,6 +224,47 @@ class MemberParkingPermitsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'form[action=?]', close_member_parking_permit_path(permit)
   end
 
+  test 'member can print own permit when a printer is configured' do
+    sign_in_as_member
+    permit = member_permit
+    printer = Printer.create!(name: 'Front Desk', cups_printer_name: 'front_desk')
+    original_print_data = CupsService.method(:print_data)
+
+    CupsService.define_singleton_method(:print_data) do |*_args, **_kwargs|
+      'member-print-99'
+    end
+
+    begin
+      post print_notice_member_parking_permit_path(permit, printer_id: printer.id)
+    ensure
+      CupsService.define_singleton_method(:print_data, original_print_data)
+    end
+
+    assert_redirected_to member_parking_permit_path(permit)
+    assert_equal "Printed to #{printer.name} (job member-print-99).", flash[:notice]
+  end
+
+  test 'member permit show includes print action when printers are configured' do
+    sign_in_as_member
+    permit = member_permit
+    printer = Printer.create!(name: 'Front Desk', cups_printer_name: 'front_desk')
+
+    get member_parking_permit_path(permit)
+
+    assert_response :success
+    assert_select 'a[href=?]', print_notice_member_parking_permit_path(permit, printer_id: printer.id)
+  end
+
+  test 'member cannot print their own ticket' do
+    sign_in_as_member
+    ticket = member_ticket
+    printer = Printer.create!(name: 'Front Desk', cups_printer_name: 'front_desk')
+
+    post print_notice_member_parking_permit_path(ticket, printer_id: printer.id)
+
+    assert_redirected_to user_path(current_member, tab: :parking)
+  end
+
   test 'member can view own ticket with a clear action but no edit action' do
     sign_in_as_member
     ticket = member_ticket

--- a/test/controllers/parking_notices_controller_test.rb
+++ b/test/controllers/parking_notices_controller_test.rb
@@ -30,6 +30,26 @@ class ParkingNoticesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'index shows print action when printers are configured' do
+    printer = Printer.create!(name: 'Front Desk', cups_printer_name: 'front_desk')
+
+    get parking_notices_url
+
+    assert_response :success
+    assert_select 'a[href=?]', print_notice_parking_notice_path(@active_permit, printer_id: printer.id)
+    assert_select 'a[href=?]', print_notice_parking_notice_path(@expired_ticket, printer_id: printer.id)
+  end
+
+  test 'show displays printer print dropdown when multiple printers exist' do
+    Printer.create!(name: 'Front Desk', cups_printer_name: 'front_desk')
+    Printer.create!(name: 'Back Office', cups_printer_name: 'back_office')
+
+    get parking_notice_url(@active_permit)
+
+    assert_response :success
+    assert_select '.btn-group .dropdown-toggle', text: /Print/
+  end
+
   # --- Show ---
 
   test 'show displays parking notice' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -544,6 +544,41 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Access paused/i, response.body)
   end
 
+  test 'admin parking tab shows print actions for permits and tickets' do
+    printer = Printer.create!(name: 'Front Desk', cups_printer_name: 'front_desk')
+    permit = parking_notices(:active_permit)
+    ticket = ParkingNotice.create!(
+      notice_type: 'ticket', status: 'active', user: @user, issued_by: @user,
+      expires_at: 3.days.from_now, description: 'Ticket on member profile', location: 'Main Area'
+    )
+
+    get user_path(@user, tab: :parking)
+
+    assert_response :success
+    assert_select 'a[href=?]', print_notice_parking_notice_path(permit, printer_id: printer.id)
+    assert_select 'a[href=?]', print_notice_parking_notice_path(ticket, printer_id: printer.id)
+  end
+
+  test 'member parking tab shows print for permits but not tickets' do
+    sign_in_as_regular_member
+    member = User.find_by!(authentik_id: "local:#{local_accounts(:regular_member).id}")
+    printer = Printer.create!(name: 'Front Desk', cups_printer_name: 'front_desk')
+    permit = member.parking_notices.create!(
+      notice_type: 'permit', status: 'active', issued_by: member,
+      expires_at: 3.days.from_now, description: 'Member permit', location: 'Woodshop'
+    )
+    ticket = ParkingNotice.create!(
+      notice_type: 'ticket', status: 'active', user: member, issued_by: users(:one),
+      expires_at: 3.days.from_now, description: 'Member ticket', location: 'Main Area'
+    )
+
+    get user_path(member, tab: :parking)
+
+    assert_response :success
+    assert_select 'a[href=?]', print_notice_member_parking_permit_path(permit, printer_id: printer.id)
+    assert_select 'a[href=?]', print_notice_member_parking_permit_path(ticket, printer_id: printer.id), count: 0
+  end
+
   private
 
   def sign_in_as_local_admin

--- a/test/views/shared/printer_print_button_partial_test.rb
+++ b/test/views/shared/printer_print_button_partial_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class PrinterPrintButtonPartialTest < ActionView::TestCase
+  setup do
+    @notice = parking_notices(:active_permit)
+    @printer = Printer.create!(name: 'Front Desk', cups_printer_name: 'front_desk')
+  end
+
+  test 'renders nothing when no printers are configured' do
+    html = render_partial(printers: [])
+
+    assert_predicate html.to_s.strip, :blank?
+  end
+
+  test 'renders a single print link when one printer exists' do
+    html = render_partial
+
+    assert_includes html, print_notice_parking_notice_path(@notice, printer_id: @printer.id)
+    assert_includes html, 'data-turbo-method="post"'
+    assert_includes html, 'btn-outline-info'
+    assert_includes html, 'Print'
+    assert_no_match(/dropdown-toggle/, html)
+  end
+
+  test 'renders a printer dropdown when multiple printers exist' do
+    Printer.create!(name: 'Back Office', cups_printer_name: 'back_office', default_printer: true)
+
+    html = render_partial(printers: Printer.ordered)
+
+    assert_includes html, 'dropdown-toggle'
+    assert_includes html, 'id="printer-dropdown"'
+    assert_includes html, 'Front Desk'
+    assert_includes html, 'Back Office'
+    assert_includes html, 'Default'
+  end
+
+  test 'uses a unique dropdown id when suffix is provided' do
+    Printer.create!(name: 'Back Office', cups_printer_name: 'back_office')
+
+    html = render_partial(printers: Printer.ordered, dropdown_suffix: @notice.id)
+
+    assert_includes html, "id=\"printer-dropdown-#{@notice.id}\""
+    assert_no_match(/id="printer-dropdown"/, html)
+  end
+
+  test 'renders compact buttons when btn_size is sm' do
+    html = render_partial(btn_size: :sm)
+
+    assert_includes html, 'btn-sm'
+    assert_no_match(/>\s*Print\s*</, html)
+  end
+
+  private
+
+  def render_partial(printers: [@printer], **locals)
+    render partial: 'shared/printer_print_button', locals: {
+      notice: @notice,
+      printers: printers,
+      print_route: :print_notice_parking_notice_path,
+      **locals
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- Add a shared printer dropdown partial and print concern so parking notices can be sent to CUPS from list and detail views
- Admins get print actions on the parking notices index, user parking tab, and detail pages for both permits and tickets
- Members get print actions on their parking tab and permit detail pages (permits only)

## Test plan
- [x] Full test suite (`docker compose -f docker-compose.test.yml run --rm test`) — 1349 tests passing
- [x] RuboCop (`docker compose -f docker-compose.lint.yml run --rm rubocop`) — clean
- [ ] Admin: open Parking Notices index and confirm Print dropdown on permit and ticket rows
- [ ] Admin: open a permit/ticket detail page and print to a configured printer
- [ ] Member: open Profile → Parking tab and confirm Print on permit rows only
- [ ] Member: open a permit detail page and print


Made with [Cursor](https://cursor.com)