### PR TITLE
Staging

### DIFF
--- a/app/controllers/concerns/training_history_data.rb
+++ b/app/controllers/concerns/training_history_data.rb
@@ -1,0 +1,30 @@
+module TrainingHistoryData
+  private
+
+  # Completed (responded but not yet dismissed) requests the member should be notified about.
+  # These surface the "training completed" cards with a dismiss action on the member dashboard.
+  def load_completed_training_requests(user)
+    @completed_training_requests = user.training_requests
+                                       .awaiting_member_acknowledgement
+                                       .includes(:training_topic, :responded_by)
+                                       .newest_first
+  end
+
+  # Loads the data for the member's Training History tab: their own training records plus,
+  # for trainers, every record in the topics they are able to train.
+  def load_training_history(user)
+    @training_history_user = user
+    @member_trainings = user.trainings_as_trainee
+                            .includes(:training_topic, :trainer)
+                            .recent
+
+    @can_view_trainer_history = user.training_topics.exists?
+    return unless @can_view_trainer_history
+
+    trainer_topic_ids = user.training_topics.select(:id)
+    scope = Training.where(training_topic_id: trainer_topic_ids)
+                    .includes(:training_topic, :trainer, :trainee)
+                    .recent
+    @pagy_trainer_trainings, @trainer_topic_trainings = pagy(scope, limit: 50, page_key: 'training_page')
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,6 @@
 class DashboardController < AdminController
   include MemberHomeTabs
+  include TrainingHistoryData
 
   def index
     @home_user = true_user || current_user
@@ -39,6 +40,8 @@ class DashboardController < AdminController
                                 .limit(50)
 
     prepare_member_home_tabs_data
+    load_completed_training_requests(@home_user)
+    load_training_history(@home_user) if @active_tab == :training_history
   end
 
   private

--- a/app/controllers/training_requests_controller.rb
+++ b/app/controllers/training_requests_controller.rb
@@ -1,6 +1,7 @@
 class TrainingRequestsController < AuthenticatedController
-  before_action :set_training_request, only: %i[edit update]
-  before_action :authorize_responder!, only: %i[edit update]
+  before_action :set_training_request, only: %i[edit update mark_trained dismiss]
+  before_action :authorize_responder!, only: %i[edit update mark_trained]
+  before_action :authorize_requester!, only: %i[dismiss]
 
   def new
     @member_requestable_topics = TrainingTopic.available_for_member_requests
@@ -58,6 +59,44 @@ class TrainingRequestsController < AuthenticatedController
     end
   end
 
+  # Trainer (or admin) records the training directly from the request. Recording a Training
+  # marks the pending request(s) responded, so it disappears from every trainer's queue and
+  # surfaces a "training completed" notification for the member.
+  def mark_trained
+    topic = @training_request.training_topic
+    trainee = @training_request.user
+
+    if Training.exists?(trainee: trainee, training_topic: topic)
+      @training_request.respond!(current_user) if @training_request.pending?
+      redirect_back_or_to user_path(current_user),
+                          notice: "#{trainee.display_name} is already trained in #{topic.name}."
+      return
+    end
+
+    result = TrainingRecorder.new(
+      current_user: current_user,
+      training_topic: topic,
+      trainee_ids: [trainee.id.to_s],
+      trainer: current_user,
+      trained_at: Time.current
+    ).call
+
+    if result.recorded_count.positive?
+      redirect_back_or_to user_path(current_user),
+                          notice: "Recorded training for #{trainee.display_name} in #{topic.name}."
+    else
+      redirect_back_or_to user_path(current_user),
+                          alert: "Could not record training for #{trainee.display_name}."
+    end
+  end
+
+  # Member dismisses a completed training request so it stops showing on their dashboard.
+  def dismiss
+    @training_request.dismiss!
+    redirect_back_or_to user_path(current_user, tab: :training_history),
+                        notice: 'Training update dismissed.'
+  end
+
   private
 
   def set_training_request
@@ -71,6 +110,12 @@ class TrainingRequestsController < AuthenticatedController
     end
 
     redirect_to user_path(current_user), alert: 'You are not allowed to respond to that request.'
+  end
+
+  def authorize_requester!
+    return if @training_request.user_id == current_user.id
+
+    redirect_to user_path(current_user), alert: 'You are not allowed to update that request.'
   end
 
   def training_request_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < AuthenticatedController
