### PR TITLE
Split admin home into nested Admin/Member dashboard nav

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -15,6 +15,27 @@
 .text-11            { font-size: 11px; }
 .fw-medium          { font-weight: 500; }
 
+/* === Sub-level nav pills ===
+   Secondary tier under the primary section tabs. Reads as subordinate:
+   muted by default, subtle tint when active (no saturated primary fill). */
+.nav-pills-sub {
+  gap: 0.25rem;
+}
+.nav-pills-sub .nav-link {
+  padding: 0.25rem 0.6rem;
+  color: var(--bs-secondary-color);
+  border-radius: var(--bs-border-radius-sm);
+}
+.nav-pills-sub .nav-link:hover {
+  color: var(--bs-body-color);
+  background-color: var(--bs-tertiary-bg);
+}
+.nav-pills-sub .nav-link.active {
+  color: var(--bs-body-color);
+  background-color: var(--bs-secondary-bg);
+  font-weight: 500;
+}
+
 .application-status-progress-track {
   height: 8px;
 }

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,45 +1,71 @@
 <div class="py-4">
-  <ul class="nav nav-tabs mb-4" role="tablist">
+  <% member_section_tabs = %i[member_dashboard profile payments parking messages] %>
+  <% member_section_active = @active_tab.in?(member_section_tabs) %>
+
+  <ul class="nav nav-tabs mb-3" role="tablist">
     <li class="nav-item" role="presentation">
-      <%= link_to root_path(tab: :admin_dashboard), class: "nav-link #{'active' if @active_tab == :admin_dashboard}", role: "tab" do %>
+      <%= link_to root_path(tab: :admin_dashboard), class: "nav-link #{'active' unless member_section_active}", role: "tab" do %>
         <i class="bi bi-speedometer2 me-1"></i> Admin Dashboard
       <% end %>
     </li>
     <li class="nav-item" role="presentation">
-      <%= link_to root_path(tab: :member_dashboard), class: "nav-link #{'active' if @active_tab == :member_dashboard}", role: "tab" do %>
+      <%= link_to root_path(tab: :member_dashboard), class: "nav-link #{'active' if member_section_active}", role: "tab" do %>
         <i class="bi bi-person-badge me-1"></i> Member Dashboard
       <% end %>
     </li>
-    <li class="nav-item" role="presentation">
-      <%= link_to root_path(tab: :profile), class: "nav-link #{'active' if @active_tab == :profile}", role: "tab" do %>
-        <i class="bi bi-person me-1"></i> Profile
-      <% end %>
-    </li>
-    <li class="nav-item" role="presentation">
-      <%= link_to root_path(tab: :payments), class: "nav-link #{'active' if @active_tab == :payments}", role: "tab" do %>
-        <i class="bi bi-credit-card me-1"></i> Payment History
-        <% if @home_payments_count.to_i > 0 %>
-          <span class="badge bg-secondary ms-1"><%= @home_payments_count %></span>
-        <% end %>
-      <% end %>
-    </li>
-    <% if @home_parking_notices_count.to_i > 0 %>
+  </ul>
+
+  <% if member_section_active %>
+    <ul class="nav nav-pills nav-pills-sub mb-4 small" role="tablist">
       <li class="nav-item" role="presentation">
-        <%= link_to root_path(tab: :parking), class: "nav-link #{'active' if @active_tab == :parking}", role: "tab" do %>
-          <i class="bi bi-car-front me-1"></i> Parking
-          <span class="badge bg-secondary ms-1"><%= @home_parking_notices_count %></span>
+        <%= link_to root_path(tab: :member_dashboard), class: "nav-link #{'active' if @active_tab == :member_dashboard}", role: "tab" do %>
+          <i class="bi bi-person me-1"></i> Dashboard
         <% end %>
       </li>
-    <% end %>
-    <li class="nav-item" role="presentation">
-      <%= link_to messages_path(folder: :unread), class: 'nav-link', role: 'tab' do %>
-        <i class="bi bi-chat-dots me-1"></i> Messages
-        <% if @home_unread_messages_count.to_i > 0 %>
-          <span class="badge bg-danger ms-1"><%= @home_unread_messages_count %></span>
+      <li class="nav-item" role="presentation">
+        <%= link_to root_path(tab: :profile), class: "nav-link #{'active' if @active_tab == :profile}", role: "tab" do %>
+          <i class="bi bi-person-vcard me-1"></i> Profile
         <% end %>