+  include TrainingHistoryData
+
   skip_before_action :require_authenticated_user!, only: [:show]
   before_action :set_user_for_show, only: [:show]
   before_action :set_user,
@@ -199,6 +201,8 @@ class UsersController < AuthenticatedController
     if @view_level == :self
       set_self_service_training_data
       set_member_dashboard_data
+      load_completed_training_requests(@user)
+      load_training_history(@user) if @active_tab == :training_history
     end
 
     # Load payment history for admin and self views (paginated)

--- a/app/models/queued_mail.rb
+++ b/app/models/queued_mail.rb
@@ -52,7 +52,7 @@ class QueuedMail < ApplicationRecord
                  queued_mail_attrs(dest, reason || action.to_s.humanize, user, action.to_s, extra_args)
                )
              else
-               message = MemberMailer.public_send(action, *build_mailer_args(action, user, to, extra_args))
+               message = dispatch_mailer(action, build_mailer_args(action, user, to, extra_args))
                create_queued_mail_from_message(
                  message,
                  queued_mail_attrs(dest, reason || action.to_s.humanize, user, action.to_s, extra_args)
@@ -245,6 +245,20 @@ class QueuedMail < ApplicationRecord
     variables = MemberMailer.build_template_variables(user, extra_args)
     ensure_admin_new_application_application_url!(variables, action, extra_args) if template
     variables
+  end
+
+  # Some mailer actions accept a trailing options hash positionally (opts = {}) while others use
+  # keyword arguments (e.g. training_completed(user, training_topic:)). build_mailer_args returns the
+  # options as a trailing Hash; splat it as keywords so keyword-based mailers receive it correctly.
+  # Ruby forwards **hash as a positional Hash to mailers that don't declare keyword params, so this
+  # is safe for both styles.
+  def self.dispatch_mailer(action, mailer_args)
+    if mailer_args.last.is_a?(Hash)
+      *positional, keyword_args = mailer_args
+      MemberMailer.public_send(action, *positional, **keyword_args)
+    else
+      MemberMailer.public_send(action, *mailer_args)
+    end
   end
 
   def self.build_mailer_args(action, user, to_addr, extra_args)

--- a/app/models/training_request.rb
+++ b/app/models/training_request.rb
@@ -15,7 +15,13 @@ class TrainingRequest < ApplicationRecord
 
   scope :pending, -> { where(status: 'pending') }
   scope :responded, -> { where(status: 'responded') }
+  scope :not_dismissed, -> { where(dismissed_at: nil) }
+  scope :dismissed, -> { where.not(dismissed_at: nil) }
   scope :newest_first, -> { order(created_at: :desc) }
+
+  # Requests the member has had responded to but has not yet dismissed. These drive the
+  # "training completed" notifications the member sees on their dashboard.
+  scope :awaiting_member_acknowledgement, -> { responded.not_dismissed }
 
   def pending?
     status == 'pending'
@@ -25,8 +31,18 @@ class TrainingRequest < ApplicationRecord
     status == 'responded'
   end
 
+  def dismissed?
+    dismissed_at.present?
+  end
+
   def respond!(responder)
     update!(status: 'responded', responded_by: responder, responded_at: Time.current)
+  end
+
+  def dismiss!
+    return if dismissed?
+
+    update!(dismissed_at: Time.current)
   end
 
   def self.clear_pending_for!(user:, training_topic:, responded_by: nil)

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class="py-4">
-  <% member_section_tabs = %i[member_dashboard profile payments parking messages] %>
+  <% member_section_tabs = %i[member_dashboard profile payments parking training_history messages] %>
   <% member_section_active = @active_tab.in?(member_section_tabs) %>
 
   <ul class="nav nav-tabs mb-3" role="tablist">
@@ -43,6 +43,14 @@
           <% end %>
         </li>
       <% end %>
+      <li class="nav-item" role="presentation">
+        <%= link_to root_path(tab: :training_history), class: "nav-link #{'active' if @active_tab == :training_history}", role: "tab" do %>
+          <i class="bi bi-mortarboard me-1"></i> Training
+          <% if @completed_training_requests.to_a.any? %>
+            <span class="badge bg-secondary ms-1"><%= @completed_training_requests.size %></span>
+          <% end %>
+        <% end %>
+      </li>
       <li class="nav-item" role="presentation">
         <%= link_to messages_path(folder: :unread), class: 'nav-link', role: 'tab' do %>
           <i class="bi bi-chat-dots me-1"></i> Messages
@@ -316,6 +324,8 @@
     <%= render 'users/tab_payments', payments: @home_payments, pagy: @pagy_payments, user: @home_user, show_payment_links: false, dashboard_mode: true %>
   <% elsif @active_tab == :parking %>
     <%= render 'users/tab_parking', parking_notices: @home_parking_notices_list, actions: :member %>
+  <% elsif @active_tab == :training_history %>
+    <%= render 'users/tab_training_history', user: @home_user %>
   <% else %>
     <%= render 'users/tab_dashboard_self', user: @home_user %>
   <% end %>

--- a/app/views/users/_tab_dashboard_self.html.erb
+++ b/app/views/users/_tab_dashboard_self.html.erb
@@ -119,6 +119,11 @@
                       <% end %>
                     </div>
                     <div class="d-flex gap-2 flex-shrink-0">
+                      <%= button_to 'Mark as trained', mark_trained_training_request_path(request),
+                            method: :post,
+                            class: 'btn btn-sm btn-outline-secondary',
+                            form: { class: 'd-inline',
+                                    data: { turbo_confirm: "Record training for #{request.user.display_name} in #{topic.name}?" } } %>
                       <%= link_to 'Respond', edit_training_request_path(request), class: 'btn btn-sm btn-outline-secondary' %>
                       <% if request.share_contact_info? && request.user.email.present? %>
                         <%= link_to 'Email', "mailto:#{request.user.email}", class: 'btn btn-sm btn-outline-secondary' %>

--- a/app/views/users/_tab_training_history.html.erb
+++ b/app/views/users/_tab_training_history.html.erb
@@ -1,0 +1,112 @@
+<%# locals: user %>
+<% completed = @completed_training_requests || [] %>
+<% member_trainings = @member_trainings || [] %>
+<% trainer_trainings = @trainer_topic_trainings || [] %>
+
+<div class="row g-3">
+  <div class="col-lg-8">
+    <% if completed.any? %>
+      <div class="card dashboard-panel mb-3">
+        <div class="card-header">
+          <h3 class="h-section-label mb-0">Recently completed</h3>
+        </div>
+        <div class="list-group list-group-flush list-compact">
+          <% completed.each do |request| %>
+            <div class="list-group-item d-flex justify-content-between align-items-start gap-3">
+              <div>
+                <div class="fw-medium"><%= request.training_topic.name %></div>
+                <div class="text-secondary text-12 mt-1">
+                  Training completed <%= admin_profile_time(request.responded_at, empty: 'recently') %><% if request.responded_by.present? %> by <%= request.responded_by.display_name %><% end %>
+                </div>
+              </div>
+              <%= button_to 'Dismiss', dismiss_training_request_path(request),
+                    method: :post,
+                    class: 'btn btn-sm btn-outline-secondary flex-shrink-0',
+                    form: { class: 'd-inline' } %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="card dashboard-panel mb-3">
+      <div class="card-header">
+        <h3 class="h-section-label mb-0">Your training</h3>
+      </div>
+      <% if member_trainings.any? %>
+        <div class="table-responsive">
+          <table class="table table-compact mb-0 align-middle">
+            <thead>
+              <tr>
+                <th>Topic</th>
+                <th>Trained</th>
+                <th>Trainer</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% member_trainings.each do |training| %>
+                <tr>
+                  <td class="fw-medium"><%= training.training_topic.name %></td>
+                  <td><%= admin_profile_time(training.trained_at) %></td>
+                  <td class="text-secondary"><%= training.trainer&.display_name || 'Not recorded' %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div class="card-body text-13 text-secondary">No trainings recorded yet.</div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="col-lg-4">
+    <%= render 'users/member_training_card', user: user, show_request_link: true %>
+  </div>
+</div>
+
+<% if @can_view_trainer_history %>
+  <div class="card dashboard-panel mb-3">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <h3 class="h-section-label mb-0">Training in topics you can teach</h3>
+      <% if @pagy_trainer_trainings %>
+        <span class="text-12 text-secondary"><%= @pagy_trainer_trainings.count %> total</span>
+      <% end %>
+    </div>
+    <% if trainer_trainings.any? %>
+      <div class="table-responsive">
+        <table class="table table-compact mb-0 align-middle">
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Topic</th>
+              <th>Trained</th>
+              <th>Trainer</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% trainer_trainings.each do |training| %>
+              <tr>
+                <td class="fw-medium">
+                  <%= link_to training.trainee.display_name, user_path(training.trainee), class: 'text-decoration-none' %>
+                </td>
+                <td><%= training.training_topic.name %></td>
+                <td><%= admin_profile_time(training.trained_at) %></td>
+                <td class="text-secondary"><%= training.trainer&.display_name || 'Not recorded' %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <% if @pagy_trainer_trainings %>
+        <div class="card-body py-2">
+          <%= render 'shared/pagination', pagy: @pagy_trainer_trainings %>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="card-body text-13 text-secondary">
+        No training records yet for the topics you can teach.
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -386,6 +386,16 @@
       </li>
     <% end %>
     <li class="nav-item" role="presentation">
+      <%= link_to user_path(@user, tab: :training_history, view_as: params[:view_as]),
+          class: "nav-link #{'active' if @active_tab == :training_history}",
+          role: "tab" do %>
+        Training
+        <% if @completed_training_requests.to_a.any? %>
+          <span class="text-secondary small ms-1"><%= @completed_training_requests.size %></span>
+        <% end %>
+      <% end %>
+    </li>
+    <li class="nav-item" role="presentation">
       <%= link_to user_path(@user, tab: :messages, view_as: params[:view_as]),
           class: "nav-link #{'active' if @active_tab == :messages}",
           role: "tab" do %>
@@ -406,6 +416,8 @@
       <%= render 'users/tab_payments', payments: @payments, pagy: @pagy_payments, user: @user, show_payment_links: false %>
     <% elsif @active_tab == :parking %>
       <%= render 'users/tab_parking', parking_notices: @parking_notices_list, actions: :member %>
+    <% elsif @active_tab == :training_history %>
+      <%= render 'users/tab_training_history', user: @user %>
     <% elsif @active_tab == :messages %>
       <%= render 'users/tab_messages', messages: @messages, pagy: @pagy_messages, user: @user, show_send: false %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,12 @@ Rails.application.routes.draw do
       post :restore
     end
   end
-  resources :training_requests, only: %i[new create edit update]
+  resources :training_requests, only: %i[new create edit update] do
+    member do
+      post :mark_trained
+      post :dismiss
+    end
+  end
 
   # Member-facing catalog of training topics
   get '/training',      to: 'training_catalog#index', as: :training_catalog

--- a/db/migrate/20260701000000_add_dismissed_at_to_training_requests.rb
+++ b/db/migrate/20260701000000_add_dismissed_at_to_training_requests.rb
@@ -1,0 +1,6 @@
+class AddDismissedAtToTrainingRequests < ActiveRecord::Migration[8.1]
+  def change
+    add_column :training_requests, :dismissed_at, :datetime
+    add_index :training_requests, :dismissed_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_19_150000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -926,6 +926,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_150000) do
 
   create_table "training_requests", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.datetime "dismissed_at"
     t.datetime "responded_at"
     t.bigint "responded_by_id"
     t.boolean "share_contact_info", default: false, null: false
@@ -933,6 +934,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_150000) do
     t.bigint "training_topic_id", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["dismissed_at"], name: "index_training_requests_on_dismissed_at"
     t.index ["responded_by_id"], name: "index_training_requests_on_responded_by_id"
     t.index ["status"], name: "index_training_requests_on_status"
     t.index ["training_topic_id"], name: "index_training_requests_on_training_topic_id"

--- a/test/controllers/training_history_test.rb
+++ b/test/controllers/training_history_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+
+class TrainingHistoryTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_local_auth_enabled = Rails.application.config.x.local_auth.enabled
+    Rails.application.config.x.local_auth.enabled = true
+  end
+
+  teardown do
+    Rails.application.config.x.local_auth.enabled = @original_local_auth_enabled
+  end
+
+  test 'member sees their own training history on the training tab' do
+    sign_in_as_member
+    member = local_member
+    Training.create!(
+      trainee: member,
+      training_topic: training_topics(:woodworking),
+      trainer: users(:one),
+      trained_at: Time.current
+    )
+
+    get user_path(member, tab: :training_history)
+
+    assert_response :success
+    assert_match 'Your training', response.body
+    assert_match 'Woodworking', response.body
+  end
+
+  test 'trainer sees training records for topics they can teach' do
+    trainer = sign_in_as_trainer
+    topic = training_topics(:laser_cutting)
+    TrainerCapability.find_or_create_by!(user: trainer, training_topic: topic)
+    Training.create!(trainee: users(:one), training_topic: topic, trainer: trainer, trained_at: Time.current)
+
+    get user_path(trainer, tab: :training_history)
+
+    assert_response :success
+    assert_match 'Training in topics you can teach', response.body
+    assert_match users(:one).display_name, response.body
+  end
+
+  test 'non-trainer member does not see the trainer history section' do
+    sign_in_as_member
+    member = local_member
+
+    get user_path(member, tab: :training_history)
+
+    assert_response :success
+    assert_no_match(/Training in topics you can teach/, response.body)
+  end
+
+  test 'training tab surfaces completed requests with a dismiss action and hides dismissed ones' do
+    sign_in_as_member
+    member = local_member
+    completed = TrainingRequest.create!(
+      user: member,
+      training_topic: training_topics(:woodworking),
+      share_contact_info: true,
+      status: 'responded',
+      responded_at: Time.current
+    )
+
+    get user_path(member, tab: :training_history)
+    assert_response :success
+    assert_match 'Training completed', response.body
+    assert_match dismiss_training_request_path(completed), response.body
+
+    completed.dismiss!
+
+    get user_path(member, tab: :training_history)
+    assert_response :success
+    assert_no_match(/Training completed/, response.body)
+  end
+
+  test 'admin dashboard renders the member training history tab' do
+    sign_in_as_admin
+
+    get root_path(tab: :training_history)
+
+    assert_response :success
+    assert_match 'Your training', response.body
+  end
+
+  private
+
+  def local_member
+    User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
+  end
+
+  def sign_in_as_member
+    post local_login_path, params: {
+      session: { email: local_accounts(:regular_member).email, password: 'memberpassword123' }
+    }
+  end
+
+  def sign_in_as_trainer
+    post local_login_path, params: {
+      session: { email: local_accounts(:trainer_account).email, password: 'trainerpassword123' }
+    }
+    User.find_by(authentik_id: "local:#{local_accounts(:trainer_account).id}")
+  end
+
+  def sign_in_as_admin
+    post local_login_path, params: {
+      session: { email: local_accounts(:active_admin).email, password: 'localpassword123' }
+    }
+    User.find_by(authentik_id: "local:#{local_accounts(:active_admin).id}")
+  end
+end