+      </li>
+      <li class="nav-item" role="presentation">
+        <%= link_to root_path(tab: :payments), class: "nav-link #{'active' if @active_tab == :payments}", role: "tab" do %>
+          <i class="bi bi-credit-card me-1"></i> Payment History
+          <% if @home_payments_count.to_i > 0 %>
+            <span class="badge bg-secondary ms-1"><%= @home_payments_count %></span>
+          <% end %>
+        <% end %>
+      </li>
+      <% if @home_parking_notices_count.to_i > 0 %>
+        <li class="nav-item" role="presentation">
+          <%= link_to root_path(tab: :parking), class: "nav-link #{'active' if @active_tab == :parking}", role: "tab" do %>
+            <i class="bi bi-car-front me-1"></i> Parking
+            <span class="badge bg-secondary ms-1"><%= @home_parking_notices_count %></span>
+          <% end %>
+        </li>
       <% end %>
-    </li>
-  </ul>
+      <li class="nav-item" role="presentation">
+        <%= link_to messages_path(folder: :unread), class: 'nav-link', role: 'tab' do %>
+          <i class="bi bi-chat-dots me-1"></i> Messages
+          <% if @home_unread_messages_count.to_i > 0 %>
+            <span class="badge bg-danger ms-1"><%= @home_unread_messages_count %></span>
+          <% end %>
+        <% end %>
+      </li>
+    </ul>
+  <% else %>
+    <ul class="nav nav-pills nav-pills-sub mb-4 small" role="tablist">
+      <li class="nav-item" role="presentation">
+        <%= link_to root_path(tab: :admin_dashboard), class: "nav-link #{'active' if @active_tab == :admin_dashboard}", role: "tab" do %>
+          <i class="bi bi-speedometer2 me-1"></i> Dashboard
+        <% end %>
+      </li>
+      <li class="nav-item" role="presentation">
+        <%= link_to parking_notices_path, class: 'nav-link', role: 'tab' do %>
+          <i class="bi bi-car-front me-1"></i> Parking
+        <% end %>
+      </li>
+    </ul>
+  <% end %>
 
   <% if @active_tab.in?(%i[member_dashboard profile]) %>
     <% member_since = @home_user.membership_start_date || @home_user.created_at %>

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -103,7 +103,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
       read_at: Time.current
     )
 
-    get root_path
+    get root_path(tab: :member_dashboard)
 
     assert_response :success
     assert_select 'a.nav-link[href=?]', messages_path(folder: :unread) do


### PR DESCRIPTION
## Summary
- Replace the flat tab strip on the admin home page (`dashboard/index.html.erb`) with a two-tier nested nav.
- **Primary tabs:** Admin Dashboard · Member Dashboard.
- **Member Dashboard sub-nav:** Dashboard, Profile, Payment History, Parking, Messages (everything that used to sit after Member Dashboard).
- **Admin Dashboard sub-nav:** Dashboard and Parking — Parking links to the existing `parking_notices_path` (same destination as the navbar's Building > Parking), reusing existing code/assets.
- Add a subtle `.nav-pills-sub` style in `application.bootstrap.scss` so the second tier reads as subordinate (muted default, soft tint when active — no saturated primary fill, per UI rules).

## Notes
- Existing `?tab=` param values are unchanged, so the content-rendering branches and member-dashboard builder links keep working.
- Non-admins are unaffected — `DashboardController` is admin-only; they continue to see their own profile view.
- Messages now lives under Member Dashboard, so its nav link no longer appears on the Admin Dashboard tab. Updated the one test that asserted the Messages link on the default home page to look in the member section.

## Test plan
- [x] `bin/rails test test/controllers/dashboard_controller_test.rb` — 11 runs, 69 assertions, 0 failures
- [ ] Visually confirm nested nav on the admin home page (both sections + sub-navs)
- [ ] Confirm Admin > Parking lands on the same page as navbar Building > Parking

Made with [Cursor](https://cursor.com)