--- a/test/controllers/training_requests_controller_test.rb
+++ b/test/controllers/training_requests_controller_test.rb
@@ -121,6 +121,94 @@ class TrainingRequestsControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil request.responded_at
   end
 
+  test 'trainer can mark a request as trained which records training and closes the request' do
+    trainer = sign_in_as_trainer
+    TrainerCapability.find_or_create_by!(user: trainer, training_topic: training_topics(:laser_cutting))
+    request = training_requests(:pending_laser_request)
+
+    assert_difference 'Training.count', 1 do
+      post mark_trained_training_request_path(request)
+    end
+
+    request.reload
+    assert_equal 'responded', request.status
+    assert_equal trainer, request.responded_by
+
+    training = Training.order(:created_at).last
+    assert_equal request.user, training.trainee
+    assert_equal trainer, training.trainer
+    assert_equal request.training_topic, training.training_topic
+  end
+
+  test 'marking trained when member already trained closes the request without a duplicate record' do
+    trainer = sign_in_as_trainer
+    topic = training_topics(:laser_cutting)
+    TrainerCapability.find_or_create_by!(user: trainer, training_topic: topic)
+    member = training_requests(:pending_laser_request).user
+    Training.create!(trainee: member, trainer: trainer, training_topic: topic, trained_at: Time.current)
+
+    later_request = TrainingRequest.create!(
+      user: member, training_topic: topic, share_contact_info: true, status: 'pending'
+    )
+
+    assert_no_difference 'Training.count' do
+      post mark_trained_training_request_path(later_request)
+    end
+
+    assert_equal 'responded', later_request.reload.status
+  end
+
+  test 'admin can mark a request as trained' do
+    sign_in_as_admin
+    request = training_requests(:pending_laser_request)
+
+    assert_difference 'Training.count', 1 do
+      post mark_trained_training_request_path(request)
+    end
+
+    assert_equal 'responded', request.reload.status
+  end
+
+  test 'member cannot mark a request as trained' do
+    sign_in_as_member
+    request = training_requests(:pending_laser_request)
+
+    assert_no_difference 'Training.count' do
+      post mark_trained_training_request_path(request)
+    end
+
+    member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
+    assert_redirected_to user_path(member)
+    assert_equal 'pending', request.reload.status
+  end
+
+  test 'member can dismiss their own completed training request' do
+    sign_in_as_member
+    member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
+    request = TrainingRequest.create!(
+      user: member,
+      training_topic: training_topics(:woodworking),
+      share_contact_info: true,
+      status: 'responded',
+      responded_at: Time.current
+    )
+
+    post dismiss_training_request_path(request)
+
+    assert_not_nil request.reload.dismissed_at
+  end
+
+  test 'member cannot dismiss another members request' do
+    sign_in_as_member
+    other_request = training_requests(:responded_woodworking_request)
+
+    post dismiss_training_request_path(other_request)
+
+    assert_nil other_request.reload.dismissed_at
+    member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
+    assert_redirected_to user_path(member)
+  end
+
   test 'member dashboard links to training request page' do
     sign_in_as_member
     member = User.find_by(authentik_id: "local:#{local_accounts(:regular_member).id}")
@@ -144,5 +232,12 @@ class TrainingRequestsControllerTest < ActionDispatch::IntegrationTest
       session: { email: local_accounts(:trainer_account).email, password: 'trainerpassword123' }
     }
     User.find_by(authentik_id: "local:#{local_accounts(:trainer_account).id}")
+  end
+
+  def sign_in_as_admin
+    post local_login_path, params: {
+      session: { email: local_accounts(:active_admin).email, password: 'localpassword123' }
+    }
+    User.find_by(authentik_id: "local:#{local_accounts(:active_admin).id}")
   end
 end

--- a/test/models/training_request_test.rb
+++ b/test/models/training_request_test.rb
@@ -26,4 +26,41 @@ class TrainingRequestTest < ActiveSupport::TestCase
 
     assert request.valid?
   end
+
+  test 'dismiss! records the dismissal time and is idempotent' do
+    request = training_requests(:responded_woodworking_request)
+    assert_not request.dismissed?
+
+    request.dismiss!
+    request.reload
+
+    assert request.dismissed?
+    assert_not_nil request.dismissed_at
+
+    original_time = request.dismissed_at
+    request.dismiss!
+    assert_equal original_time, request.reload.dismissed_at
+  end
+
+  test 'not_dismissed and dismissed scopes partition by dismissal' do
+    dismissed = training_requests(:responded_woodworking_request)
+    dismissed.dismiss!
+    active = training_requests(:pending_laser_request)
+
+    assert_includes TrainingRequest.not_dismissed, active
+    assert_not_includes TrainingRequest.not_dismissed, dismissed
+    assert_includes TrainingRequest.dismissed, dismissed
+    assert_not_includes TrainingRequest.dismissed, active
+  end
+
+  test 'awaiting_member_acknowledgement returns responded requests that are not dismissed' do
+    responded = training_requests(:responded_woodworking_request)
+    pending = training_requests(:pending_laser_request)
+
+    assert_includes TrainingRequest.awaiting_member_acknowledgement, responded
+    assert_not_includes TrainingRequest.awaiting_member_acknowledgement, pending
+
+    responded.dismiss!
+    assert_not_includes TrainingRequest.awaiting_member_acknowledgement, responded
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New training-recording and authorization paths touch membership training data; schema migration adds `dismissed_at` with broad controller/view surface area but tests cover main flows.
> 
> **Overview**
> Adds a **Training** tab on the member home dashboard and self profile so members can see their training records, dismiss “training completed” notices, and (for trainers) browse paginated training across topics they teach.
> 
> **Training requests** gain `dismissed_at` and member-facing **Dismiss** / trainer **Mark as trained** actions. Marking trained uses `TrainingRecorder` (same path as bulk record) and closes the request; duplicate training only marks the request responded. Completed-but-not-dismissed requests show on the Training tab with a badge count on nav.
> 
> Shared **`TrainingHistoryData`** concern loads acknowledgement cards and history data in `DashboardController` and `UsersController`. **`QueuedMail.dispatch_mailer`** splats trailing option hashes as keywords so keyword-based mailers like `training_completed` queue correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a49344309d4cab0c98da37557f48062f599d7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->